### PR TITLE
Add read-only GitHub triage data endpoint

### DIFF
--- a/src/app/api/projects/[projectId]/triage/route.ts
+++ b/src/app/api/projects/[projectId]/triage/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getProjectTriageWithGh } from "@/lib/github-local";
+import { getProject } from "@/lib/store";
+import type { ProjectTriageGroup, ProjectTriageResponse } from "@/lib/types";
+
+const triageGroups: ProjectTriageGroup[] = ["blocked", "needs_qa", "ready_to_merge", "in_progress", "done", "untracked"];
+
+export async function GET(_request: Request, { params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+  const project = await getProject(projectId);
+  if (!project) {
+    return NextResponse.json({ ok: false, error: "Project not found." }, { status: 404 });
+  }
+
+  const repo = project.githubRepo.trim();
+  if (!repo) {
+    return NextResponse.json({ ok: false, projectId: project.projectId, error: "Project has no bound GitHub repo." }, { status: 400 });
+  }
+
+  try {
+    const items = await getProjectTriageWithGh(repo);
+    const groups = Object.fromEntries(triageGroups.map((group) => [group, items.filter((item) => item.group === group)])) as ProjectTriageResponse["groups"];
+    const counts = Object.fromEntries(triageGroups.map((group) => [group, groups[group].length])) as ProjectTriageResponse["counts"];
+
+    return NextResponse.json({
+      ok: true,
+      projectId: project.projectId,
+      repo,
+      generatedAt: new Date().toISOString(),
+      counts,
+      groups
+    } satisfies ProjectTriageResponse);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "GitHub triage read failed.";
+    return NextResponse.json({ ok: false, projectId: project.projectId, repo, error: message }, { status: 502 });
+  }
+}

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { allTaskixLabels, roleLabel } from "@/lib/github-labels";
 import { dataDir } from "@/lib/paths";
-import type { IssueSpec } from "@/lib/types";
+import type { IssueSpec, ProjectTriageGroup, ProjectTriageItem } from "@/lib/types";
 
 const execFileAsync = promisify(execFile);
 
@@ -29,6 +29,22 @@ export type GhIssueSnapshot = {
   }>;
 };
 
+type GhTriageIssue = {
+  number: number;
+  url: string;
+  state: string;
+  labels: Array<{ name: string }>;
+};
+
+type GhTriagePr = {
+  number: number;
+  url: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  mergeStateStatus?: string | null;
+  closingIssuesReferences?: Array<{ number: number }>;
+};
+
 export async function listLocalGitHubRepos(owner: string): Promise<LocalGitHubRepo[]> {
   const { stdout } = await execFileAsync("gh", ["repo", "list", owner, "--limit", "100", "--json", "nameWithOwner,sshUrl,url,isPrivate"]);
   return JSON.parse(stdout) as LocalGitHubRepo[];
@@ -36,6 +52,89 @@ export async function listLocalGitHubRepos(owner: string): Promise<LocalGitHubRe
 
 export async function verifyLocalGitHubRepo(repo: string): Promise<void> {
   await execFileAsync("gh", ["api", `repos/${repo}`, "--jq", ".full_name"]);
+}
+
+export async function getProjectTriageWithGh(repo: string): Promise<ProjectTriageItem[]> {
+  const { stdout } = await execFileAsync("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--limit",
+    "100",
+    "--json",
+    "number,url,state,labels"
+  ]);
+  const issues = JSON.parse(stdout) as GhTriageIssue[];
+  return Promise.all(issues.map((issue) => getTriageItemWithGh(repo, issue)));
+}
+
+async function getTriageItemWithGh(repo: string, issue: GhTriageIssue): Promise<ProjectTriageItem> {
+  const prs = await listLinkedPullRequestsWithGh(repo, issue.number);
+  const primaryPr = pickPrimaryPullRequest(prs);
+  const issueLabels = issue.labels.map((label) => label.name);
+  const primaryLinkedPrLabels = primaryPr?.labels.map((label) => label.name) ?? [];
+  const group = classifyTriageIssue({
+    issueState: issue.state,
+    issueLabels,
+    primaryLinkedPrState: primaryPr?.state ?? null,
+    primaryLinkedPrLabels
+  });
+
+  return {
+    issueNumber: issue.number,
+    issueUrl: issue.url,
+    issueState: issue.state,
+    issueLabels,
+    primaryLinkedPrUrl: primaryPr?.url ?? null,
+    primaryLinkedPrState: primaryPr?.state ?? null,
+    primaryLinkedPrLabels,
+    group
+  };
+}
+
+async function listLinkedPullRequestsWithGh(repo: string, issueNumber: number): Promise<GhTriagePr[]> {
+  const { stdout } = await execFileAsync("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--search",
+    `linked:issue-${issueNumber}`,
+    "--json",
+    "number,url,state,labels,mergeStateStatus,closingIssuesReferences",
+    "--limit",
+    "20"
+  ]);
+  const prs = JSON.parse(stdout) as GhTriagePr[];
+  return prs.filter((pr) => pr.closingIssuesReferences?.some((linkedIssue) => linkedIssue.number === issueNumber));
+}
+
+function pickPrimaryPullRequest(prs: GhTriagePr[]): GhTriagePr | null {
+  return prs.find((pr) => pr.state === "OPEN") ?? prs[0] ?? null;
+}
+
+function classifyTriageIssue(input: {
+  issueState: string;
+  issueLabels: string[];
+  primaryLinkedPrState: string | null;
+  primaryLinkedPrLabels: string[];
+}): ProjectTriageGroup {
+  const labels = new Set([...input.issueLabels, ...input.primaryLinkedPrLabels].map((label) => label.toLowerCase()));
+  if (input.issueState === "CLOSED" || input.primaryLinkedPrState === "MERGED" || hasAnyLabel(labels, ["taskix:merged"])) return "done";
+  if (hasAnyLabel(labels, ["taskix:blocked", "qa-failed", "taskix:qa-failed"])) return "blocked";
+  if (hasAnyLabel(labels, ["taskix:need-qa", "qa-running", "taskix:qa-running"])) return "needs_qa";
+  if (hasAnyLabel(labels, ["taskix:ready-to-merge", "qa-passed", "taskix:qa-passed"])) return "ready_to_merge";
+  if (hasAnyLabel(labels, ["taskix:dev-running", "taskix:pr-opened"]) || input.primaryLinkedPrState === "OPEN") return "in_progress";
+  return "untracked";
+}
+
+function hasAnyLabel(labels: Set<string>, expected: string[]): boolean {
+  return expected.some((label) => labels.has(label));
 }
 
 export async function ensureTaskixLabels(repo: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -132,6 +132,28 @@ export type ProjectRecord = {
   teamRoles: Role[];
 };
 
+export type ProjectTriageGroup = "blocked" | "needs_qa" | "ready_to_merge" | "in_progress" | "done" | "untracked";
+
+export type ProjectTriageItem = {
+  issueNumber: number;
+  issueUrl: string;
+  issueState: string;
+  issueLabels: string[];
+  primaryLinkedPrUrl: string | null;
+  primaryLinkedPrState: string | null;
+  primaryLinkedPrLabels: string[];
+  group: ProjectTriageGroup;
+};
+
+export type ProjectTriageResponse = {
+  ok: true;
+  projectId: string;
+  repo: string;
+  generatedAt: string;
+  counts: Record<ProjectTriageGroup, number>;
+  groups: Record<ProjectTriageGroup, ProjectTriageItem[]>;
+};
+
 export type AgentMessage = {
   role: AgentMessageRole;
   content: string;


### PR DESCRIPTION
Closes #65.

## Summary
- Add the backend-only read-only triage endpoint at /api/projects/[projectId]/triage.
- Load the project-bound GitHub repo and return issue-centric grouped triage data.
- Keep reusable grouping/read logic in src/lib/github-local.ts and shared response/item types in src/lib/types.ts.
- Classify issues into exactly blocked, needs_qa, ready_to_merge, in_progress, done, and untracked.
- Include issue number/url/state/labels plus primary linked PR url/state/labels and the computed group.
- Return clear 404, 400, and 502 JSON errors for missing project, missing repo, and GitHub read failures.

## Verification
- npm run typecheck
- npm run build
- Temporary production server on :8001: GET /api/projects/547661a4/triage returned 200 JSON with projectId/repo/generatedAt/counts/groups.
- Temporary production server on :8001: GET /api/projects/547661a4/github-triage returned 404.
- Temporary production server on :8001: GET /api/projects/not-a-project/triage returned 404 JSON.