### PR TITLE
Show feedback after GitHub sync

### DIFF
--- a/src/components/ProjectSyncForm.tsx
+++ b/src/components/ProjectSyncForm.tsx
@@ -1,27 +1,54 @@
 "use client";
 
-import { Button } from "@mantine/core";
+import { Button, Group, Text } from "@mantine/core";
 import { RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+type SyncResponse = {
+  synced: number;
+};
+
 export function ProjectSyncForm({ projectId }: { projectId: string }) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [messageColor, setMessageColor] = useState<"dimmed" | "red" | "green">("dimmed");
 
   async function sync() {
     setPending(true);
+    setMessage("");
     try {
-      await fetch(`/api/projects/${projectId}/sync`, { method: "POST" });
+      const response = await fetch(`/api/projects/${projectId}/sync`, { method: "POST" });
+      if (!response.ok) throw new Error(await response.text());
+
+      const result = await response.json() as SyncResponse;
+      if (result.synced > 0) {
+        setMessage(`Synced ${result.synced} workflow${result.synced === 1 ? "" : "s"}`);
+        setMessageColor("green");
+      } else {
+        setMessage("Nothing to sync");
+        setMessageColor("dimmed");
+      }
       router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "GitHub sync failed");
+      setMessageColor("red");
     } finally {
       setPending(false);
     }
   }
 
   return (
-    <Button type="button" variant="light" size="xs" radius="xl" leftSection={<RefreshCw size={14} />} loading={pending} onClick={sync}>
-      Sync GitHub
-    </Button>
+    <Group gap={6} wrap="nowrap">
+      <Button type="button" variant="light" size="xs" radius="xl" leftSection={<RefreshCw size={14} />} loading={pending} onClick={sync}>
+        Sync GitHub
+      </Button>
+      {message ? (
+        <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>
+          {message}
+        </Text>
+      ) : null}
+    </Group>
   );
 }


### PR DESCRIPTION
## Summary

- Shows feedback after clicking `Sync GitHub`.
- Distinguishes synced workflows, nothing to sync, and failed HTTP responses.
- Keeps the existing GitHub sync behavior unchanged.

## Linked Issue

Closes #6

## Verification

- `npm run typecheck`
- `npm run build`

## QA

QA should follow the instructions in issue #6 and add `qa-passwd` or `qa-failed` there.
