### PR TITLE
Enforce deterministic ready-to-merge policy for merged PRs

### DIFF
--- a/scripts/issue-run-policy.test.mjs
+++ b/scripts/issue-run-policy.test.mjs
@@ -61,7 +61,17 @@ const mergedBlocked = manualDeployArchitectPolicyDecision({
   prMerged: true
 });
 
-assert.equal(mergedBlocked.decision, "blocked");
+assert.equal(mergedBlocked.decision, "merged");
 assert.match(mergedBlocked.summary, /already merged/);
+
+const mergedPlan = manualDeployFinalLabelPlan({
+  prUrl: "https://github.com/Taskix-AI/Taskix/pull/999",
+  architectDecision: mergedBlocked
+});
+
+assert.equal(mergedPlan.decision, "merged");
+assert.deepEqual(mergedPlan.labelsApplied, []);
+assert.deepEqual(mergedPlan.labelsRemoved, ["taskix:need-qa", "taskix:qa-running", "taskix:ready-to-merge", "taskix:blocked"]);
+assert.match(mergedPlan.summary, /skipped ready-to-merge labeling/);
 
 console.log("issue-run policy simulation passed");

--- a/src/lib/issue-run-policy.ts
+++ b/src/lib/issue-run-policy.ts
@@ -1,7 +1,7 @@
 import type { ArchitectPrReviewResult } from "@/lib/types";
 
 export type LabelPlan = {
-  decision: "ready_to_merge" | "blocked" | "changes_requested";
+  decision: "ready_to_merge" | "blocked" | "changes_requested" | "merged";
   summary: string;
   labelsApplied: string[];
   labelsRemoved: string[];
@@ -27,6 +27,16 @@ export function manualDeployFinalLabelPlan(input: {
   prUrl: string;
   architectDecision: ArchitectPrReviewResult;
 }): LabelPlan {
+  if (input.architectDecision.decision === "merged") {
+    return {
+      decision: "merged",
+      summary: `${input.architectDecision.summary}\n\nManual-deploy project: ${input.prUrl} is already merged, so Taskix skipped ready-to-merge labeling.`,
+      labelsApplied: input.architectDecision.labelsApplied,
+      labelsRemoved: ["taskix:need-qa", "taskix:qa-running", "taskix:ready-to-merge", "taskix:blocked"],
+      comments: input.architectDecision.comments
+    };
+  }
+
   if (input.architectDecision.decision !== "ready_to_merge") {
     return {
       decision: input.architectDecision.decision === "changes_requested" ? "changes_requested" : "blocked",
@@ -63,8 +73,8 @@ export function manualDeployArchitectPolicyDecision(input: {
   }
   if (input.prMerged || state === "MERGED") {
     return {
-      decision: "blocked",
-      summary: `Architect policy blocked ${input.prUrl}: PR is already merged.`,
+      decision: "merged",
+      summary: `Architect policy observed ${input.prUrl} is already merged; ready-to-merge labeling is skipped.`,
       labelsApplied: [],
       comments: []
     };


### PR DESCRIPTION
## Summary
- treat already merged generated PRs as a terminal `merged` outcome instead of a blocked ready-to-merge path
- skip `taskix:ready-to-merge` labeling when the generated PR is already merged and clear transient QA/blocked labels
- extend the issue-run policy smoke test to lock in the merged-vs-open behavior

Closes #60

## Verification
- `npm run test:issue-run`
- `npm run typecheck`
- `npm run build` *(fails in existing Next.js prerender path: `/_global-error` throws `TypeError: Cannot read properties of null (reading 'useContext')`)*

## Recovery / Ready-to-Merge Evidence
- Deterministic recovery: the manual-deploy policy now returns `ready_to_merge` only for open, unmerged PRs and returns `merged` for already merged PRs.
- Recovered base visibility: existing recovery behavior remains unchanged; Taskix still reports recovered base information from `readPullRequestRefs` when PR context is recovered.
- Ready-to-merge expectations: open generated PRs still receive `taskix:ready-to-merge` after QA passes, while merged PRs explicitly skip that label.
- No generated PR merge: the manual-deploy path still stops at labeling/summary decisions and does not merge PRs.
