### PR TITLE
Stop issue runs before automatic merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev -H 127.0.0.1 -p 8000",
     "build": "next build",
     "start": "next start -H 127.0.0.1 -p 8000",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:issue-run": "node --experimental-strip-types scripts/issue-run-policy.test.mjs"
   },
   "dependencies": {
     "@mantine/core": "^9.1.0",

--- a/scripts/issue-run-policy.test.mjs
+++ b/scripts/issue-run-policy.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   expectedDeveloperBranch,
+  manualDeployArchitectPolicyDecision,
   manualDeployFinalLabelPlan,
   prRecoveryBranches
 } from "../src/lib/issue-run-policy.ts";
@@ -25,12 +26,12 @@ assert.deepEqual(
 
 const ready = manualDeployFinalLabelPlan({
   prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
-  architectDecision: {
-    decision: "ready_to_merge",
-    summary: "Architect approved after QA.",
-    labelsApplied: [],
-    comments: []
-  }
+  architectDecision: manualDeployArchitectPolicyDecision({
+    prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+    qaPassed: true,
+    prState: "OPEN",
+    prMerged: false
+  })
 });
 
 assert.equal(ready.decision, "ready_to_merge");
@@ -40,16 +41,27 @@ assert.match(ready.summary, /without merging it/);
 
 const blocked = manualDeployFinalLabelPlan({
   prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
-  architectDecision: {
-    decision: "blocked",
-    summary: "Architect could not verify readiness.",
-    labelsApplied: [],
-    comments: []
-  }
+  architectDecision: manualDeployArchitectPolicyDecision({
+    prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+    qaPassed: false,
+    prState: "OPEN",
+    prMerged: false
+  })
 });
 
 assert.equal(blocked.decision, "blocked");
 assert.deepEqual(blocked.labelsApplied, ["taskix:blocked"]);
 assert.deepEqual(blocked.labelsRemoved, ["taskix:qa-running", "taskix:ready-to-merge"]);
+assert.match(blocked.summary, /QA has not passed/);
+
+const mergedBlocked = manualDeployArchitectPolicyDecision({
+  prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+  qaPassed: true,
+  prState: "MERGED",
+  prMerged: true
+});
+
+assert.equal(mergedBlocked.decision, "blocked");
+assert.match(mergedBlocked.summary, /already merged/);
 
 console.log("issue-run policy simulation passed");

--- a/scripts/issue-run-policy.test.mjs
+++ b/scripts/issue-run-policy.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import {
+  expectedDeveloperBranch,
+  manualDeployFinalLabelPlan,
+  prRecoveryBranches
+} from "../src/lib/issue-run-policy.ts";
+
+const workflowCode = "WF-20260501-999";
+const issueNumber = 123;
+const expectedBranch = `taskix/${workflowCode}-issue-${issueNumber}`;
+
+assert.equal(expectedDeveloperBranch(workflowCode, issueNumber), expectedBranch);
+
+assert.deepEqual(
+  prRecoveryBranches({ developerBranch: "", workflowCode, issueNumberOrId: issueNumber }),
+  [expectedBranch],
+  "empty developer branch should fall back to deterministic workflow branch"
+);
+
+assert.deepEqual(
+  prRecoveryBranches({ developerBranch: expectedBranch, workflowCode, issueNumberOrId: issueNumber }),
+  [expectedBranch],
+  "duplicate developer/expected branch should be de-duplicated"
+);
+
+const ready = manualDeployFinalLabelPlan({
+  prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+  architectDecision: {
+    decision: "ready_to_merge",
+    summary: "Architect approved after QA.",
+    labelsApplied: [],
+    comments: []
+  }
+});
+
+assert.equal(ready.decision, "ready_to_merge");
+assert.deepEqual(ready.labelsApplied, ["taskix:ready-to-merge"]);
+assert.deepEqual(ready.labelsRemoved, ["taskix:need-qa", "taskix:qa-running", "taskix:blocked"]);
+assert.match(ready.summary, /without merging it/);
+
+const blocked = manualDeployFinalLabelPlan({
+  prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+  architectDecision: {
+    decision: "blocked",
+    summary: "Architect could not verify readiness.",
+    labelsApplied: [],
+    comments: []
+  }
+});
+
+assert.equal(blocked.decision, "blocked");
+assert.deepEqual(blocked.labelsApplied, ["taskix:blocked"]);
+assert.deepEqual(blocked.labelsRemoved, ["taskix:qa-running", "taskix:ready-to-merge"]);
+
+console.log("issue-run policy simulation passed");

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,10 +2,22 @@ import { Alert, Button, Group, Paper, Text } from "@mantine/core";
 import { FolderPlus, Info } from "lucide-react";
 import { PageTitle } from "@/components/PageTitle";
 import { ProjectsTable } from "@/components/Tables";
-import { listProjects } from "@/lib/store";
+import { listProjects, listWorkflows } from "@/lib/store";
 
 export default async function ProjectsPage({ searchParams }: { searchParams: Promise<{ message?: string; error?: string }> }) {
-  const [{ message, error }, projects] = await Promise.all([searchParams, listProjects()]);
+  const [{ message, error }, projects, workflows] = await Promise.all([searchParams, listProjects(), listWorkflows()]);
+  const latestWorkflowByProject = new Map<string, string>();
+  for (const workflow of workflows) {
+    if (!workflow.projectId) continue;
+    const current = latestWorkflowByProject.get(workflow.projectId);
+    if (!current || workflow.createdAt > current) latestWorkflowByProject.set(workflow.projectId, workflow.createdAt);
+  }
+  const projectsWithLatest = projects
+    .map((project) => ({
+      ...project,
+      latestAt: latestWorkflowByProject.get(project.projectId) ?? project.createdAt
+    }))
+    .sort((a, b) => b.latestAt.localeCompare(a.latestAt));
 
   return (
     <>
@@ -27,7 +39,7 @@ export default async function ProjectsPage({ searchParams }: { searchParams: Pro
             Add Project
           </Button>
         </Group>
-        <ProjectsTable projects={projects} />
+        <ProjectsTable projects={projectsWithLatest} />
       </Paper>
     </>
   );

--- a/src/components/Tables.tsx
+++ b/src/components/Tables.tsx
@@ -80,7 +80,9 @@ function WorkflowRow({ workflow }: { workflow: WorkflowRecord }) {
   );
 }
 
-export function ProjectsTable({ projects }: { projects: ProjectRecord[] }) {
+type ProjectTableRecord = ProjectRecord & { latestAt?: string };
+
+export function ProjectsTable({ projects }: { projects: ProjectTableRecord[] }) {
   return (
     <TableScrollContainer minWidth={780}>
       <Table highlightOnHover verticalSpacing="sm">
@@ -88,6 +90,7 @@ export function ProjectsTable({ projects }: { projects: ProjectRecord[] }) {
           <TableTr>
             <TableTh>Slug</TableTh>
             <TableTh>Name</TableTh>
+            <TableTh>Latest</TableTh>
             <TableTh>Account</TableTh>
             <TableTh>Repo</TableTh>
             <TableTh>Deploy</TableTh>
@@ -105,6 +108,11 @@ export function ProjectsTable({ projects }: { projects: ProjectRecord[] }) {
                 </TableTd>
                 <TableTd>
                   <a className="row-link" href={`/projects/${project.projectId}`}>{project.name}</a>
+                </TableTd>
+                <TableTd>
+                  <a className="row-link" href={`/projects/${project.projectId}`}>
+                    <Text size="sm" c="dimmed">{formatDateTime(project.latestAt ?? project.createdAt)}</Text>
+                  </a>
                 </TableTd>
                 <TableTd>
                   <a className="row-link" href={`/projects/${project.projectId}`}>{project.githubAccount}</a>
@@ -126,7 +134,7 @@ export function ProjectsTable({ projects }: { projects: ProjectRecord[] }) {
             ))
           ) : (
             <TableTr>
-              <TableTd colSpan={6}>
+              <TableTd colSpan={7}>
                 <Text c="dimmed" ta="center" py="md">
                   No projects yet.
                 </Text>
@@ -137,4 +145,15 @@ export function ProjectsTable({ projects }: { projects: ProjectRecord[] }) {
       </Table>
     </TableScrollContainer>
   );
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(date);
 }

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -1,13 +1,18 @@
+import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
 import { developerRoleIds, developerRoleProfile, formatDeveloperRoleCatalog } from "@/lib/developer-roles";
 import type { ArchitectPrReviewResult, ArchitectReviewResult, DeveloperIssueResult, DeveloperResult, IssueSpec, QaPrReviewResult, QaResult } from "@/lib/types";
-import { rootDir } from "@/lib/paths";
+import { dataDir, rootDir } from "@/lib/paths";
 import type { Settings } from "@/lib/types";
 
 type CodexTextResult = { text: string; sessionId?: string | null };
+type RunJsonOptions = { cwd?: string };
+type RunCodexOptions = { cwd?: string };
+const execFileAsync = promisify(execFile);
 const codexTimeoutMs = 10 * 60 * 1000;
 export type ArchitectBlockerResolution = {
   action: "retry_developer" | "request_user_input" | "mark_blocked";
@@ -278,11 +283,24 @@ Implementation must stay within owned paths unless the issue explicitly calls ou
       changedFiles: { type: "array", items: { type: "string" } },
       testsRun: { type: "array", items: { type: "string" } }
     });
+    let workspaceDir: string;
+    try {
+      workspaceDir = await this.prepareDeveloperWorkspace(input.repo, input.workflowId, input.issueNumber);
+    } catch (error) {
+      return {
+        summary: `Developer workspace preparation failed for issue #${input.issueNumber}: ${error instanceof Error ? error.message : String(error)}`,
+        branch: "",
+        prUrl: "",
+        changedFiles: [],
+        testsRun: []
+      };
+    }
     const prompt = `${rolePrompts.developer}
 
 GitHub repo: ${input.repo}
 GitHub issue: #${input.issueNumber}
 Workflow: ${input.workflowId}
+Workspace: ${workspaceDir}
 
 Developer role: ${input.issue.developerRole ?? "general_developer"}
 Role profile:
@@ -300,15 +318,15 @@ Required GitHub label behavior:
 Execution rules:
 - Use gh to read issue #${input.issueNumber}; treat GitHub as the source of truth.
 - Do not modify the current Taskix app checkout or its .git directory.
-- Create or reuse an isolated working clone under data/taskix-workspaces/${input.workflowId}-issue-${input.issueNumber}.
-- Run git fetch, checkout, commit, push, and gh pr create only inside that isolated clone.
+- The current working directory is the isolated clone for this issue: ${workspaceDir}.
+- Run git fetch, checkout, commit, push, and gh pr create only in the current working directory.
 - Work only inside ownedPaths unless the issue explicitly requires an integration point.
 - Create a branch named taskix/${input.workflowId}-issue-${input.issueNumber} or a similarly unique branch.
 - Implement the issue, run relevant tests, commit, push, and open a PR.
 - If implementation is blocked, comment on the issue, add taskix:blocked, and still return JSON with prUrl as an empty string.
 
 Return JSON with summary, branch, prUrl, changedFiles, testsRun.`;
-    const result = await this.runJsonResult<DeveloperIssueResult>(prompt, schema);
+    const result = await this.runJsonResult<DeveloperIssueResult>(prompt, schema, { cwd: workspaceDir });
     return result.value ?? {
       summary: `Developer runner did not complete issue #${input.issueNumber}.${result.error ? `\n\nCodex error:\n${result.error}` : ""}`,
       branch: "",
@@ -493,7 +511,7 @@ Summarize code review outcome, merge readiness, and deployment status according 
     return (await this.runJsonResult<T>(prompt, schema)).value;
   }
 
-  private async runJsonResult<T>(prompt: string, schema: object): Promise<{ value: T | null; error: string | null }> {
+  private async runJsonResult<T>(prompt: string, schema: object, options: RunJsonOptions = {}): Promise<{ value: T | null; error: string | null }> {
     const tmp = await this.tmpDir();
     const schemaPath = path.join(tmp, "schema.json");
     const outputPath = path.join(tmp, "output.json");
@@ -510,7 +528,7 @@ Summarize code review outcome, merge readiness, and deployment status according 
       "-o",
       outputPath,
       prompt
-    ]);
+    ], { cwd: options.cwd });
     if (!result.ok) return { value: null, error: result.stderr.trim() || "Codex exited with a non-zero status." };
     try {
       return { value: JSON.parse(await readFile(outputPath, "utf8")) as T, error: null };
@@ -532,12 +550,12 @@ Summarize code review outcome, merge readiness, and deployment status according 
     }
   }
 
-  private async runCodex(args: string[]): Promise<{ ok: boolean; stderr: string }> {
+  private async runCodex(args: string[], options: RunCodexOptions = {}): Promise<{ ok: boolean; stderr: string }> {
     const codexHome = this.settings.codexHome;
     await mkdir(codexHome, { recursive: true });
     return new Promise((resolve) => {
       const child = spawn(this.settings.codexBin, ["exec", ...args], {
-        cwd: rootDir,
+        cwd: options.cwd ?? rootDir,
         env: { ...process.env, CODEX_HOME: codexHome },
         stdio: ["ignore", "pipe", "pipe"]
       });
@@ -573,6 +591,26 @@ Summarize code review outcome, merge readiness, and deployment status according 
       return dir;
     });
   }
+
+  private async prepareDeveloperWorkspace(repo: string, workflowId: string, issueNumber: number): Promise<string> {
+    const workspaceRoot = path.join(dataDir, "taskix-workspaces");
+    await mkdir(workspaceRoot, { recursive: true });
+    const baseDir = path.join(workspaceRoot, sanitizePathSegment(`${workflowId}-issue-${issueNumber}`));
+    const workspaceDir = await chooseWorkspaceDir(baseDir);
+
+    if (!existsSync(path.join(workspaceDir, ".git"))) {
+      await mkdir(path.dirname(workspaceDir), { recursive: true });
+      await execFileAsync("gh", ["repo", "clone", repo, workspaceDir]);
+      return workspaceDir;
+    }
+
+    try {
+      await execFileAsync("git", ["-C", workspaceDir, "fetch", "origin", "--prune"]);
+    } catch {
+      // A stale clone is still a safer execution directory than the app checkout.
+    }
+    return workspaceDir;
+  }
 }
 
 function objectSchema(properties: Record<string, unknown>): object {
@@ -586,6 +624,17 @@ function extractSessionId(stderr: string): string | null {
 
 function approvalArgs(policy: string): string[] {
   return policy === "never" ? ["--full-auto"] : [];
+}
+
+async function chooseWorkspaceDir(baseDir: string): Promise<string> {
+  if (!existsSync(baseDir) || existsSync(path.join(baseDir, ".git"))) return baseDir;
+  const fallback = `${baseDir}-${Date.now().toString(36)}`;
+  await mkdir(path.dirname(fallback), { recursive: true });
+  return fallback;
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]/g, "-");
 }
 
 function mockIssues(): IssueSpec[] {

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -299,7 +299,9 @@ Required GitHub label behavior:
 
 Execution rules:
 - Use gh to read issue #${input.issueNumber}; treat GitHub as the source of truth.
-- Clone or use the repo in a workspace under this project if needed.
+- Do not modify the current Taskix app checkout or its .git directory.
+- Create or reuse an isolated working clone under data/taskix-workspaces/${input.workflowId}-issue-${input.issueNumber}.
+- Run git fetch, checkout, commit, push, and gh pr create only inside that isolated clone.
 - Work only inside ownedPaths unless the issue explicitly requires an integration point.
 - Create a branch named taskix/${input.workflowId}-issue-${input.issueNumber} or a similarly unique branch.
 - Implement the issue, run relevant tests, commit, push, and open a PR.

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -325,6 +325,7 @@ Execution rules:
 - Run git fetch, checkout, commit, push, and gh pr create only in the current working directory.
 - Work only inside ownedPaths unless the issue explicitly requires an integration point.
 - Create a branch named taskix/${input.workflowId}-issue-${input.issueNumber} or a similarly unique branch.
+- If this work validates Taskix recovery/ready-to-merge behavior, document observable verification evidence in the PR body, including deterministic recovery, recovered base visibility, ready-to-merge expectations, and no generated PR merge.
 - Implement the issue, run relevant tests, commit, push, and open a PR.
 - If implementation is blocked, comment on the issue, add taskix:blocked, and still return JSON with prUrl as an empty string.
 
@@ -399,6 +400,7 @@ Required GitHub label behavior:
 - Add taskix:qa-running to the issue and PR when you start.
 - Read the issue acceptance criteria and PR diff using gh.
 - Validate implementation, ownedPaths, and relevant tests.
+- When passing QA, comment concise verification evidence on the PR, including commands run and any observable labels/state required by acceptance criteria.
 - If passed, add taskix:qa-passed and remove taskix:qa-running.
 - If failed, comment findings on the PR, add taskix:qa-failed, and remove taskix:qa-running.
 

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -341,8 +341,8 @@ Required GitHub label behavior:
 - Read the linked issue and PR with gh.
 - If QA is required before merge, add taskix:need-qa to the PR and issue, then return decision "need_qa".
 - If changes are required from developer, comment on the PR, add taskix:blocked, and return decision "changes_requested".
-- If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge.
-- Merge only when it is safe. If merged, add taskix:merged. If auto deploy is enabled and deployment succeeds, add taskix:deployed.
+- If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge and return decision "ready_to_merge".
+- Do not merge PRs in normal Taskix validation runs. Only return decision "merged" if an explicit merge-validation instruction is present outside this prompt. Auto deploy does not authorize merge by itself.
 
 Return JSON with decision, summary, labelsApplied, comments.`;
     return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -295,12 +295,14 @@ Implementation must stay within owned paths unless the issue explicitly calls ou
         testsRun: []
       };
     }
+    const baseBranch = await currentAppBranch();
     const prompt = `${rolePrompts.developer}
 
 GitHub repo: ${input.repo}
 GitHub issue: #${input.issueNumber}
 Workflow: ${input.workflowId}
 Workspace: ${workspaceDir}
+Base branch: ${baseBranch ?? "repository default branch"}
 
 Developer role: ${input.issue.developerRole ?? "general_developer"}
 Role profile:
@@ -319,6 +321,7 @@ Execution rules:
 - Use gh to read issue #${input.issueNumber}; treat GitHub as the source of truth.
 - Do not modify the current Taskix app checkout or its .git directory.
 - The current working directory is the isolated clone for this issue: ${workspaceDir}.
+- Start from the checked-out base branch in the current working directory.
 - Run git fetch, checkout, commit, push, and gh pr create only in the current working directory.
 - Work only inside ownedPaths unless the issue explicitly requires an integration point.
 - Create a branch named taskix/${input.workflowId}-issue-${input.issueNumber} or a similarly unique branch.
@@ -601,6 +604,7 @@ Summarize code review outcome, merge readiness, and deployment status according 
     if (!existsSync(path.join(workspaceDir, ".git"))) {
       await mkdir(path.dirname(workspaceDir), { recursive: true });
       await execFileAsync("gh", ["repo", "clone", repo, workspaceDir]);
+      await checkoutWorkspaceBase(workspaceDir);
       return workspaceDir;
     }
 
@@ -609,6 +613,7 @@ Summarize code review outcome, merge readiness, and deployment status according 
     } catch {
       // A stale clone is still a safer execution directory than the app checkout.
     }
+    await checkoutWorkspaceBase(workspaceDir);
     return workspaceDir;
   }
 }
@@ -635,6 +640,26 @@ async function chooseWorkspaceDir(baseDir: string): Promise<string> {
 
 function sanitizePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9_.-]/g, "-");
+}
+
+async function checkoutWorkspaceBase(workspaceDir: string): Promise<void> {
+  const branch = await currentAppBranch();
+  if (!branch) return;
+  try {
+    await execFileAsync("git", ["-C", workspaceDir, "fetch", "origin", branch]);
+    await execFileAsync("git", ["-C", workspaceDir, "checkout", "-B", branch, `origin/${branch}`]);
+  } catch {
+    // If the running app branch is not available remotely, keep the clone's default branch.
+  }
+}
+
+async function currentAppBranch(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", rootDir, "branch", "--show-current"]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 function mockIssues(): IssueSpec[] {

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -378,6 +378,44 @@ Return JSON with decision, summary, labelsApplied, comments.`;
     };
   }
 
+  async architectConfirmManualReady(input: {
+    repo: string;
+    issueNumber: number;
+    prUrl: string;
+  }): Promise<ArchitectPrReviewResult> {
+    const schema = objectSchema({
+      decision: { type: "string", enum: ["ready_to_merge", "changes_requested", "blocked"] },
+      summary: { type: "string" },
+      labelsApplied: { type: "array", items: { type: "string" } },
+      comments: { type: "array", items: { type: "string" } }
+    });
+    const prompt = `${rolePrompts.architect}
+
+GitHub repo: ${input.repo}
+Issue: #${input.issueNumber}
+PR: ${input.prUrl}
+Project deployment policy: manual deploy; do not merge.
+
+You are the architect and own final merge-readiness review after QA has passed.
+
+Rules:
+- Read the linked issue, PR diff, labels, and QA result with gh.
+- Decide whether the PR is ready to merge, needs changes, or is blocked.
+- Do not merge the PR.
+- Do not add or remove GitHub labels; Taskix will apply labels after your structured decision.
+- Return "ready_to_merge" only when QA has passed and the PR satisfies the issue acceptance criteria.
+- Return "changes_requested" if implementation changes are required.
+- Return "blocked" if readiness cannot be determined from available GitHub state.
+
+Return JSON with decision, summary, labelsApplied, comments. Set labelsApplied to an empty array.`;
+    return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {
+      decision: "blocked",
+      summary: `Architect runner did not complete manual ready review for ${input.prUrl}.`,
+      labelsApplied: [],
+      comments: []
+    };
+  }
+
   async qaReviewPr(input: {
     repo: string;
     issueNumber: number;

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -342,7 +342,8 @@ Required GitHub label behavior:
 - If QA is required before merge, add taskix:need-qa to the PR and issue, then return decision "need_qa".
 - If changes are required from developer, comment on the PR, add taskix:blocked, and return decision "changes_requested".
 - If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge and return decision "ready_to_merge".
-- Do not merge PRs in normal Taskix validation runs. Only return decision "merged" if an explicit merge-validation instruction is present outside this prompt. Auto deploy does not authorize merge by itself.
+- If auto deploy is disabled, do not merge the PR; stop at taskix:ready-to-merge.
+- If auto deploy is enabled and QA has passed, you may merge only when repository checks and branch state are safe.
 
 Return JSON with decision, summary, labelsApplied, comments.`;
     return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -80,6 +80,29 @@ export async function commentIssueWithGh(repo: string, issueNumber: number, body
   await execFileAsync("gh", ["issue", "comment", String(issueNumber), "--repo", repo, "--body", body]);
 }
 
+export async function findPullRequestByHeadWithGh(repo: string, branch: string): Promise<string | null> {
+  const { stdout } = await execFileAsync("gh", ["pr", "list", "--repo", repo, "--head", branch, "--state", "all", "--json", "url", "--limit", "1"]);
+  const prs = JSON.parse(stdout) as Array<{ url: string }>;
+  return prs[0]?.url ?? null;
+}
+
+export async function createPullRequestWithGh(input: {
+  repo: string;
+  head: string;
+  base: string | null;
+  title: string;
+  body: string;
+  labels: string[];
+}): Promise<string> {
+  await ensureTaskixLabels(input.repo);
+  const args = ["pr", "create", "--repo", input.repo, "--head", input.head, "--title", input.title, "--body", input.body];
+  if (input.base) args.push("--base", input.base);
+  const { stdout } = await execFileAsync("gh", args);
+  const prUrl = stdout.trim();
+  if (input.labels.length) await addLabelsWithGh(input.repo, prUrl, input.labels);
+  return prUrl;
+}
+
 export async function addLabelsWithGh(repo: string, target: number | string, labels: string[]): Promise<void> {
   if (!labels.length) return;
   await ensureTaskixLabels(repo);

--- a/src/lib/issue-run-policy.ts
+++ b/src/lib/issue-run-policy.ts
@@ -1,0 +1,51 @@
+import type { ArchitectPrReviewResult } from "@/lib/types";
+
+export type LabelPlan = {
+  decision: "ready_to_merge" | "blocked" | "changes_requested";
+  summary: string;
+  labelsApplied: string[];
+  labelsRemoved: string[];
+  comments: string[];
+};
+
+export function expectedDeveloperBranch(workflowCode: string, issueNumberOrId: number | string): string {
+  return `taskix/${workflowCode}-issue-${issueNumberOrId}`;
+}
+
+export function prRecoveryBranches(input: {
+  developerBranch?: string | null;
+  workflowCode: string;
+  issueNumberOrId: number | string;
+}): string[] {
+  return [
+    input.developerBranch?.trim() || "",
+    expectedDeveloperBranch(input.workflowCode, input.issueNumberOrId)
+  ].filter(uniqueNonEmpty);
+}
+
+export function manualDeployFinalLabelPlan(input: {
+  prUrl: string;
+  architectDecision: ArchitectPrReviewResult;
+}): LabelPlan {
+  if (input.architectDecision.decision !== "ready_to_merge") {
+    return {
+      decision: input.architectDecision.decision === "changes_requested" ? "changes_requested" : "blocked",
+      summary: input.architectDecision.summary,
+      labelsApplied: [...new Set([...input.architectDecision.labelsApplied, "taskix:blocked"])],
+      labelsRemoved: ["taskix:qa-running", "taskix:ready-to-merge"],
+      comments: input.architectDecision.comments
+    };
+  }
+
+  return {
+    decision: "ready_to_merge",
+    summary: `${input.architectDecision.summary}\n\nManual-deploy project: architect approved merge readiness after QA; Taskix marked ${input.prUrl} ready to merge without merging it.`,
+    labelsApplied: [...new Set([...input.architectDecision.labelsApplied, "taskix:ready-to-merge"])],
+    labelsRemoved: ["taskix:need-qa", "taskix:qa-running", "taskix:blocked"],
+    comments: input.architectDecision.comments
+  };
+}
+
+function uniqueNonEmpty(value: string, index: number, values: string[]): boolean {
+  return Boolean(value) && values.indexOf(value) === index;
+}

--- a/src/lib/issue-run-policy.ts
+++ b/src/lib/issue-run-policy.ts
@@ -46,6 +46,45 @@ export function manualDeployFinalLabelPlan(input: {
   };
 }
 
+export function manualDeployArchitectPolicyDecision(input: {
+  prUrl: string;
+  qaPassed: boolean;
+  prState?: string | null;
+  prMerged?: boolean;
+}): ArchitectPrReviewResult {
+  const state = input.prState?.toUpperCase() ?? "OPEN";
+  if (!input.qaPassed) {
+    return {
+      decision: "blocked",
+      summary: `Architect policy blocked ${input.prUrl}: QA has not passed.`,
+      labelsApplied: [],
+      comments: []
+    };
+  }
+  if (input.prMerged || state === "MERGED") {
+    return {
+      decision: "blocked",
+      summary: `Architect policy blocked ${input.prUrl}: PR is already merged.`,
+      labelsApplied: [],
+      comments: []
+    };
+  }
+  if (state !== "OPEN") {
+    return {
+      decision: "blocked",
+      summary: `Architect policy blocked ${input.prUrl}: PR state is ${state}.`,
+      labelsApplied: [],
+      comments: []
+    };
+  }
+  return {
+    decision: "ready_to_merge",
+    summary: `Architect policy approved ${input.prUrl} after QA passed; manual deployment keeps the PR open for human merge.`,
+    labelsApplied: [],
+    comments: []
+  };
+}
+
 function uniqueNonEmpty(value: string, index: number, values: string[]): boolean {
   return Boolean(value) && values.indexOf(value) === index;
 }

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -421,6 +421,14 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
         autoDeploy: project.autoDeploy,
         qaPassed: true
       });
+      if (!project.autoDeploy && architectReview.decision === "merged") {
+        architectReview = {
+          ...architectReview,
+          decision: "ready_to_merge",
+          summary: `${architectReview.summary}\n\nTaskix stopped before merge because automatic merge is not enabled for this project.`,
+          labelsApplied: [...new Set([...architectReview.labelsApplied.filter((label) => label !== "taskix:merged"), "taskix:ready-to-merge"])]
+        };
+      }
       if (workflow.projectId) {
         await appendAgentMessages({
           sessionKey: `${workflow.projectId}:architect`,

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -1,10 +1,14 @@
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
-import { addLabelsWithGh, createIssueWithGh, createPullRequestWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
+import { addLabelsWithGh, createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
+
+const execFileAsync = promisify(execFile);
 
 export async function createWorkflow(requirement: string, chatId: number, project?: ProjectRecord | null): Promise<WorkflowRecord> {
   const createdAt = new Date().toISOString();
@@ -284,12 +288,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     workflowId: displayWorkflowCode(workflow)
   });
   if (!developerResult.prUrl) {
-    const recoveryBranch = developerResult.branch || expectedDeveloperBranch(workflow, issue);
-    const recoveredPrUrl = await recoverDeveloperPullRequest(project.githubRepo, issue, workflow, recoveryBranch);
-    if (recoveredPrUrl) {
-      developerResult.prUrl = recoveredPrUrl;
-      developerResult.branch = recoveryBranch;
-      developerResult.summary = `${developerResult.summary}\n\nTaskix recovered the PR URL after developer publishing returned empty.`;
+    const recovery = await recoverDeveloperPullRequest(project.githubRepo, issue, workflow, developerResult.branch);
+    if (recovery) {
+      developerResult.prUrl = recovery.prUrl;
+      developerResult.branch = recovery.branch;
+      developerResult.summary = `${developerResult.summary}\n\nTaskix recovered existing PR context after developer publishing returned empty.\nRecovery source: ${recovery.source}.\nRecovered base: ${recovery.base ?? "repository default branch"}.`;
+      timeline.push(`Recovered existing PR context for issue ${issue.issueId} via ${recovery.source}; base ${recovery.base ?? "repository default branch"}.`);
     }
   }
   issue.prUrl = developerResult.prUrl || null;
@@ -479,29 +483,39 @@ function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" 
   return null;
 }
 
-async function recoverDeveloperPullRequest(repo: string, issue: IssueRecord, workflow: WorkflowRecord, branch: string): Promise<string | null> {
+async function recoverDeveloperPullRequest(
+  repo: string,
+  issue: IssueRecord,
+  workflow: WorkflowRecord,
+  branch: string
+): Promise<{ prUrl: string; branch: string; base: string | null; source: string } | null> {
   try {
-    const existingPrUrl = await findPullRequestByHeadWithGh(repo, branch);
-    if (existingPrUrl) return existingPrUrl;
-    const base = await runningWorkflowBaseBranch();
-    const labels = ["taskix:pr-opened", "taskix:architect-review", `role:${issue.developerRole ?? "general_developer"}`];
-    const body = [
-      `Closes #${issue.githubIssueNumber}`,
-      "",
-      `Recovered by Taskix after developer pushed branch ${branch} but did not return a PR URL.`,
-      `Base branch: ${base ?? "repository default branch"}.`,
-      "",
-      `Workflow: ${displayWorkflowCode(workflow)}`,
-      `Issue: ${issue.issueId}`
-    ].join("\n");
-    return await createPullRequestWithGh({
-      repo,
-      head: branch,
-      base,
-      title: issue.title,
-      body,
-      labels
-    });
+    const expectedBranch = expectedDeveloperBranch(workflow, issue);
+    const branchCandidates = [...new Set([branch, expectedBranch].map((value) => value.trim()).filter(Boolean))];
+
+    for (const candidateBranch of branchCandidates) {
+      const existingPrUrl = await findPullRequestByHeadWithGh(repo, candidateBranch);
+      if (!existingPrUrl) continue;
+      const details = await readPullRequestRefs(repo, existingPrUrl);
+      return {
+        prUrl: existingPrUrl,
+        branch: details.head ?? candidateBranch,
+        base: details.base,
+        source: candidateBranch === branch ? "developer branch lookup" : "expected workflow branch lookup"
+      };
+    }
+
+    if (!issue.githubIssueNumber) return null;
+    const snapshot = await getIssueSnapshotWithGh(repo, issue.githubIssueNumber);
+    const linkedPr = choosePrimaryPr(snapshot.linkedPrs);
+    if (!linkedPr) return null;
+    const details = await readPullRequestRefs(repo, linkedPr.url);
+    return {
+      prUrl: linkedPr.url,
+      branch: details.head ?? expectedBranch,
+      base: details.base,
+      source: "linked issue pull request lookup"
+    };
   } catch {
     return null;
   }
@@ -511,15 +525,16 @@ function expectedDeveloperBranch(workflow: WorkflowRecord, issue: IssueRecord): 
   return `taskix/${displayWorkflowCode(workflow)}-issue-${issue.githubIssueNumber ?? issue.issueId}`;
 }
 
-async function runningWorkflowBaseBranch(): Promise<string | null> {
+async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: string | null; base: string | null }> {
   try {
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const execFileAsync = promisify(execFile);
-    const { stdout } = await execFileAsync("git", ["branch", "--show-current"]);
-    return stdout.trim() || null;
+    const { stdout } = await execFileAsync("gh", ["pr", "view", pr, "--repo", repo, "--json", "headRefName,baseRefName"]);
+    const payload = JSON.parse(stdout) as { headRefName?: string; baseRefName?: string };
+    return {
+      head: payload.headRefName?.trim() || null,
+      base: payload.baseRefName?.trim() || null
+    };
   } catch {
-    return null;
+    return { head: null, base: null };
   }
 }
 

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -283,10 +283,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     issue,
     workflowId: displayWorkflowCode(workflow)
   });
-  if (!developerResult.prUrl && developerResult.branch) {
-    const recoveredPrUrl = await recoverDeveloperPullRequest(project.githubRepo, issue, workflow, developerResult.branch);
+  if (!developerResult.prUrl) {
+    const recoveryBranch = developerResult.branch || expectedDeveloperBranch(workflow, issue);
+    const recoveredPrUrl = await recoverDeveloperPullRequest(project.githubRepo, issue, workflow, recoveryBranch);
     if (recoveredPrUrl) {
       developerResult.prUrl = recoveredPrUrl;
+      developerResult.branch = recoveryBranch;
       developerResult.summary = `${developerResult.summary}\n\nTaskix recovered the PR URL after developer publishing returned empty.`;
     }
   }
@@ -481,12 +483,13 @@ async function recoverDeveloperPullRequest(repo: string, issue: IssueRecord, wor
   try {
     const existingPrUrl = await findPullRequestByHeadWithGh(repo, branch);
     if (existingPrUrl) return existingPrUrl;
-    const base = await currentBranch();
+    const base = await runningWorkflowBaseBranch();
     const labels = ["taskix:pr-opened", "taskix:architect-review", `role:${issue.developerRole ?? "general_developer"}`];
     const body = [
       `Closes #${issue.githubIssueNumber}`,
       "",
       `Recovered by Taskix after developer pushed branch ${branch} but did not return a PR URL.`,
+      `Base branch: ${base ?? "repository default branch"}.`,
       "",
       `Workflow: ${displayWorkflowCode(workflow)}`,
       `Issue: ${issue.issueId}`
@@ -504,7 +507,11 @@ async function recoverDeveloperPullRequest(repo: string, issue: IssueRecord, wor
   }
 }
 
-async function currentBranch(): Promise<string | null> {
+function expectedDeveloperBranch(workflow: WorkflowRecord, issue: IssueRecord): string {
+  return `taskix/${displayWorkflowCode(workflow)}-issue-${issue.githubIssueNumber ?? issue.issueId}`;
+}
+
+async function runningWorkflowBaseBranch(): Promise<string | null> {
   try {
     const { execFile } = await import("node:child_process");
     const { promisify } = await import("node:util");

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
 import { addLabelsWithGh, createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
+import { expectedDeveloperBranch, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -490,8 +491,11 @@ async function recoverDeveloperPullRequest(
   branch: string
 ): Promise<{ prUrl: string; branch: string; base: string | null; source: string } | null> {
   try {
-    const expectedBranch = expectedDeveloperBranch(workflow, issue);
-    const branchCandidates = [...new Set([branch, expectedBranch].map((value) => value.trim()).filter(Boolean))];
+    const branchCandidates = prRecoveryBranches({
+      developerBranch: branch,
+      workflowCode: displayWorkflowCode(workflow),
+      issueNumberOrId: issue.githubIssueNumber ?? issue.issueId
+    });
 
     for (const candidateBranch of branchCandidates) {
       const existingPrUrl = await findPullRequestByHeadWithGh(repo, candidateBranch);
@@ -501,7 +505,7 @@ async function recoverDeveloperPullRequest(
         prUrl: existingPrUrl,
         branch: details.head ?? candidateBranch,
         base: details.base,
-        source: candidateBranch === branch ? "developer branch lookup" : "expected workflow branch lookup"
+        source: branch && candidateBranch === branch ? "developer branch lookup" : "expected workflow branch lookup"
       };
     }
 
@@ -512,17 +516,13 @@ async function recoverDeveloperPullRequest(
     const details = await readPullRequestRefs(repo, linkedPr.url);
     return {
       prUrl: linkedPr.url,
-      branch: details.head ?? expectedBranch,
+      branch: details.head ?? expectedDeveloperBranch(displayWorkflowCode(workflow), issue.githubIssueNumber ?? issue.issueId),
       base: details.base,
       source: "linked issue pull request lookup"
     };
   } catch {
     return null;
   }
-}
-
-function expectedDeveloperBranch(workflow: WorkflowRecord, issue: IssueRecord): string {
-  return `taskix/${displayWorkflowCode(workflow)}-issue-${issue.githubIssueNumber ?? issue.issueId}`;
 }
 
 async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: string | null; base: string | null }> {
@@ -582,34 +582,34 @@ async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, 
       issueNumber: issue.githubIssueNumber,
       prUrl
     });
-    if (architectDecision.decision !== "ready_to_merge") {
-      const addLabels = ["taskix:blocked"];
-      const removeLabels = ["taskix:qa-running", "taskix:ready-to-merge"];
+    const labelPlan = manualDeployFinalLabelPlan({ prUrl, architectDecision });
+    if (labelPlan.decision !== "ready_to_merge") {
       await Promise.all([
-        addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
-        addLabelsWithGh(project.githubRepo, prUrl, addLabels),
-        removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
-        removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
+        addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsApplied),
+        addLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsApplied),
+        removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsRemoved),
+        removeLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsRemoved)
       ]);
       return {
         ...architectDecision,
-        labelsApplied: [...new Set([...architectDecision.labelsApplied, ...addLabels])]
+        decision: labelPlan.decision,
+        summary: labelPlan.summary,
+        labelsApplied: labelPlan.labelsApplied,
+        comments: labelPlan.comments
       };
     }
 
-    const addLabels = ["taskix:ready-to-merge"];
-    const removeLabels = ["taskix:need-qa", "taskix:qa-running", "taskix:blocked"];
     await Promise.all([
-      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
-      addLabelsWithGh(project.githubRepo, prUrl, addLabels),
-      removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
-      removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
+      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsApplied),
+      addLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsApplied),
+      removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsRemoved),
+      removeLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsRemoved)
     ]);
     return {
       decision: "ready_to_merge" as const,
-      summary: `${architectDecision.summary}\n\nManual-deploy project: architect approved merge readiness after QA; Taskix marked ${prUrl} ready to merge without merging it.`,
-      labelsApplied: [...new Set([...architectDecision.labelsApplied, ...addLabels])],
-      comments: architectDecision.comments
+      summary: labelPlan.summary,
+      labelsApplied: labelPlan.labelsApplied,
+      comments: labelPlan.comments
     };
   }
 

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
 import { addLabelsWithGh, createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
-import { expectedDeveloperBranch, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
+import { expectedDeveloperBranch, manualDeployArchitectPolicyDecision, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -525,16 +525,18 @@ async function recoverDeveloperPullRequest(
   }
 }
 
-async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: string | null; base: string | null }> {
+async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: string | null; base: string | null; state: string | null; merged: boolean }> {
   try {
-    const { stdout } = await execFileAsync("gh", ["pr", "view", pr, "--repo", repo, "--json", "headRefName,baseRefName"]);
-    const payload = JSON.parse(stdout) as { headRefName?: string; baseRefName?: string };
+    const { stdout } = await execFileAsync("gh", ["pr", "view", pr, "--repo", repo, "--json", "headRefName,baseRefName,state,mergedAt"]);
+    const payload = JSON.parse(stdout) as { headRefName?: string; baseRefName?: string; state?: string; mergedAt?: string | null };
     return {
       head: payload.headRefName?.trim() || null,
-      base: payload.baseRefName?.trim() || null
+      base: payload.baseRefName?.trim() || null,
+      state: payload.state?.trim() || null,
+      merged: Boolean(payload.mergedAt)
     };
   } catch {
-    return { head: null, base: null };
+    return { head: null, base: null, state: null, merged: false };
   }
 }
 
@@ -577,10 +579,12 @@ async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord
 
 async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
   if (!project.autoDeploy && issue.githubIssueNumber) {
-    const architectDecision = await codex.architectConfirmManualReady({
-      repo: project.githubRepo,
-      issueNumber: issue.githubIssueNumber,
-      prUrl
+    const prRefs = await readPullRequestRefs(project.githubRepo, prUrl);
+    const architectDecision = manualDeployArchitectPolicyDecision({
+      prUrl,
+      qaPassed: true,
+      prState: prRefs.state,
+      prMerged: prRefs.merged
     });
     const labelPlan = manualDeployFinalLabelPlan({ prUrl, architectDecision });
     if (labelPlan.decision !== "ready_to_merge") {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -577,8 +577,28 @@ async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord
 
 async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
   if (!project.autoDeploy && issue.githubIssueNumber) {
+    const architectDecision = await codex.architectConfirmManualReady({
+      repo: project.githubRepo,
+      issueNumber: issue.githubIssueNumber,
+      prUrl
+    });
+    if (architectDecision.decision !== "ready_to_merge") {
+      const addLabels = ["taskix:blocked"];
+      const removeLabels = ["taskix:qa-running", "taskix:ready-to-merge"];
+      await Promise.all([
+        addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
+        addLabelsWithGh(project.githubRepo, prUrl, addLabels),
+        removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
+        removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
+      ]);
+      return {
+        ...architectDecision,
+        labelsApplied: [...new Set([...architectDecision.labelsApplied, ...addLabels])]
+      };
+    }
+
     const addLabels = ["taskix:ready-to-merge"];
-    const removeLabels = ["taskix:need-qa", "taskix:qa-running"];
+    const removeLabels = ["taskix:need-qa", "taskix:qa-running", "taskix:blocked"];
     await Promise.all([
       addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
       addLabelsWithGh(project.githubRepo, prUrl, addLabels),
@@ -587,9 +607,9 @@ async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, 
     ]);
     return {
       decision: "ready_to_merge" as const,
-      summary: `Manual-deploy project: QA passed and Taskix marked ${prUrl} ready to merge without merging it.`,
-      labelsApplied: addLabels,
-      comments: []
+      summary: `${architectDecision.summary}\n\nManual-deploy project: architect approved merge readiness after QA; Taskix marked ${prUrl} ready to merge without merging it.`,
+      labelsApplied: [...new Set([...architectDecision.labelsApplied, ...addLabels])],
+      comments: architectDecision.comments
     };
   }
 

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
-import { addLabelsWithGh, createIssueWithGh, getIssueSnapshotWithGh } from "@/lib/github-local";
+import { addLabelsWithGh, createIssueWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -331,25 +331,7 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     };
   }
 
-  let architectReview = await codex.architectReviewPr({
-    repo: project.githubRepo,
-    issueNumber: issue.githubIssueNumber,
-    prUrl: developerResult.prUrl,
-    autoDeploy: project.autoDeploy
-  });
-  if (isIncompleteArchitectReview(architectReview)) {
-    const labels = ["taskix:need-qa"];
-    await Promise.all([
-      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
-      addLabelsWithGh(project.githubRepo, developerResult.prUrl, labels)
-    ]);
-    architectReview = {
-      decision: "need_qa",
-      summary: `Architect runner did not complete structured PR review. Taskix conservatively requested QA for ${developerResult.prUrl}.`,
-      labelsApplied: labels,
-      comments: []
-    };
-  }
+  let architectReview = await requestInitialPrReview(project, issue, developerResult.prUrl, codex);
   if (workflow.projectId) {
     await appendAgentMessages({
       sessionKey: `${workflow.projectId}:architect`,
@@ -427,21 +409,7 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
   }
     if (qaResult.passed) {
       timeline.push(`QA passed PR for issue ${issue.issueId}.`);
-      architectReview = await codex.architectReviewPr({
-        repo: project.githubRepo,
-        issueNumber: issue.githubIssueNumber,
-        prUrl: developerResult.prUrl,
-        autoDeploy: project.autoDeploy,
-        qaPassed: true
-      });
-      if (!project.autoDeploy && architectReview.decision === "merged") {
-        architectReview = {
-          ...architectReview,
-          decision: "ready_to_merge",
-          summary: `${architectReview.summary}\n\nTaskix stopped before merge because automatic merge is not enabled for this project.`,
-          labelsApplied: [...new Set([...architectReview.labelsApplied.filter((label) => label !== "taskix:merged"), "taskix:ready-to-merge"])]
-        };
-      }
+      architectReview = await requestFinalPrReview(project, issue, developerResult.prUrl, codex);
       if (workflow.projectId) {
         await appendAgentMessages({
           sessionKey: `${workflow.projectId}:architect`,
@@ -502,8 +470,68 @@ function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" 
   return null;
 }
 
-function isIncompleteArchitectReview(review: { decision: string; summary: string; labelsApplied: string[] }): boolean {
-  return review.decision === "blocked" && !review.labelsApplied.length && review.summary.includes("Architect runner did not complete PR review");
+async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
+  if (!project.autoDeploy && issue.githubIssueNumber) {
+    const labels = ["taskix:need-qa"];
+    await Promise.all([
+      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
+      addLabelsWithGh(project.githubRepo, prUrl, labels)
+    ]);
+    return {
+      decision: "need_qa" as const,
+      summary: `Manual-deploy project: Taskix requested QA for ${prUrl} and stopped before merge review.`,
+      labelsApplied: labels,
+      comments: []
+    };
+  }
+
+  const review = await codex.architectReviewPr({
+    repo: project.githubRepo,
+    issueNumber: issue.githubIssueNumber ?? 0,
+    prUrl,
+    autoDeploy: project.autoDeploy
+  });
+  if (review.decision === "blocked" && !review.labelsApplied.length && review.summary.includes("Architect runner did not complete PR review") && issue.githubIssueNumber) {
+    const labels = ["taskix:need-qa"];
+    await Promise.all([
+      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
+      addLabelsWithGh(project.githubRepo, prUrl, labels)
+    ]);
+    return {
+      decision: "need_qa" as const,
+      summary: `Architect runner did not complete structured PR review. Taskix conservatively requested QA for ${prUrl}.`,
+      labelsApplied: labels,
+      comments: []
+    };
+  }
+  return review;
+}
+
+async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
+  if (!project.autoDeploy && issue.githubIssueNumber) {
+    const addLabels = ["taskix:ready-to-merge"];
+    const removeLabels = ["taskix:need-qa", "taskix:qa-running"];
+    await Promise.all([
+      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
+      addLabelsWithGh(project.githubRepo, prUrl, addLabels),
+      removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
+      removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
+    ]);
+    return {
+      decision: "ready_to_merge" as const,
+      summary: `Manual-deploy project: QA passed and Taskix marked ${prUrl} ready to merge without merging it.`,
+      labelsApplied: addLabels,
+      comments: []
+    };
+  }
+
+  return codex.architectReviewPr({
+    repo: project.githubRepo,
+    issueNumber: issue.githubIssueNumber ?? 0,
+    prUrl,
+    autoDeploy: project.autoDeploy,
+    qaPassed: true
+  });
 }
 
 function deriveWorkflowStatus(workflow: WorkflowRecord): WorkflowRecord["status"] {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
-import { createIssueWithGh, getIssueSnapshotWithGh } from "@/lib/github-local";
+import { addLabelsWithGh, createIssueWithGh, getIssueSnapshotWithGh } from "@/lib/github-local";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -337,6 +337,19 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     prUrl: developerResult.prUrl,
     autoDeploy: project.autoDeploy
   });
+  if (isIncompleteArchitectReview(architectReview)) {
+    const labels = ["taskix:need-qa"];
+    await Promise.all([
+      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
+      addLabelsWithGh(project.githubRepo, developerResult.prUrl, labels)
+    ]);
+    architectReview = {
+      decision: "need_qa",
+      summary: `Architect runner did not complete structured PR review. Taskix conservatively requested QA for ${developerResult.prUrl}.`,
+      labelsApplied: labels,
+      comments: []
+    };
+  }
   if (workflow.projectId) {
     await appendAgentMessages({
       sessionKey: `${workflow.projectId}:architect`,
@@ -487,6 +500,10 @@ function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" 
   if (labels.includes("taskix:qa-failed")) return "blocked";
   if (labels.includes("taskix:need-qa") || labels.includes("taskix:qa-running")) return "active";
   return null;
+}
+
+function isIncompleteArchitectReview(review: { decision: string; summary: string; labelsApplied: string[] }): boolean {
+  return review.decision === "blocked" && !review.labelsApplied.length && review.summary.includes("Architect runner did not complete PR review");
 }
 
 function deriveWorkflowStatus(workflow: WorkflowRecord): WorkflowRecord["status"] {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
-import { addLabelsWithGh, createIssueWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
+import { addLabelsWithGh, createIssueWithGh, createPullRequestWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -283,6 +283,13 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     issue,
     workflowId: displayWorkflowCode(workflow)
   });
+  if (!developerResult.prUrl && developerResult.branch) {
+    const recoveredPrUrl = await recoverDeveloperPullRequest(project.githubRepo, issue, workflow, developerResult.branch);
+    if (recoveredPrUrl) {
+      developerResult.prUrl = recoveredPrUrl;
+      developerResult.summary = `${developerResult.summary}\n\nTaskix recovered the PR URL after developer publishing returned empty.`;
+    }
+  }
   issue.prUrl = developerResult.prUrl || null;
   issue.branch = developerResult.branch || null;
   if (workflow.projectId) {
@@ -468,6 +475,45 @@ function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" 
   if (labels.includes("taskix:qa-failed")) return "blocked";
   if (labels.includes("taskix:need-qa") || labels.includes("taskix:qa-running")) return "active";
   return null;
+}
+
+async function recoverDeveloperPullRequest(repo: string, issue: IssueRecord, workflow: WorkflowRecord, branch: string): Promise<string | null> {
+  try {
+    const existingPrUrl = await findPullRequestByHeadWithGh(repo, branch);
+    if (existingPrUrl) return existingPrUrl;
+    const base = await currentBranch();
+    const labels = ["taskix:pr-opened", "taskix:architect-review", `role:${issue.developerRole ?? "general_developer"}`];
+    const body = [
+      `Closes #${issue.githubIssueNumber}`,
+      "",
+      `Recovered by Taskix after developer pushed branch ${branch} but did not return a PR URL.`,
+      "",
+      `Workflow: ${displayWorkflowCode(workflow)}`,
+      `Issue: ${issue.issueId}`
+    ].join("\n");
+    return await createPullRequestWithGh({
+      repo,
+      head: branch,
+      base,
+      title: issue.title,
+      body,
+      labels
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function currentBranch(): Promise<string | null> {
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync("git", ["branch", "--show-current"]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {


### PR DESCRIPTION
## Summary
- Updates architect PR review instructions to stop at `ready_to_merge` after QA passes.
- Adds an orchestrator guard that downgrades accidental `merged` decisions to `ready_to_merge` when automatic merge/deploy is not enabled.
- Keeps developer and QA execution unchanged.

## Linked Issue
Closes #36

## Verification
- `npm run typecheck`
- `npm run build`

## QA
QA should rerun #34 on this branch/latest PR and confirm one issue_run reaches ready-to-merge with the generated PR still open and no auto-merge.