### PR TITLE
Fix QA passed label name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ QA should test from user-visible behavior and leave a GitHub issue comment with:
 - Findings with severity, reproduction steps, expected result, and actual result.
 - Any untested areas or environment limits.
 
-When QA passes, add the `qa-passwd` label. When QA fails, add `qa-failed` and comment with the failure details. Developers should address failed QA findings in a follow-up commit and request another QA pass on the same issue. Merge the PR into `main` only after QA has passed.
+When QA passes, add the `qa-passed` label. When QA fails, add `qa-failed` and comment with the failure details. Developers should address failed QA findings in a follow-up commit and request another QA pass on the same issue. Merge the PR into `main` only after QA has passed.
 
 ## Commit & Pull Request Guidelines
 


### PR DESCRIPTION
## Summary

- Fixes the manual QA pass label in `AGENTS.md` from `qa-passwd` to `qa-passed`.
- Keeps the existing `qa-failed` failure label.
- The GitHub label was renamed to `qa-passed`, preserving existing issue associations.

## Linked Issue

Closes #12

## Verification

- `rg -n "qa-passwd|qa-passed" AGENTS.md README.md src`
- `npm run typecheck`
- `npm run build`

## QA

QA should follow the instructions in issue #12 and add `qa-passed` or `qa-failed` there.
