### PR TITLE
Enforce architect-gated manual deploy readiness

### DIFF
--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -403,6 +403,8 @@ Rules:
 - Decide whether the PR is ready to merge, needs changes, or is blocked.
 - Do not merge the PR.
 - Do not add or remove GitHub labels; Taskix will apply labels after your structured decision.
+- Treat "ready_to_merge" as the architect's explicit final approval after QA for a manual-deploy project.
+- Preserve QA-visible evidence in your reasoning; do not rely on or recreate an earlier ready-to-merge state.
 - Return "ready_to_merge" only when QA has passed and the PR satisfies the issue acceptance criteria.
 - Return "changes_requested" if implementation changes are required.
 - Return "blocked" if readiness cannot be determined from available GitHub state.

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -541,13 +541,16 @@ async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: st
 async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
   if (!project.autoDeploy && issue.githubIssueNumber) {
     const labels = ["taskix:need-qa"];
+    const removeLabels = ["taskix:ready-to-merge", "taskix:blocked"];
     await Promise.all([
       addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
-      addLabelsWithGh(project.githubRepo, prUrl, labels)
+      addLabelsWithGh(project.githubRepo, prUrl, labels),
+      removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, removeLabels),
+      removeLabelsWithGh(project.githubRepo, prUrl, removeLabels)
     ]);
     return {
       decision: "need_qa" as const,
-      summary: `Manual-deploy project: Taskix requested QA for ${prUrl} and stopped before merge review.`,
+      summary: `Manual-deploy project: Taskix requested QA for ${prUrl}, cleared any stale ready-to-merge state, and deferred final merge-readiness approval until the architect reviews the QA result.`,
       labelsApplied: labels,
       comments: []
     };
@@ -607,7 +610,7 @@ async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, 
     ]);
     return {
       decision: "ready_to_merge" as const,
-      summary: `${architectDecision.summary}\n\nManual-deploy project: architect approved merge readiness after QA; Taskix marked ${prUrl} ready to merge without merging it.`,
+      summary: `${architectDecision.summary}\n\nManual-deploy project: architect explicitly approved merge readiness after QA; Taskix preserved QA-visible evidence, marked ${prUrl} ready to merge, and did not merge the PR.`,
       labelsApplied: [...new Set([...architectDecision.labelsApplied, ...addLabels])],
       comments: architectDecision.comments
     };


### PR DESCRIPTION
## Summary
- clear stale `taskix:ready-to-merge` and `taskix:blocked` labels when a manual-deploy PR is handed to QA
- keep final ready-to-merge assignment gated on the architect's explicit post-QA review
- clarify the architect manual-ready prompt so QA-visible evidence remains part of the decision and no earlier ready state is reused

## Linked Issue
Closes #58

## Verification
- `npm run typecheck`
- `npm run build` *(currently fails in the existing branch with an unrelated Next.js prerender error on `/_global-error`)*

## Recheck Evidence
- Deterministic recovery: manual-deploy rechecks now clear stale `taskix:ready-to-merge` before QA, so a recovered PR cannot appear merge-ready before the architect's final review.
- Recovered base visibility: the existing recovery summary/base reporting in the developer flow is unchanged by this patch.
- Ready-to-merge expectations: `taskix:ready-to-merge` is only applied from the post-QA architect approval path, and the summary now states that approval explicitly.
- No generated PR merge: the manual-deploy final review path still stops at label updates and explicitly states that Taskix did not merge the PR.