### PR TITLE
Add Tools readiness checklist

### DIFF
--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,3 +1,5 @@
+import { Badge, Group, Paper, SimpleGrid, Text, ThemeIcon } from "@mantine/core";
+import { CheckCircle2, FolderGit2, GitBranch, PlayCircle, Terminal } from "lucide-react";
 import { PageTitle } from "@/components/PageTitle";
 import { CodexStatusPanel } from "@/components/CodexStatusPanel";
 import { GhStatusPanel } from "@/components/GhStatusPanel";
@@ -6,8 +8,42 @@ export default function ToolsPage() {
   return (
     <>
       <PageTitle title="Tools" />
+      <Paper mb="md">
+        <Group justify="space-between" p="md" className="section-header">
+          <div>
+            <Text fw={760}>Readiness Checklist</Text>
+            <Text size="sm" c="dimmed">
+              Confirm these prerequisites before creating projects or running workflows.
+            </Text>
+          </div>
+          <Badge variant="light">local setup</Badge>
+        </Group>
+        <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="sm" p="md">
+          <ChecklistItem icon={<Terminal size={16} />} title="Codex CLI" detail="`codex exec` works with the configured model." />
+          <ChecklistItem icon={<GitBranch size={16} />} title="GitHub CLI" detail="`gh auth status` is authenticated over SSH." />
+          <ChecklistItem icon={<FolderGit2 size={16} />} title="GitHub Owner" detail="Settings has an owner and generated SSH key." />
+          <ChecklistItem icon={<PlayCircle size={16} />} title="Workflow Run" detail="Project is bound to a repo before jobs run." />
+        </SimpleGrid>
+      </Paper>
       <CodexStatusPanel />
       <GhStatusPanel />
     </>
+  );
+}
+
+function ChecklistItem({ icon, title, detail }: { icon: React.ReactNode; title: string; detail: string }) {
+  return (
+    <Group align="flex-start" gap="sm" wrap="nowrap">
+      <ThemeIcon variant="light" size="md">
+        {icon}
+      </ThemeIcon>
+      <div>
+        <Group gap={6}>
+          <CheckCircle2 size={13} />
+          <Text fw={720} size="sm">{title}</Text>
+        </Group>
+        <Text size="xs" c="dimmed">{detail}</Text>
+      </div>
+    </Group>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a readiness checklist to the Tools page.
- Calls out Codex CLI, GitHub CLI, GitHub owner, and project binding prerequisites.
- Leaves existing Codex and GitHub status panels unchanged.

## Linked Issue

Closes #8

## Verification

- `npm run typecheck`
- `npm run build`

## QA

QA should follow the instructions in issue #8 and add `qa-passwd` or `qa-failed` there.
