### PR TITLE
Stop manual-deploy architect flow at ready_to_merge

### DIFF
--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -341,8 +341,8 @@ Required GitHub label behavior:
 - Read the linked issue and PR with gh.
 - If QA is required before merge, add taskix:need-qa to the PR and issue, then return decision "need_qa".
 - If changes are required from developer, comment on the PR, add taskix:blocked, and return decision "changes_requested".
-- If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge.
-- Merge only when it is safe. If merged, add taskix:merged. If auto deploy is enabled and deployment succeeds, add taskix:deployed.
+- If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge and return decision "ready_to_merge".
+- Do not merge PRs in normal Taskix validation runs. Only return decision "merged" if an explicit merge-validation instruction is present outside this prompt. Auto deploy does not authorize merge by itself.
 
 Return JSON with decision, summary, labelsApplied, comments.`;
     return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -124,7 +124,7 @@ export async function runWorkflowIssue(workflowId: string, issueId: string, proj
 
   const result = await runIssue(issue, workflow, codex, createIssueCreator(project, settings), project);
   workflow.timeline.push(...result.timeline);
-  workflow.status = deriveWorkflowStatus(workflow);
+  workflow.status = deriveWorkflowStatus(workflow, project?.autoDeploy);
   if (result.blocked) workflow.status = "blocked";
   await saveWorkflow(workflow);
   if (project) await saveProject(project);
@@ -204,7 +204,7 @@ export async function syncWorkflowFromGitHub(workflowId: string, project?: Proje
     }
   }
 
-  workflow.status = deriveWorkflowStatus(workflow);
+  workflow.status = deriveWorkflowStatus(workflow, project?.autoDeploy);
   const after = JSON.stringify(workflow.issues.map((issue) => ({
     issueId: issue.issueId,
     labels: issue.labels,
@@ -421,6 +421,14 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
         autoDeploy: project.autoDeploy,
         qaPassed: true
       });
+      if (!project.autoDeploy && architectReview.decision === "merged") {
+        architectReview = {
+          ...architectReview,
+          decision: "ready_to_merge",
+          summary: `${architectReview.summary}\n\nTaskix stopped before merge because automatic merge is not enabled for this project.`,
+          labelsApplied: [...new Set([...architectReview.labelsApplied.filter((label) => label !== "taskix:merged"), "taskix:ready-to-merge"])]
+        };
+      }
       if (workflow.projectId) {
         await appendAgentMessages({
           sessionKey: `${workflow.projectId}:architect`,
@@ -481,14 +489,18 @@ function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" 
   return null;
 }
 
-function deriveWorkflowStatus(workflow: WorkflowRecord): WorkflowRecord["status"] {
+function deriveWorkflowStatus(workflow: WorkflowRecord, autoDeploy?: boolean): WorkflowRecord["status"] {
   if (!workflow.issues.length) return workflow.status;
   const issues = workflow.issues;
   const hasBlocked = issues.some((issue) => includesAny([...(issue.labels ?? []), ...(issue.prLabels ?? [])], ["taskix:blocked", "taskix:qa-failed"]));
   if (hasBlocked) return "blocked";
-  const allDone = issues.every((issue) => includesAny([...(issue.labels ?? []), ...(issue.prLabels ?? [])], ["taskix:merged", "taskix:deployed"]) || issue.prState === "MERGED");
+  const doneLabels = autoDeploy === false ? ["taskix:merged", "taskix:deployed", "taskix:ready-to-merge"] : ["taskix:merged", "taskix:deployed"];
+  const allDone = issues.every((issue) => includesAny([...(issue.labels ?? []), ...(issue.prLabels ?? [])], doneLabels) || issue.prState === "MERGED");
   if (allDone) return "done";
-  const anyProgress = issues.some((issue) => includesAny([...(issue.labels ?? []), ...(issue.prLabels ?? [])], ["taskix:dev-running", "taskix:pr-opened", "taskix:architect-review", "taskix:need-qa", "taskix:qa-running", "taskix:qa-passed", "taskix:ready-to-merge"]));
+  const progressLabels = autoDeploy === false
+    ? ["taskix:dev-running", "taskix:pr-opened", "taskix:architect-review", "taskix:need-qa", "taskix:qa-running", "taskix:qa-passed"]
+    : ["taskix:dev-running", "taskix:pr-opened", "taskix:architect-review", "taskix:need-qa", "taskix:qa-running", "taskix:qa-passed", "taskix:ready-to-merge"];
+  const anyProgress = issues.some((issue) => includesAny([...(issue.labels ?? []), ...(issue.prLabels ?? [])], progressLabels));
   return anyProgress ? "in_progress" : workflow.status;
 }
 


### PR DESCRIPTION
## Summary
- prevent normal architect validation runs from auto-merging PRs
- rewrite manual-deploy post-QA architect results from merged to ready_to_merge
- treat taskix:ready-to-merge as the terminal workflow state for manual-deploy projects

## Verification
- npm run typecheck
- npm run build (currently fails on existing Next.js prerender issue for /_global-error)

Fixes #44