### PR TITLE
Show QA status in workflow UI

### DIFF
--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -8,6 +8,7 @@ import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { findReadyForArchitectPayload } from "@/lib/pm-handoff";
+import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
 
 export default async function ProjectDetailPage({
@@ -123,12 +124,19 @@ export default async function ProjectDetailPage({
                       <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
                     </Group>
                   </Group>
-                  {workflow.issues.map((issue) => (
-                    <Text key={issue.issueId} size="xs" c="dimmed">
-                      {issue.issueId}: {issue.title} · {issue.developerRole ?? issue.assigneeRole}
-                      {issue.prState ? ` · PR ${issue.prState}` : ""}
-                    </Text>
-                  ))}
+                  {workflow.issues.map((issue) => {
+                    const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
+                    const qaStatus = getIssueQaStatus(issue, qaSession);
+                    return (
+                      <Group key={issue.issueId} gap={6} wrap="nowrap">
+                        <Text size="xs" c="dimmed" lineClamp={1}>
+                          {issue.issueId}: {issue.title} · {issue.developerRole ?? issue.assigneeRole}
+                          {issue.prState ? ` · PR ${issue.prState}` : ""}
+                        </Text>
+                        <Badge color={qaStatus.color} size="xs" variant="light">{qaStatus.label}</Badge>
+                      </Group>
+                    );
+                  })}
                 </div>
               ))}
               {doneWorkflows.length ? (

--- a/src/app/projects/[projectId]/workflows/[workflowId]/page.tsx
+++ b/src/app/projects/[projectId]/workflows/[workflowId]/page.tsx
@@ -5,6 +5,7 @@ import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
+import { getIssueQaStatus } from "@/lib/qa-status";
 import { getProject, getWorkflow, listAgentSessions, listJobs } from "@/lib/store";
 import type { AgentSessionRecord, IssueRecord, JobRecord } from "@/lib/types";
 
@@ -144,6 +145,7 @@ function IssueCard({
   const issueSessions = sessions.filter((session) => session.issueId === issue.issueId);
   const developerSession = issueSessions.find((session) => session.role === "developer");
   const qaSession = issueSessions.find((session) => session.role === "qa");
+  const qaStatus = getIssueQaStatus(issue, qaSession);
 
   return (
     <div className="workflow-issue-card">
@@ -153,6 +155,7 @@ function IssueCard({
             <Text fw={760}>{issue.issueId}</Text>
             <Badge size="sm" variant="light">{issue.developerRole ?? issue.assigneeRole}</Badge>
             {issue.prState ? <Badge size="sm" variant="outline">PR {issue.prState}</Badge> : null}
+            <Badge size="sm" color={qaStatus.color} variant="light">{qaStatus.label}</Badge>
           </Group>
           <Text fw={700} mt={4}>{issue.title}</Text>
           <Text size="sm" c="dimmed" lineClamp={3}>{issue.description}</Text>

--- a/src/components/Tables.tsx
+++ b/src/components/Tables.tsx
@@ -1,6 +1,7 @@
 import {
   Badge,
   Code,
+  Group,
   Table,
   TableScrollContainer,
   TableTbody,
@@ -10,6 +11,7 @@ import {
   TableTr,
   Text
 } from "@mantine/core";
+import { getWorkflowQaStatus } from "@/lib/qa-status";
 import type { ProjectRecord, WorkflowRecord } from "@/lib/types";
 
 export function WorkflowsTable({ workflows }: { workflows: WorkflowRecord[] }) {
@@ -20,6 +22,7 @@ export function WorkflowsTable({ workflows }: { workflows: WorkflowRecord[] }) {
           <TableTr>
             <TableTh>ID</TableTh>
             <TableTh>Status</TableTh>
+            <TableTh>QA</TableTh>
             <TableTh>Created</TableTh>
             <TableTh>Requirement</TableTh>
           </TableTr>
@@ -27,28 +30,11 @@ export function WorkflowsTable({ workflows }: { workflows: WorkflowRecord[] }) {
         <TableTbody>
           {workflows.length ? (
             workflows.slice(-10).map((workflow) => (
-              <TableTr key={workflow.workflowId}>
-                <TableTd>
-                  <Code>{workflow.trackingCode ?? workflow.workflowId}</Code>
-                </TableTd>
-                <TableTd>
-                  <Badge variant="light">{workflow.status}</Badge>
-                </TableTd>
-                <TableTd>
-                  <Text size="sm" c="dimmed">
-                    {workflow.createdAt}
-                  </Text>
-                </TableTd>
-                <TableTd>
-                  <Text size="sm" lineClamp={2} maw={520} title={workflow.userRequirement}>
-                    {workflow.userRequirement}
-                  </Text>
-                </TableTd>
-              </TableTr>
+              <WorkflowRow key={workflow.workflowId} workflow={workflow} />
             ))
           ) : (
             <TableTr>
-              <TableTd colSpan={4}>
+              <TableTd colSpan={5}>
                 <Text c="dimmed" ta="center" py="md">
                   No workflows yet.
                 </Text>
@@ -58,6 +44,39 @@ export function WorkflowsTable({ workflows }: { workflows: WorkflowRecord[] }) {
         </TableTbody>
       </Table>
     </TableScrollContainer>
+  );
+}
+
+function WorkflowRow({ workflow }: { workflow: WorkflowRecord }) {
+  const qaStatus = getWorkflowQaStatus(workflow);
+
+  return (
+    <TableTr>
+      <TableTd>
+        <Code>{workflow.trackingCode ?? workflow.workflowId}</Code>
+      </TableTd>
+      <TableTd>
+        <Badge variant="light">{workflow.status}</Badge>
+      </TableTd>
+      <TableTd>
+        <Group gap={6} wrap="nowrap">
+          <Badge color={qaStatus.color} variant="light">{qaStatus.label}</Badge>
+          {workflow.issues.length ? (
+            <Text size="xs" c="dimmed">{workflow.issues.length} issue{workflow.issues.length === 1 ? "" : "s"}</Text>
+          ) : null}
+        </Group>
+      </TableTd>
+      <TableTd>
+        <Text size="sm" c="dimmed">
+          {workflow.createdAt}
+        </Text>
+      </TableTd>
+      <TableTd>
+        <Text size="sm" lineClamp={2} maw={520} title={workflow.userRequirement}>
+          {workflow.userRequirement}
+        </Text>
+      </TableTd>
+    </TableTr>
   );
 }
 

--- a/src/lib/qa-status.ts
+++ b/src/lib/qa-status.ts
@@ -1,0 +1,39 @@
+import type { AgentSessionRecord, IssueRecord, WorkflowRecord } from "@/lib/types";
+
+export type QaStatusId = "not_requested" | "needed" | "running" | "passed" | "failed";
+
+export type QaStatus = {
+  id: QaStatusId;
+  label: string;
+  color: string;
+};
+
+const qaStatuses: Record<QaStatusId, QaStatus> = {
+  not_requested: { id: "not_requested", label: "QA not requested", color: "gray" },
+  needed: { id: "needed", label: "QA needed", color: "orange" },
+  running: { id: "running", label: "QA running", color: "blue" },
+  passed: { id: "passed", label: "QA passed", color: "green" },
+  failed: { id: "failed", label: "QA failed", color: "red" }
+};
+
+export function getIssueQaStatus(issue: IssueRecord, qaSession?: AgentSessionRecord | null): QaStatus {
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? []), ...(qaSession?.labels ?? [])]);
+
+  if (labels.has("taskix:qa-failed") || qaSession?.status === "blocked") return qaStatuses.failed;
+  if (labels.has("taskix:qa-passed") || qaSession?.status === "done") return qaStatuses.passed;
+  if (labels.has("taskix:qa-running") || qaSession?.status === "active") return qaStatuses.running;
+  if (labels.has("taskix:need-qa") || qaSession?.role === "qa") return qaStatuses.needed;
+  return qaStatuses.not_requested;
+}
+
+export function getWorkflowQaStatus(workflow: WorkflowRecord): QaStatus {
+  if (!workflow.issues.length) return qaStatuses.not_requested;
+
+  const issueStatuses = workflow.issues.map((issue) => getIssueQaStatus(issue).id);
+  if (issueStatuses.includes("failed")) return qaStatuses.failed;
+  if (issueStatuses.includes("running")) return qaStatuses.running;
+  if (issueStatuses.includes("needed")) return qaStatuses.needed;
+  if (issueStatuses.every((status) => status === "passed")) return qaStatuses.passed;
+  if (issueStatuses.includes("passed")) return { id: "needed", label: "QA partial", color: "yellow" };
+  return qaStatuses.not_requested;
+}


### PR DESCRIPTION
## Summary

- Adds a shared QA status helper for workflow issue labels and QA session state.
- Shows QA gate status in the dashboard workflow table.
- Shows per-issue QA status in project workflow summaries and workflow detail issue cards.

## Linked Issue

Closes #2

## Verification

- `npm run typecheck`
- `npm run build`

## QA

QA should follow the instructions in issue #2 and add `qa-passwd` or `qa-failed` there.
