### PR TITLE
Show feedback after running project jobs

### DIFF
--- a/src/components/ProjectRunJobsForm.tsx
+++ b/src/components/ProjectRunJobsForm.tsx
@@ -1,27 +1,63 @@
 "use client";
 
-import { Button } from "@mantine/core";
+import { Button, Group, Text } from "@mantine/core";
 import { Play } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+type RunJobResponse = {
+  ran: boolean;
+  job: {
+    jobId: string;
+    type: string;
+    status: string;
+    error?: string | null;
+  } | null;
+};
+
 export function ProjectRunJobsForm({ projectId }: { projectId: string }) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [messageColor, setMessageColor] = useState<"dimmed" | "red" | "green">("dimmed");
 
   async function runJob() {
     setPending(true);
+    setMessage("");
     try {
-      await fetch(`/api/projects/${projectId}/jobs/run`, { method: "POST" });
+      const response = await fetch(`/api/projects/${projectId}/jobs/run`, { method: "POST" });
+      if (!response.ok) throw new Error(await response.text());
+
+      const result = await response.json() as RunJobResponse;
+      if (!result.ran || !result.job) {
+        setMessage("No pending jobs");
+        setMessageColor("dimmed");
+      } else if (result.job.status === "failed") {
+        setMessage(result.job.error ? `Failed: ${result.job.error}` : `${result.job.type} failed`);
+        setMessageColor("red");
+      } else {
+        setMessage(`${result.job.type} ${result.job.status}`);
+        setMessageColor("green");
+      }
       router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Run Jobs request failed");
+      setMessageColor("red");
     } finally {
       setPending(false);
     }
   }
 
   return (
-    <Button type="button" variant="light" size="xs" radius="xl" leftSection={<Play size={14} />} loading={pending} onClick={runJob}>
-      Run Jobs
-    </Button>
+    <Group gap={6} wrap="nowrap">
+      <Button type="button" variant="light" size="xs" radius="xl" leftSection={<Play size={14} />} loading={pending} onClick={runJob}>
+        Run Jobs
+      </Button>
+      {message ? (
+        <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>
+          {message}
+        </Text>
+      ) : null}
+    </Group>
   );
 }


### PR DESCRIPTION
## Summary

- Shows feedback after clicking `Run Jobs`.
- Distinguishes a claimed job, no pending jobs, and failed HTTP/job responses.
- Keeps the existing job runner behavior unchanged.

## Linked Issue

Closes #4

## Verification

- `npm run typecheck`
- `npm run build`

## QA

QA should follow the instructions in issue #4 and add `qa-passwd` or `qa-failed` there.
