### PR TITLE
Document Issue 15 safe smoke recheck plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,14 @@ Minimal local QA smoke workflow for main-flow E2E validation:
   - QA evidence record: issue `#23` comments thread at https://github.com/Taskix-AI/Taskix/issues/23
 - Architect merge-readiness inputs: confirmation that the smoke job passed or failed, the exact commands run, the browser scenarios exercised, and the final QA evidence link on issue `#23`
 
+Planning-only safe main-flow smoke recheck for Issue 15:
+
+- Workflow ID: `WF-20260430-004`
+- Planning issue: https://github.com/Taskix-AI/Taskix/issues/32
+- Scope: documentation-only planning for a safe main-flow smoke recheck; no deployment work is in scope
+- Execution stop point: implementation stops after planning is documented in repository guidance
+- Job handling: any `issue_run` jobs are only queued for later manual Run Jobs execution and are not executed as part of this work
+
 - PM keeps talking with the user and hands confirmed requirements to the architect.
 - Architect creates issues with developerRole and ownedPaths.
 - Developers must stay inside ownedPaths.


### PR DESCRIPTION
## Summary
- add a planning-only repository guidance entry for the Issue 15 safe main-flow smoke recheck
- state that no deployment work is in scope and execution stops after planning
- clarify that any issue_run jobs are queued for later manual Run Jobs execution

Closes #32

## Verification
- not run (documentation-only change)