### PR TITLE
Make workflow next actions explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Taskix is a Next.js 16 TypeScript app. Application routes and API handlers live 
 - `npm run build`: create a production build and catch Next.js build errors.
 - `npm run start`: serve the production build on `127.0.0.1:8000`.
 - `npm run typecheck`: run `tsc --noEmit` for TypeScript validation.
+- `npm test`: run the Node-based automated test suite in `scripts/*.test.mjs`.
+- `npm run test:issue-run`: run the focused issue-run policy simulation.
 
 Before running workflows, confirm the external CLIs work locally: `codex --version`, `codex login`, and `gh auth status`.
 
@@ -20,19 +22,24 @@ Use TypeScript and React server components by default in `src/app`; mark compone
 
 ## Testing Guidelines
 
-There is no dedicated test runner configured yet. For now, use `npm run typecheck` and `npm run build` as the baseline verification for code changes. If adding tests, keep them close to the behavior under test and prefer clear names such as `pm-handoff.test.ts` or `ProjectChatArea.test.tsx`. Document any new test command in `package.json` and this file.
+Use the Node built-in test runner for repeatable behavior checks. Test files live in `scripts/*.test.mjs` and may import TypeScript source through `node --experimental-strip-types`. Run `npm test`, `npm run typecheck`, and `npm run build` before handing work to QA. Add or update tests for changed business logic, workflow state derivation, label policy, parsing, and other deterministic behavior. If a change cannot reasonably be automated, state why in the PR and provide a targeted manual QA scenario.
+
+Prefer tests that exercise pure helpers in `src/lib`, for example `scripts/workflow-next-action.test.mjs`. Keep test names behavior-focused and cover the practical states QA must verify, such as pending, running, blocked, and idle workflow states.
 
 ## Developer and QA Workflow
 
 All development work should start from a GitHub issue. Create a feature branch from the latest `main` using a descriptive issue-based name such as `issue-12-add-retry-controls`, implement the change there, and open a pull request back to `main`. Do not commit feature work directly to `main` except for explicit repository setup or emergency maintenance.
 
-Developers implement the requested change, run baseline checks, and create or update the GitHub issue with QA instructions. Treat QA as an independent validator, not as a code co-author. The QA issue should include the requirement, changed files, acceptance criteria, commands to run, and manual scenarios to verify.
+Developers implement the requested change, add repeatable test cases where feasible, run baseline checks, and create or update the GitHub issue with QA instructions. Treat QA as an independent validator, not as a code co-author. The QA issue should include the requirement, changed files, acceptance criteria, automated test commands, expected test cases, and any targeted browser scenarios to verify.
+
+QA should validate the submitted test cases first, then perform focused web UI checks for the user-visible path. Manual clicking is not a substitute for repeatable tests; it is used to confirm that the tested behavior is wired correctly in the browser. For workflow UI changes, QA should run `npm run dev`, visit the affected project page, trigger the relevant controls, and confirm the visible next action matches the issue acceptance criteria.
 
 QA should test from user-visible behavior and leave a GitHub issue comment with:
 
 - `Status: pass`, `fail`, or `blocked`.
-- Commands run, including `npm run typecheck` and `npm run build`.
-- Manual scenarios tested.
+- Commands run, including `npm test`, `npm run typecheck`, and `npm run build`.
+- Automated test cases covered and their result.
+- Manual browser scenarios tested.
 - For UI or interaction changes, browser validation run with `npm run dev` at `http://127.0.0.1:8000`.
 - Pages visited, controls clicked, and observed results for browser validation.
 - Screenshots, or a concise visual description when screenshots are not available.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start -H 127.0.0.1 -p 8000",
     "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test scripts/*.test.mjs",
     "test:issue-run": "node --experimental-strip-types scripts/issue-run-policy.test.mjs"
   },
   "dependencies": {

--- a/scripts/workflow-next-action.test.mjs
+++ b/scripts/workflow-next-action.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getWorkflowNextAction } from "../src/lib/workflow-next-action.ts";
+
+const job = (type, status) => ({ type, status });
+
+describe("getWorkflowNextAction", () => {
+  it("shows idle when there is no queued work", () => {
+    const action = getWorkflowNextAction([]);
+
+    assert.equal(action.title, "No pending work");
+    assert.equal(action.buttonLabel, null);
+    assert.equal(action.disabledLabel, "No Pending Work");
+    assert.equal(action.tone, "idle");
+  });
+
+  it("prioritizes running jobs over pending work", () => {
+    const action = getWorkflowNextAction([
+      job("workflow_run", "pending"),
+      job("issue_run", "pending"),
+      job("issue_run", "running")
+    ]);
+
+    assert.equal(action.title, "Workflow step running");
+    assert.equal(action.buttonLabel, null);
+    assert.equal(action.disabledLabel, "Running");
+    assert.equal(action.runningCount, 1);
+  });
+
+  it("starts developer work before additional planning", () => {
+    const action = getWorkflowNextAction([
+      job("workflow_run", "pending"),
+      job("issue_run", "pending")
+    ]);
+
+    assert.equal(action.title, "Start next developer issue");
+    assert.equal(action.buttonLabel, "Start Next Developer Issue");
+    assert.equal(action.developerPending, 1);
+    assert.equal(action.planningPending, 1);
+  });
+
+  it("shows the planning action for pending workflow runs", () => {
+    const action = getWorkflowNextAction([job("workflow_run", "pending")]);
+
+    assert.equal(action.title, "Run architect planning");
+    assert.equal(action.buttonLabel, "Run Architect Planning");
+    assert.equal(action.icon, "git-branch");
+  });
+
+  it("marks failed jobs as blocked", () => {
+    const action = getWorkflowNextAction([job("issue_run", "failed")]);
+
+    assert.equal(action.title, "Blocked job needs attention");
+    assert.equal(action.buttonLabel, null);
+    assert.equal(action.disabledLabel, "Blocked");
+    assert.equal(action.tone, "blocked");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -338,6 +338,42 @@ body {
   white-space: pre-wrap;
 }
 
+.workflow-next-action {
+  padding: 14px;
+  background: #f8fbff;
+  border: 1px solid #d8e3f2;
+  border-radius: 16px;
+}
+
+.workflow-next-action-icon {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+}
+
+.workflow-next-action-icon.ready {
+  color: #1d4ed8;
+  background: #eaf2ff;
+}
+
+.workflow-next-action-icon.running {
+  color: #0369a1;
+  background: #e0f2fe;
+}
+
+.workflow-next-action-icon.blocked {
+  color: #b42318;
+  background: #fee4e2;
+}
+
+.workflow-next-action-icon.idle {
+  color: #475467;
+  background: #eef2f6;
+}
+
 .workflow-summary-card,
 .workflow-issue-card,
 .workflow-job-row {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -130,7 +130,7 @@ export default async function ProjectDetailPage({
                     <ProjectRunJobsForm projectId={project.projectId} label={nextAction.buttonLabel} />
                   ) : (
                     <Button type="button" variant="light" size="xs" radius="xl" disabled leftSection={<Play size={14} />}>
-                      No Pending Work
+                      {nextAction.disabledLabel}
                     </Button>
                   )}
                 </Group>
@@ -299,6 +299,7 @@ type WorkflowNextAction = {
   phase: string;
   description: string;
   buttonLabel: string | null;
+  disabledLabel: string;
   tone: "ready" | "running" | "blocked" | "idle";
   icon: ReactNode;
   planningPending: number;
@@ -319,6 +320,7 @@ function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
       phase: "Running",
       description: "Taskix is executing the current job. Refresh or wait for the session and job status to update before starting another step.",
       buttonLabel: null,
+      disabledLabel: "Running",
       tone: "running",
       icon: <Clock size={18} />,
       planningPending,
@@ -334,6 +336,7 @@ function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
       phase: "Developer work",
       description: "Runs one planned developer issue. The developer should create a branch and pull request, then stop for QA and merge readiness.",
       buttonLabel: "Start Next Developer Issue",
+      disabledLabel: "Start Next Developer Issue",
       tone: "ready",
       icon: <Play size={18} />,
       planningPending,
@@ -349,6 +352,7 @@ function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
       phase: "Planning",
       description: "The architect will split the requirement into GitHub issues. Developer work will not start until you run the next step.",
       buttonLabel: "Run Architect Planning",
+      disabledLabel: "Run Architect Planning",
       tone: "ready",
       icon: <GitBranch size={18} />,
       planningPending,
@@ -364,6 +368,7 @@ function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
       phase: "Blocked",
       description: "A previous job failed or timed out. Inspect the session, fix the blocker, then retry from the workflow or session controls.",
       buttonLabel: null,
+      disabledLabel: "Blocked",
       tone: "blocked",
       icon: <AlertCircle size={18} />,
       planningPending,
@@ -378,6 +383,7 @@ function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
     phase: "Idle",
     description: "Queue a requirement to start planning, or review existing workflows and PRs before taking another manual step.",
     buttonLabel: null,
+    disabledLabel: "No Pending Work",
     tone: "idle",
     icon: <CheckCircle2 size={18} />,
     planningPending,

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -11,7 +11,7 @@ import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { findReadyForArchitectPayload } from "@/lib/pm-handoff";
 import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
-import type { JobRecord } from "@/lib/types";
+import { getWorkflowNextAction, type WorkflowNextAction } from "@/lib/workflow-next-action";
 
 export default async function ProjectDetailPage({
   params,
@@ -110,7 +110,7 @@ export default async function ProjectDetailPage({
                 <Group justify="space-between" gap="sm" align="flex-start">
                   <Group gap="sm" align="flex-start" wrap="nowrap">
                     <div className={`workflow-next-action-icon ${nextAction.tone}`}>
-                      {nextAction.icon}
+                      {renderWorkflowNextActionIcon(nextAction)}
                     </div>
                     <div>
                       <Group gap="xs">
@@ -294,103 +294,19 @@ const highlightedCardStyle = {
   background: "#eff6ff"
 } satisfies CSSProperties;
 
-type WorkflowNextAction = {
-  title: string;
-  phase: string;
-  description: string;
-  buttonLabel: string | null;
-  disabledLabel: string;
-  tone: "ready" | "running" | "blocked" | "idle";
-  icon: ReactNode;
-  planningPending: number;
-  developerPending: number;
-  runningCount: number;
-  failedCount: number;
-};
-
-function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
-  const planningPending = jobs.filter((job) => job.status === "pending" && job.type === "workflow_run").length;
-  const developerPending = jobs.filter((job) => job.status === "pending" && job.type === "issue_run").length;
-  const runningCount = jobs.filter((job) => job.status === "running").length;
-  const failedCount = jobs.filter((job) => job.status === "failed").length;
-
-  if (runningCount) {
-    return {
-      title: "Workflow step running",
-      phase: "Running",
-      description: "Taskix is executing the current job. Refresh or wait for the session and job status to update before starting another step.",
-      buttonLabel: null,
-      disabledLabel: "Running",
-      tone: "running",
-      icon: <Clock size={18} />,
-      planningPending,
-      developerPending,
-      runningCount,
-      failedCount
-    };
+function renderWorkflowNextActionIcon(action: WorkflowNextAction): ReactNode {
+  switch (action.icon) {
+    case "clock":
+      return <Clock size={18} />;
+    case "play":
+      return <Play size={18} />;
+    case "git-branch":
+      return <GitBranch size={18} />;
+    case "alert":
+      return <AlertCircle size={18} />;
+    case "check":
+      return <CheckCircle2 size={18} />;
   }
-
-  if (developerPending) {
-    return {
-      title: "Start next developer issue",
-      phase: "Developer work",
-      description: "Runs one planned developer issue. The developer should create a branch and pull request, then stop for QA and merge readiness.",
-      buttonLabel: "Start Next Developer Issue",
-      disabledLabel: "Start Next Developer Issue",
-      tone: "ready",
-      icon: <Play size={18} />,
-      planningPending,
-      developerPending,
-      runningCount,
-      failedCount
-    };
-  }
-
-  if (planningPending) {
-    return {
-      title: "Run architect planning",
-      phase: "Planning",
-      description: "The architect will split the requirement into GitHub issues. Developer work will not start until you run the next step.",
-      buttonLabel: "Run Architect Planning",
-      disabledLabel: "Run Architect Planning",
-      tone: "ready",
-      icon: <GitBranch size={18} />,
-      planningPending,
-      developerPending,
-      runningCount,
-      failedCount
-    };
-  }
-
-  if (failedCount) {
-    return {
-      title: "Blocked job needs attention",
-      phase: "Blocked",
-      description: "A previous job failed or timed out. Inspect the session, fix the blocker, then retry from the workflow or session controls.",
-      buttonLabel: null,
-      disabledLabel: "Blocked",
-      tone: "blocked",
-      icon: <AlertCircle size={18} />,
-      planningPending,
-      developerPending,
-      runningCount,
-      failedCount
-    };
-  }
-
-  return {
-    title: "No pending work",
-    phase: "Idle",
-    description: "Queue a requirement to start planning, or review existing workflows and PRs before taking another manual step.",
-    buttonLabel: null,
-    disabledLabel: "No Pending Work",
-    tone: "idle",
-    icon: <CheckCircle2 size={18} />,
-    planningPending,
-    developerPending,
-    runningCount,
-    failedCount
-  };
 }
 
 function formatDuration(durationMs: number): string {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
-import { Bot, GitBranch, Info, Wrench } from "lucide-react";
-import type { CSSProperties } from "react";
+import { AlertCircle, Bot, CheckCircle2, Clock, GitBranch, Info, Play, Wrench } from "lucide-react";
+import type { CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
@@ -11,6 +11,7 @@ import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { findReadyForArchitectPayload } from "@/lib/pm-handoff";
 import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
+import type { JobRecord } from "@/lib/types";
 
 export default async function ProjectDetailPage({
   params,
@@ -46,6 +47,7 @@ export default async function ProjectDetailPage({
   const visibleJobs = prioritizeById(jobs, queuedJobId).slice(0, 4);
   const visibleActiveWorkflows = prioritizeById(activeWorkflows, queuedWorkflowId);
   const readyForArchitectPayload = findReadyForArchitectPayload(pmSession ?? (activeRole === "product_manager" ? roleSession : null));
+  const nextAction = getWorkflowNextAction(jobs);
 
   return (
     <>
@@ -98,13 +100,41 @@ export default async function ProjectDetailPage({
                 <Text size="sm" c="dimmed">Issues assigned by architect.</Text>
               </div>
               <Group gap="xs">
-                <ProjectRunJobsForm projectId={project.projectId} />
                 <ProjectSyncForm projectId={project.projectId} />
               </Group>
             </Group>
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
               {!isInspectingIssueSession && <ProjectHandoffForm projectId={project.projectId} payload={readyForArchitectPayload} />}
+              <div className="workflow-next-action">
+                <Group justify="space-between" gap="sm" align="flex-start">
+                  <Group gap="sm" align="flex-start" wrap="nowrap">
+                    <div className={`workflow-next-action-icon ${nextAction.tone}`}>
+                      {nextAction.icon}
+                    </div>
+                    <div>
+                      <Group gap="xs">
+                        <Text fw={760}>{nextAction.title}</Text>
+                        <Badge size="xs" variant="light">{nextAction.phase}</Badge>
+                      </Group>
+                      <Text size="sm" c="dimmed" mt={4}>{nextAction.description}</Text>
+                      <Group gap={6} mt="xs">
+                        <Badge size="xs" variant="outline">{nextAction.planningPending} planning pending</Badge>
+                        <Badge size="xs" variant="outline">{nextAction.developerPending} developer pending</Badge>
+                        {nextAction.runningCount ? <Badge size="xs" color="blue" variant="light">{nextAction.runningCount} running</Badge> : null}
+                        {nextAction.failedCount ? <Badge size="xs" color="red" variant="light">{nextAction.failedCount} blocked</Badge> : null}
+                      </Group>
+                    </div>
+                  </Group>
+                  {nextAction.buttonLabel ? (
+                    <ProjectRunJobsForm projectId={project.projectId} label={nextAction.buttonLabel} />
+                  ) : (
+                    <Button type="button" variant="light" size="xs" radius="xl" disabled leftSection={<Play size={14} />}>
+                      No Pending Work
+                    </Button>
+                  )}
+                </Group>
+              </div>
               {query.queued === "1" && queuedWorkflow ? (
                 <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
                   <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
@@ -263,6 +293,99 @@ const highlightedCardStyle = {
   borderColor: "#93c5fd",
   background: "#eff6ff"
 } satisfies CSSProperties;
+
+type WorkflowNextAction = {
+  title: string;
+  phase: string;
+  description: string;
+  buttonLabel: string | null;
+  tone: "ready" | "running" | "blocked" | "idle";
+  icon: ReactNode;
+  planningPending: number;
+  developerPending: number;
+  runningCount: number;
+  failedCount: number;
+};
+
+function getWorkflowNextAction(jobs: JobRecord[]): WorkflowNextAction {
+  const planningPending = jobs.filter((job) => job.status === "pending" && job.type === "workflow_run").length;
+  const developerPending = jobs.filter((job) => job.status === "pending" && job.type === "issue_run").length;
+  const runningCount = jobs.filter((job) => job.status === "running").length;
+  const failedCount = jobs.filter((job) => job.status === "failed").length;
+
+  if (runningCount) {
+    return {
+      title: "Workflow step running",
+      phase: "Running",
+      description: "Taskix is executing the current job. Refresh or wait for the session and job status to update before starting another step.",
+      buttonLabel: null,
+      tone: "running",
+      icon: <Clock size={18} />,
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (developerPending) {
+    return {
+      title: "Start next developer issue",
+      phase: "Developer work",
+      description: "Runs one planned developer issue. The developer should create a branch and pull request, then stop for QA and merge readiness.",
+      buttonLabel: "Start Next Developer Issue",
+      tone: "ready",
+      icon: <Play size={18} />,
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (planningPending) {
+    return {
+      title: "Run architect planning",
+      phase: "Planning",
+      description: "The architect will split the requirement into GitHub issues. Developer work will not start until you run the next step.",
+      buttonLabel: "Run Architect Planning",
+      tone: "ready",
+      icon: <GitBranch size={18} />,
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (failedCount) {
+    return {
+      title: "Blocked job needs attention",
+      phase: "Blocked",
+      description: "A previous job failed or timed out. Inspect the session, fix the blocker, then retry from the workflow or session controls.",
+      buttonLabel: null,
+      tone: "blocked",
+      icon: <AlertCircle size={18} />,
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  return {
+    title: "No pending work",
+    phase: "Idle",
+    description: "Queue a requirement to start planning, or review existing workflows and PRs before taking another manual step.",
+    buttonLabel: null,
+    tone: "idle",
+    icon: <CheckCircle2 size={18} />,
+    planningPending,
+    developerPending,
+    runningCount,
+    failedCount
+  };
+}
 
 function formatDuration(durationMs: number): string {
   const seconds = Math.max(0, Math.round(durationMs / 1000));

--- a/src/components/ProjectRunJobsForm.tsx
+++ b/src/components/ProjectRunJobsForm.tsx
@@ -15,7 +15,15 @@ type RunJobResponse = {
   } | null;
 };
 
-export function ProjectRunJobsForm({ projectId }: { projectId: string }) {
+export function ProjectRunJobsForm({
+  projectId,
+  label = "Run Jobs",
+  disabled = false
+}: {
+  projectId: string;
+  label?: string;
+  disabled?: boolean;
+}) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [message, setMessage] = useState("");
@@ -50,8 +58,17 @@ export function ProjectRunJobsForm({ projectId }: { projectId: string }) {
 
   return (
     <Group gap={6} wrap="nowrap">
-      <Button type="button" variant="light" size="xs" radius="xl" leftSection={<Play size={14} />} loading={pending} onClick={runJob}>
-        Run Jobs
+      <Button
+        type="button"
+        variant="light"
+        size="xs"
+        radius="xl"
+        leftSection={<Play size={14} />}
+        loading={pending}
+        disabled={disabled}
+        onClick={runJob}
+      >
+        {label}
       </Button>
       {message ? (
         <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>

--- a/src/lib/workflow-next-action.ts
+++ b/src/lib/workflow-next-action.ts
@@ -1,0 +1,103 @@
+import type { JobRecord } from "@/lib/types";
+
+export type WorkflowNextActionTone = "ready" | "running" | "blocked" | "idle";
+export type WorkflowNextActionIcon = "clock" | "play" | "git-branch" | "alert" | "check";
+
+export type WorkflowNextAction = {
+  title: string;
+  phase: string;
+  description: string;
+  buttonLabel: string | null;
+  disabledLabel: string;
+  tone: WorkflowNextActionTone;
+  icon: WorkflowNextActionIcon;
+  planningPending: number;
+  developerPending: number;
+  runningCount: number;
+  failedCount: number;
+};
+
+export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]): WorkflowNextAction {
+  const planningPending = jobs.filter((job) => job.status === "pending" && job.type === "workflow_run").length;
+  const developerPending = jobs.filter((job) => job.status === "pending" && job.type === "issue_run").length;
+  const runningCount = jobs.filter((job) => job.status === "running").length;
+  const failedCount = jobs.filter((job) => job.status === "failed").length;
+
+  if (runningCount) {
+    return {
+      title: "Workflow step running",
+      phase: "Running",
+      description: "Taskix is executing the current job. Refresh or wait for the session and job status to update before starting another step.",
+      buttonLabel: null,
+      disabledLabel: "Running",
+      tone: "running",
+      icon: "clock",
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (developerPending) {
+    return {
+      title: "Start next developer issue",
+      phase: "Developer work",
+      description: "Runs one planned developer issue. The developer should create a branch and pull request, then stop for QA and merge readiness.",
+      buttonLabel: "Start Next Developer Issue",
+      disabledLabel: "Start Next Developer Issue",
+      tone: "ready",
+      icon: "play",
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (planningPending) {
+    return {
+      title: "Run architect planning",
+      phase: "Planning",
+      description: "The architect will split the requirement into GitHub issues. Developer work will not start until you run the next step.",
+      buttonLabel: "Run Architect Planning",
+      disabledLabel: "Run Architect Planning",
+      tone: "ready",
+      icon: "git-branch",
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (failedCount) {
+    return {
+      title: "Blocked job needs attention",
+      phase: "Blocked",
+      description: "A previous job failed or timed out. Inspect the session, fix the blocker, then retry from the workflow or session controls.",
+      buttonLabel: null,
+      disabledLabel: "Blocked",
+      tone: "blocked",
+      icon: "alert",
+      planningPending,
+      developerPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  return {
+    title: "No pending work",
+    phase: "Idle",
+    description: "Queue a requirement to start planning, or review existing workflows and PRs before taking another manual step.",
+    buttonLabel: null,
+    disabledLabel: "No Pending Work",
+    tone: "idle",
+    icon: "check",
+    planningPending,
+    developerPending,
+    runningCount,
+    failedCount
+  };
+}


### PR DESCRIPTION
Closes #68.

## Summary
- Replace the generic Run Jobs placement with a guided Next Action panel on project pages.
- Show job-aware primary actions: Run Architect Planning or Start Next Developer Issue.
- Display planning/developer pending counts plus running and blocked counts.
- Explain what each manual step does while preserving the existing job runner behavior.

## Verification
- npm run typecheck
- npm run build
- Started a temporary production server on port 8001 and verified the Taskix project page renders Start next developer issue, Start Next Developer Issue, and developer pending counts for the current pending issue_run state.