### PR TITLE
Make dashboard stat cards navigable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,6 +173,26 @@ body {
   border-bottom: 1px solid var(--app-border);
 }
 
+.dashboard-stat-card {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.dashboard-stat-card:hover {
+  border-color: #b8c7d9;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.dashboard-stat-card:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 .project-form {
   display: flex;
   flex-direction: column;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,10 +12,10 @@ export default async function DashboardPage() {
     <>
       <PageTitle title="Dashboard" />
       <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md" mb="md">
-        <Stat icon={<Bot size={18} />} label="Codex model" value={settings.codexModel} />
-        <Stat icon={<GitBranch size={18} />} label="Fallback repo" value={settings.githubRepo || "not set"} />
-        <Stat icon={<FolderKanban size={18} />} label="Projects" value={String(projects.length)} />
-        <Stat icon={<Workflow size={18} />} label="Workflows" value={String(workflows.length)} />
+        <Stat href="/tools" icon={<Bot size={18} />} label="Codex model" value={settings.codexModel} />
+        <Stat href="/settings" icon={<GitBranch size={18} />} label="Fallback repo" value={settings.githubRepo || "not set"} />
+        <Stat href="/projects" icon={<FolderKanban size={18} />} label="Projects" value={String(projects.length)} />
+        <Stat href="/projects" icon={<Workflow size={18} />} label="Workflows" value={String(workflows.length)} />
       </SimpleGrid>
       <Paper>
         <Group justify="space-between" p="md" className="section-header">
@@ -33,9 +33,9 @@ export default async function DashboardPage() {
   );
 }
 
-function Stat({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+function Stat({ href, icon, label, value }: { href: string; icon: React.ReactNode; label: string; value: string }) {
   return (
-    <Card withBorder shadow="xs" padding="md">
+    <Card component="a" href={href} withBorder shadow="xs" padding="md" className="dashboard-stat-card">
       <Group justify="space-between" align="flex-start">
         <div>
           <Text size="xs" tt="uppercase" fw={800} c="dimmed">


### PR DESCRIPTION
Closes #14.

## Summary
- Turn dashboard stat cards into links while keeping their labels and values unchanged.
- Route Codex model to /tools, fallback repo to /settings, and projects/workflows to /projects.
- Add subtle hover and focus states for the linked cards.

## Verification
- npm run typecheck
- npm run build
- Reused existing local dev server on :8000 and verified dashboard HTML renders card links to /tools, /settings, /projects, /projects.
- Verified /tools, /settings, and /projects return HTTP 200.