### PR TITLE
Allow project creation without AGENTS write

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -18,18 +18,21 @@ export async function POST(request: Request) {
   const githubAccount = settings.githubUsername;
   const agentsFilePath = String(form.get("agentsFilePath") ?? "AGENTS.md").trim();
   const autoDeploy = form.get("autoDeploy") === "true";
+  const updateAgentsFile = form.get("updateAgentsFile") === "true";
 
   const error = validateProject(projectName, githubRepo, githubAccount, agentsFilePath);
   if (error) return redirect(request, `/projects/new?error=${encodeURIComponent(error)}`);
 
   try {
     await verifyLocalGitHubRepo(githubRepo);
-    await upsertAgentsFileWithGh({
-      repo: githubRepo,
-      projectName,
-      autoDeploy,
-      path: agentsFilePath
-    });
+    if (updateAgentsFile) {
+      await upsertAgentsFileWithGh({
+        repo: githubRepo,
+        projectName,
+        autoDeploy,
+        path: agentsFilePath
+      });
+    }
   } catch (verificationError) {
     const message = verificationError instanceof Error ? verificationError.message : "GitHub connection failed.";
     return redirect(request, `/projects/new?error=${encodeURIComponent(message)}`);
@@ -41,7 +44,8 @@ export async function POST(request: Request) {
     githubAccount,
     githubAccessToken: "",
     autoDeploy,
-    agentsFilePath
+    agentsFilePath,
+    updateAgentsFile
   });
   return redirect(request, `/projects?message=${encodeURIComponent(`Project ${project.name} created. Telegram users can switch with /use ${project.slug}.`)}`);
 }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -80,6 +80,7 @@ export default async function ProjectDetailPage({
               <Text size="sm">Architect: <Code>{project.architectSessionId ?? "new"}</Code></Text>
               <Text size="sm">DevOps: <Code>{project.devopsSessionId ?? "new"}</Code></Text>
               <Text size="sm">Agents: <Code>{project.agentsFilePath}</Code></Text>
+              <Text size="sm">Agents update: <Code>{project.updateAgentsFile ? "enabled" : "skipped"}</Code></Text>
             </Stack>
           </Paper>
 

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -59,11 +59,18 @@ export default async function NewProjectPage({ searchParams }: { searchParams: P
             <TextInput
               name="agentsFilePath"
               label="Agent Instructions File"
-              description="Codex reads AGENTS.md. Existing content outside Taskix's managed block is preserved."
+              description="Used only when AGENTS update is enabled. Existing content outside Taskix's managed block is preserved."
               defaultValue="AGENTS.md"
               required
             />
           </SimpleGrid>
+          <Checkbox
+            name="updateAgentsFile"
+            value="true"
+            mt="md"
+            label="Update AGENTS.md in the selected repository"
+            description="Enable only when you want Taskix to commit or update the managed workflow section in the remote repo."
+          />
           <Checkbox
             name="autoDeploy"
             value="true"
@@ -72,7 +79,7 @@ export default async function NewProjectPage({ searchParams }: { searchParams: P
             description="Leave disabled if the architect should stop at merge readiness and wait for manual deployment approval."
           />
           <Alert color="gray" icon={<ShieldCheck size={16} />} mt="md">
-            Project creation uses your configured GitHub account and local gh login to write the workflow into AGENTS.md.
+            Project creation always verifies the repository with your local gh login. Updating AGENTS.md is optional and may modify the remote repository.
           </Alert>
           <Button type="submit" disabled={!hasGitHubAccount || !repos.length} leftSection={<FolderPlus size={16} />} w={{ base: "100%", sm: "fit-content" }}>
             Connect GitHub & Add Project

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -26,6 +26,7 @@ export async function createProject(input: {
   githubAccessToken: string;
   autoDeploy: boolean;
   agentsFilePath: string;
+  updateAgentsFile: boolean;
 }): Promise<ProjectRecord> {
   const project: ProjectRecord = {
     projectId: randomUUID().slice(0, 8),
@@ -36,6 +37,7 @@ export async function createProject(input: {
     githubAccessToken: input.githubAccessToken.trim(),
     autoDeploy: input.autoDeploy,
     agentsFilePath: input.agentsFilePath.trim() || "AGENTS.md",
+    updateAgentsFile: input.updateAgentsFile,
     projectManagerSessionId: null,
     architectSessionId: null,
     devopsSessionId: null,
@@ -257,6 +259,7 @@ function normalizeProject(project: ProjectRecord): ProjectRecord {
     ...project,
     autoDeploy: project.autoDeploy ?? false,
     agentsFilePath: project.agentsFilePath ?? "AGENTS.md",
+    updateAgentsFile: project.updateAgentsFile ?? true,
     architectSessionId: project.architectSessionId ?? null,
     devopsSessionId: project.devopsSessionId ?? null,
     teamRoles: project.teamRoles ?? ["developer", "qa", "architect", "devops"]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,6 +124,7 @@ export type ProjectRecord = {
   githubAccessToken: string;
   autoDeploy: boolean;
   agentsFilePath: string;
+  updateAgentsFile: boolean;
   projectManagerSessionId?: string | null;
   architectSessionId?: string | null;
   devopsSessionId?: string | null;


### PR DESCRIPTION
## Summary

- Adds an explicit optional `Update AGENTS.md` checkbox to project creation.
- Allows creating a local Taskix project binding without writing to the remote repo.
- Stores and shows whether AGENTS update was enabled or skipped.
- Keeps repo verification required and preserves the old AGENTS update path when opted in.

## Linked Issue

Closes #18

## Related QA

Unblocks the main-flow E2E blocker reported in #15.

## Verification

- `npm run typecheck`
- `npm run build`

## QA

QA should follow issue #18 browser validation, then retry issue #15 from project creation onward. Add `qa-passed` or `qa-failed` on #18.
