### PR TITLE
Enforce manual-deploy QA evidence gating

### DIFF
--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -325,7 +325,12 @@ Execution rules:
 - Run git fetch, checkout, commit, push, and gh pr create only in the current working directory.
 - Work only inside ownedPaths unless the issue explicitly requires an integration point.
 - Create a branch named taskix/${input.workflowId}-issue-${input.issueNumber} or a similarly unique branch.
-- If this work validates Taskix recovery/ready-to-merge behavior, document observable verification evidence in the PR body, including deterministic recovery, recovered base visibility, ready-to-merge expectations, and no generated PR merge.
+- If this work validates Taskix recovery/ready-to-merge behavior, the PR body must include a "## Manual-Deploy QA Evidence" section with these exact bullets:
+  - "- Deterministic recovery:" explain how recovery is deterministic in this change.
+  - "- Recovery source:" identify the recovery source or state "not needed".
+  - "- Recovered base:" identify the recovered base branch or state "not needed".
+  - "- Ready-to-merge expectation:" state that the final manual-deploy state should stop at "taskix:ready-to-merge".
+  - "- Generated PR merge:" state that no generated PR is merged in this flow.
 - Implement the issue, run relevant tests, commit, push, and open a PR.
 - If implementation is blocked, comment on the issue, add taskix:blocked, and still return JSON with prUrl as an empty string.
 
@@ -365,6 +370,7 @@ Required GitHub label behavior:
 - Read the linked issue and PR with gh.
 - If QA is required before merge, add taskix:need-qa to the PR and issue, then return decision "need_qa".
 - If changes are required from developer, comment on the PR, add taskix:blocked, and return decision "changes_requested".
+- Before returning "ready_to_merge" or "merged" after QA, verify the PR contains a QA passing evidence comment that records commands run and the observable label/state.
 - If QA is already passed or QA is not needed and the PR is acceptable, add taskix:ready-to-merge and return decision "ready_to_merge".
 - If auto deploy is disabled, do not merge the PR; stop at taskix:ready-to-merge.
 - If auto deploy is enabled and QA has passed, you may merge only when repository checks and branch state are safe.
@@ -400,7 +406,14 @@ Required GitHub label behavior:
 - Add taskix:qa-running to the issue and PR when you start.
 - Read the issue acceptance criteria and PR diff using gh.
 - Validate implementation, ownedPaths, and relevant tests.
-- When passing QA, comment concise verification evidence on the PR, including commands run and any observable labels/state required by acceptance criteria.
+- When passing QA, comment on the PR with a "## QA Passing Evidence" heading and these exact bullets:
+  - "- Commands run:" list the validation commands.
+  - "- PR body evidence visible:" confirm whether the required manual-deploy evidence section is visible.
+  - "- Recovery source visible:" record the observed recovery source or "not needed".
+  - "- Recovered base visible:" record the observed recovered base or "not needed".
+  - "- Ready-to-merge expectation confirmed:" confirm the flow should stop at "taskix:ready-to-merge".
+  - "- Generated PR still open:" record "yes" or "no".
+  - "- Generated PR merged:" record "no" when passing this manual-deploy flow.
 - If passed, add taskix:qa-passed and remove taskix:qa-running.
 - If failed, comment findings on the PR, add taskix:qa-failed, and remove taskix:qa-running.
 

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -538,6 +538,57 @@ async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: st
   }
 }
 
+type PullRequestEvidence = {
+  body: string;
+  comments: string[];
+};
+
+async function readPullRequestEvidence(repo: string, pr: string): Promise<PullRequestEvidence> {
+  try {
+    const { stdout } = await execFileAsync("gh", ["pr", "view", pr, "--repo", repo, "--json", "body,comments"]);
+    const payload = JSON.parse(stdout) as { body?: string; comments?: Array<{ body?: string }> };
+    return {
+      body: payload.body ?? "",
+      comments: (payload.comments ?? []).map((comment) => comment.body ?? "")
+    };
+  } catch {
+    return { body: "", comments: [] };
+  }
+}
+
+function normalizeEvidenceText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function missingManualDeployBodyEvidence(body: string): string[] {
+  const required = [
+    "## Manual-Deploy QA Evidence",
+    "- Deterministic recovery:",
+    "- Recovery source:",
+    "- Recovered base:",
+    "- Ready-to-merge expectation:",
+    "- Generated PR merge:"
+  ];
+  const normalized = normalizeEvidenceText(body);
+  return required.filter((marker) => !normalized.includes(marker.toLowerCase()));
+}
+
+function hasPassingQaEvidenceComment(comments: string[]): boolean {
+  return comments.some((comment) => {
+    const normalized = normalizeEvidenceText(comment);
+    return [
+      "## qa passing evidence",
+      "- commands run:",
+      "- pr body evidence visible:",
+      "- recovery source visible:",
+      "- recovered base visible:",
+      "- ready-to-merge expectation confirmed:",
+      "- generated pr still open:",
+      "- generated pr merged: no"
+    ].every((marker) => normalized.includes(marker));
+  });
+}
+
 async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
   if (!project.autoDeploy && issue.githubIssueNumber) {
     const labels = ["taskix:need-qa"];
@@ -577,8 +628,32 @@ async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord
 
 async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
   if (!project.autoDeploy && issue.githubIssueNumber) {
+    const evidence = await readPullRequestEvidence(project.githubRepo, prUrl);
+    const missingBodyEvidence = missingManualDeployBodyEvidence(evidence.body);
+    const hasQaEvidenceComment = hasPassingQaEvidenceComment(evidence.comments);
+    if (missingBodyEvidence.length || !hasQaEvidenceComment) {
+      const addLabels = ["taskix:blocked", "taskix:need-qa"];
+      const removeLabels = ["taskix:qa-running", "taskix:qa-passed", "taskix:ready-to-merge"];
+      const missingEvidence = [
+        ...(missingBodyEvidence.length ? [`PR body missing: ${missingBodyEvidence.join(", ")}`] : []),
+        ...(!hasQaEvidenceComment ? ["PR comment missing required `## QA Passing Evidence` markers."] : [])
+      ].join(" ");
+      await Promise.all([
+        addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
+        addLabelsWithGh(project.githubRepo, prUrl, addLabels),
+        removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
+        removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
+      ]);
+      return {
+        decision: "blocked" as const,
+        summary: `Manual-deploy project: QA evidence for ${prUrl} is incomplete, so Taskix did not emit ready-to-merge. ${missingEvidence}`.trim(),
+        labelsApplied: addLabels,
+        comments: []
+      };
+    }
+
     const addLabels = ["taskix:ready-to-merge"];
-    const removeLabels = ["taskix:need-qa", "taskix:qa-running"];
+    const removeLabels = ["taskix:need-qa", "taskix:qa-running", "taskix:blocked"];
     await Promise.all([
       addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addLabels),
       addLabelsWithGh(project.githubRepo, prUrl, addLabels),


### PR DESCRIPTION
## Summary
- require generated developer PR bodies to include a stable `## Manual-Deploy QA Evidence` section for the Issue 36 / PR 37 recheck flow
- require generated QA passes to leave a stable `## QA Passing Evidence` PR comment with commands and observed state
- block the manual-deploy final review from applying `taskix:ready-to-merge` unless both evidence surfaces are present, and keep generated PRs unmerged

## Linked Issue
Closes #56

## Verification
- `npm run typecheck`
- `npm run build` *(fails on the base branch with Next.js prerendering `/_global-error`: `Cannot read properties of null (reading 'useContext')` during static page generation)*

## Manual-Deploy Evidence
- Deterministic recovery: the final manual-deploy gate now checks explicit PR-body and QA-comment markers instead of relying on implicit QA pass state alone.
- Recovered base visibility: generated PR bodies are now instructed to expose the recovered base in a stable evidence section, and the gate refuses `taskix:ready-to-merge` if that section is missing.
- Ready-to-merge expectation: manual-deploy flows only emit `taskix:ready-to-merge` after the PR body and QA passing evidence comment are both visible on the PR.
- No generated PR merge: the manual-deploy path still stops before merge and now blocks instead of silently advancing when evidence is incomplete.
