### PR TITLE
Document safe main-flow smoke recheck plan

### DIFF
--- a/docs/issue-15-safe-main-flow-smoke-plan.md
+++ b/docs/issue-15-safe-main-flow-smoke-plan.md
@@ -1,0 +1,30 @@
+# Issue 15 Safe Main-Flow Smoke Recheck Plan
+
+This note is a planning-only reference for a safe main-flow smoke recheck. It keeps developers and QA aligned on what is in scope for this work and what is explicitly deferred.
+
+## Goal
+
+- Define a minimal, safe plan for rechecking the main flow.
+- Keep this issue documentation-only.
+- Preserve a clear handoff note for later manual execution.
+
+## Scope
+
+- Document the intended smoke recheck at a high level.
+- Record that the work stops after planning is written down.
+- Provide one shared reference for future developer and QA execution.
+
+## Non-Goals
+
+- No deployment work.
+- No application code or infrastructure changes.
+- No immediate execution of queued jobs.
+- No automatic triggering of smoke validation from this issue.
+
+## Deferred Execution
+
+Any `issue_run` jobs related to this smoke recheck are queued for later manual `Run Jobs` execution. They are not run as part of Issue 33 or workflow `WF-20260430-004`.
+
+## Stop Point
+
+Implementation ends when this planning note is present in the repository. Follow-up execution, validation, and reporting happen in later manually started work.


### PR DESCRIPTION
## Summary
- add a planning-only note for the safe main-flow smoke recheck
- define scope, non-goals, deferred execution, and the execution stop point
- state that issue_run jobs are queued for later manual Run Jobs execution

Closes #33

## Verification
- Not run (documentation-only change)