### PR TITLE
Improve workflow start visibility

### DIFF
--- a/src/app/api/projects/[projectId]/handoff/route.ts
+++ b/src/app/api/projects/[projectId]/handoff/route.ts
@@ -20,12 +20,17 @@ export async function POST(request: Request, { params }: { params: Promise<{ pro
   try {
     const requirement = payload ? formatPmHandoffPayload(payload) : directRequirement;
     const workflow = await createWorkflow(requirement, 0, project);
-    await createJob({
+    const job = await createJob({
       projectId: project.projectId,
       type: "workflow_run",
       payload: { workflowId: workflow.workflowId }
     });
-    return redirect(request, `/projects/${project.projectId}?role=architect&autorun=1`);
+    const next = new URL(`/projects/${project.projectId}`, request.url);
+    next.searchParams.set("role", "architect");
+    next.searchParams.set("queued", "1");
+    next.searchParams.set("workflow", workflow.workflowId);
+    next.searchParams.set("job", job.jobId);
+    return NextResponse.redirect(next, { status: 303 });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Architect handoff failed.";
     return redirect(request, `/projects/${project.projectId}?role=product_manager&error=${encodeURIComponent(message)}`);

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
 import { Bot, GitBranch, Info, Wrench } from "lucide-react";
+import type { CSSProperties } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
@@ -16,7 +17,7 @@ export default async function ProjectDetailPage({
   searchParams
 }: {
   params: Promise<{ projectId: string }>;
-  searchParams: Promise<{ role?: string; session?: string; error?: string; autorun?: string }>;
+  searchParams: Promise<{ role?: string; session?: string; error?: string; autorun?: string; workflow?: string; job?: string; queued?: string }>;
 }) {
   const [{ projectId }, query] = await Promise.all([params, searchParams]);
   const project = await getProject(projectId);
@@ -38,6 +39,12 @@ export default async function ProjectDetailPage({
   const dynamicSessions = allDynamicSessions.filter((session) => !session.archivedAt);
   const activeWorkflows = workflows.filter((workflow) => workflow.status !== "done");
   const doneWorkflows = workflows.filter((workflow) => workflow.status === "done");
+  const queuedWorkflowId = query.workflow ?? null;
+  const queuedJobId = query.job ?? null;
+  const queuedWorkflow = queuedWorkflowId ? workflows.find((workflow) => workflow.workflowId === queuedWorkflowId) ?? null : null;
+  const queuedJob = queuedJobId ? jobs.find((job) => job.jobId === queuedJobId) ?? null : null;
+  const visibleJobs = prioritizeById(jobs, queuedJobId).slice(0, 4);
+  const visibleActiveWorkflows = prioritizeById(activeWorkflows, queuedWorkflowId);
   const readyForArchitectPayload = findReadyForArchitectPayload(pmSession ?? (activeRole === "product_manager" ? roleSession : null));
 
   return (
@@ -98,13 +105,39 @@ export default async function ProjectDetailPage({
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
               {!isInspectingIssueSession && <ProjectHandoffForm projectId={project.projectId} payload={readyForArchitectPayload} />}
-              {jobs.slice(0, 4).map((job) => (
-                <Text key={job.jobId} size="xs" c="dimmed">
-                  Job {job.jobId}: {job.type} · {job.status}{job.error ? ` · ${job.error}` : ""}
-                </Text>
+              {query.queued === "1" && queuedWorkflow ? (
+                <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
+                  <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
+                  <Text size="xs" c="dimmed">
+                    {queuedWorkflow.trackingCode ?? queuedWorkflow.workflowId} is waiting in the workflow area below.
+                    {queuedJob ? ` Pending job: ${queuedJob.type} (${queuedJob.status}).` : ""}
+                  </Text>
+                </Alert>
+              ) : null}
+              {visibleJobs.map((job) => (
+                <div
+                  key={job.jobId}
+                  className="workflow-job-row"
+                  style={job.jobId === queuedJobId ? highlightedCardStyle : undefined}
+                >
+                  <Group justify="space-between" gap="xs" wrap="nowrap">
+                    <Text size="sm" fw={700}>{job.type}</Text>
+                    <Badge size="xs" variant="light">{job.status}</Badge>
+                  </Group>
+                  <Text size="xs" c="dimmed" mt={4}>
+                    Job {job.jobId}
+                    {job.payload.workflowId ? ` · workflow ${job.payload.workflowId}` : ""}
+                    {job.error ? ` · ${job.error}` : ""}
+                  </Text>
+                </div>
               ))}
-              {activeWorkflows.map((workflow) => (
-                <div key={workflow.workflowId} className="workflow-summary-card">
+              {!visibleJobs.length ? <Text c="dimmed" size="sm">No queued jobs yet.</Text> : null}
+              {visibleActiveWorkflows.map((workflow) => (
+                <div
+                  key={workflow.workflowId}
+                  className="workflow-summary-card"
+                  style={workflow.workflowId === queuedWorkflowId ? highlightedCardStyle : undefined}
+                >
                   <Group justify="space-between" gap="xs">
                     <div>
                       <Text fw={700} size="sm">
@@ -215,6 +248,21 @@ export default async function ProjectDetailPage({
     </>
   );
 }
+
+function prioritizeById<T extends { workflowId?: string; jobId?: string }>(items: T[], selectedId: string | null): T[] {
+  if (!selectedId) return items;
+  return [...items].sort((left, right) => {
+    const leftSelected = left.workflowId === selectedId || left.jobId === selectedId;
+    const rightSelected = right.workflowId === selectedId || right.jobId === selectedId;
+    if (leftSelected === rightSelected) return 0;
+    return leftSelected ? -1 : 1;
+  });
+}
+
+const highlightedCardStyle = {
+  borderColor: "#93c5fd",
+  background: "#eff6ff"
+} satisfies CSSProperties;
 
 function formatDuration(durationMs: number): string {
   const seconds = Math.max(0, Math.round(durationMs / 1000));

--- a/src/components/ProjectHandoffForm.tsx
+++ b/src/components/ProjectHandoffForm.tsx
@@ -27,14 +27,14 @@ function DirectRequirementFields() {
 
   return (
     <div className="handoff-box muted">
-      <Text size="sm" fw={700}>Start Workflow</Text>
+      <Text size="sm" fw={700}>Minimal Planning Smoke Path</Text>
       <Text size="xs" c="dimmed">
-        Paste a confirmed requirement here, or use PM chat to produce ready JSON.
+        Paste one confirmed requirement to queue a single architect planning workflow. This is a lightweight smoke path, not the full PM authoring flow.
       </Text>
       <Textarea
         name="requirement"
         aria-label="Direct workflow requirement"
-        placeholder="Describe the workflow requirement for the architect..."
+        placeholder="Describe the confirmed requirement the architect should plan..."
         autosize
         minRows={3}
         maxRows={6}
@@ -51,8 +51,11 @@ function DirectRequirementFields() {
         leftSection={pending ? <LoaderCircle size={15} className="chat-composer-spinner" /> : <GitBranch size={15} />}
         disabled={pending}
       >
-        {pending ? "Queueing workflow..." : "Start From Requirement"}
+        {pending ? "Queueing workflow..." : "Queue Planning Workflow"}
       </Button>
+      <Text size="xs" c="dimmed" mt="xs">
+        After submit, Taskix returns to the architect view with the queued workflow and pending `workflow_run` job highlighted.
+      </Text>
     </div>
   );
 }
@@ -64,7 +67,7 @@ function HandoffButton({ payload }: { payload: PmHandoffPayload }) {
     <div className="handoff-box">
       <Text size="sm" fw={700}>Start Workflow</Text>
       <Text size="xs" c="dimmed">
-        PM marked this requirement ready.
+        PM marked this requirement ready. Queue one planning workflow from the confirmed handoff.
       </Text>
       <Text size="sm" fw={720} mt="xs" lineClamp={2}>{payload.requirement}</Text>
       <Button
@@ -76,7 +79,7 @@ function HandoffButton({ payload }: { payload: PmHandoffPayload }) {
         leftSection={pending ? <LoaderCircle size={15} className="chat-composer-spinner" /> : <GitBranch size={15} />}
         disabled={pending}
       >
-        {pending ? "Queueing workflow..." : "Start Workflow"}
+        {pending ? "Queueing workflow..." : "Queue Workflow"}
       </Button>
     </div>
   );


### PR DESCRIPTION
Closes #28.
Closes #29.

## Summary
- Redirect workflow handoff back with queued workflow/job IDs instead of auto-running immediately.
- Show a queued workflow alert and highlighted pending job/workflow on the project page.
- Clarify the direct requirement smoke-path copy and queue button labels.

## Verification
- npm run typecheck
- npm run build
- npm run dev, then verified /projects and a queued project detail URL return 200