### PR TITLE
Allow direct workflow start from project page

### DIFF
--- a/src/app/api/projects/[projectId]/handoff/route.ts
+++ b/src/app/api/projects/[projectId]/handoff/route.ts
@@ -10,14 +10,16 @@ export async function POST(request: Request, { params }: { params: Promise<{ pro
 
   const form = await request.formData();
   const submittedPayload = parseReadyForArchitectPayload(String(form.get("payload") ?? ""));
+  const directRequirement = String(form.get("requirement") ?? "").trim();
   const pmSession = await getAgentSession(`${project.projectId}:product_manager`);
   const payload = submittedPayload ?? findReadyForArchitectPayload(pmSession);
-  if (!payload) {
-    return redirect(request, `/projects/${project.projectId}?role=product_manager&error=${encodeURIComponent("PM has not produced ready_for_architect JSON yet.")}`);
+  if (!payload && !directRequirement) {
+    return redirect(request, `/projects/${project.projectId}?role=product_manager&error=${encodeURIComponent("Enter a requirement or use PM chat to produce ready_for_architect JSON.")}`);
   }
 
   try {
-    const workflow = await createWorkflow(formatPmHandoffPayload(payload), 0, project);
+    const requirement = payload ? formatPmHandoffPayload(payload) : directRequirement;
+    const workflow = await createWorkflow(requirement, 0, project);
     await createJob({
       projectId: project.projectId,
       type: "workflow_run",

--- a/src/components/ProjectHandoffForm.tsx
+++ b/src/components/ProjectHandoffForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Text } from "@mantine/core";
+import { Button, Text, Textarea } from "@mantine/core";
 import { GitBranch, LoaderCircle } from "lucide-react";
 import { useFormStatus } from "react-dom";
 import type { PmHandoffPayload } from "@/lib/pm-handoff";
@@ -8,12 +8,9 @@ import type { PmHandoffPayload } from "@/lib/pm-handoff";
 export function ProjectHandoffForm({ projectId, payload }: { projectId: string; payload: PmHandoffPayload | null }) {
   if (!payload) {
     return (
-      <div className="handoff-box muted">
-        <Text size="sm" fw={700}>Start Workflow</Text>
-        <Text size="xs" c="dimmed">
-          The button appears after PM outputs ready_for_architect JSON.
-        </Text>
-      </div>
+      <form method="post" action={`/api/projects/${projectId}/handoff`} className="handoff-form">
+        <DirectRequirementFields />
+      </form>
     );
   }
 
@@ -22,6 +19,41 @@ export function ProjectHandoffForm({ projectId, payload }: { projectId: string; 
       <input type="hidden" name="payload" value={JSON.stringify(payload)} />
       <HandoffButton payload={payload} />
     </form>
+  );
+}
+
+function DirectRequirementFields() {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="handoff-box muted">
+      <Text size="sm" fw={700}>Start Workflow</Text>
+      <Text size="xs" c="dimmed">
+        Paste a confirmed requirement here, or use PM chat to produce ready JSON.
+      </Text>
+      <Textarea
+        name="requirement"
+        aria-label="Direct workflow requirement"
+        placeholder="Describe the workflow requirement for the architect..."
+        autosize
+        minRows={3}
+        maxRows={6}
+        mt="xs"
+        required
+        disabled={pending}
+      />
+      <Button
+        type="submit"
+        fullWidth
+        mt="sm"
+        radius="xl"
+        variant="light"
+        leftSection={pending ? <LoaderCircle size={15} className="chat-composer-spinner" /> : <GitBranch size={15} />}
+        disabled={pending}
+      >
+        {pending ? "Queueing workflow..." : "Start From Requirement"}
+      </Button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a direct requirement form to the project page when PM has not produced `ready_for_architect` JSON.
- Lets the existing handoff API create and queue a project workflow from either PM payload or direct requirement text.
- Preserves the existing PM handoff start path.

## Linked Issue

Closes #16

## Verification

- `npm run typecheck`
- `npm run build`
- Attempted `npm run dev`; server started after clearing port 8000, but shell `curl` access was inconsistent in this environment. QA should perform browser validation from issue #16.

## QA

QA should follow issue #16 browser validation and add `qa-passed` or `qa-failed`.
