### PR TITLE
Improve project chat scrolling and timestamps

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,11 +228,15 @@ body {
 .chat-panel {
   display: flex;
   flex-direction: column;
+  height: calc(100vh - 108px);
   min-height: calc(100vh - 180px);
   overflow: hidden;
 }
 
 .chat-header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -244,10 +248,14 @@ body {
 
 .chat-scroll {
   flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 28px min(8vw, 84px) 12px;
   background:
     radial-gradient(circle at 10% 10%, rgba(37, 99, 235, 0.06), transparent 28%),
     #f8fbff;
+  scrollbar-gutter: stable;
 }
 
 .chat-composer {
@@ -616,6 +624,10 @@ body {
   .project-context {
     position: static;
   }
+
+  .chat-panel {
+    height: calc(100vh - 128px);
+  }
 }
 
 @media (max-width: 720px) {
@@ -631,6 +643,11 @@ body {
 
   .chat-composer {
     padding: 14px;
+  }
+
+  .chat-header {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .chat-composer-actions {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -259,6 +259,10 @@ body {
 }
 
 .chat-composer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  flex: 0 0 auto;
   padding: 10px min(8vw, 84px) 22px;
   border-top: 0;
   background:

--- a/src/components/ProjectChatArea.tsx
+++ b/src/components/ProjectChatArea.tsx
@@ -22,6 +22,7 @@ export function ProjectChatArea({
 }) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [pending, setPending] = useState(false);
   const [optimisticMessage, setOptimisticMessage] = useState<AgentMessage | null>(null);
   const target = activeRole === "product_manager" ? "PM" : activeRole === "architect" ? "Architect" : "DevOps";
@@ -30,6 +31,12 @@ export function ProjectChatArea({
     setPending(false);
     setOptimisticMessage(null);
   }, [session?.updatedAt, activeRole]);
+
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    scroll.scrollTop = scroll.scrollHeight;
+  }, [session?.sessionKey, session?.updatedAt, session?.messages.length, optimisticMessage?.createdAt, pending]);
 
   async function submitMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -62,7 +69,7 @@ export function ProjectChatArea({
 
   return (
     <>
-      <div className="chat-scroll">
+      <div ref={scrollRef} className="chat-scroll">
         <MessageList projectId={projectId} session={session} optimisticMessage={optimisticMessage} pending={pending} />
       </div>
       {!readOnly && (
@@ -130,7 +137,12 @@ function MessageList({
         <div key={`${message.createdAt}-${index}`} className={`chat-message ${message.role}`}>
           <div className="chat-avatar">{message.role === "user" ? "U" : message.role === "assistant" ? "A" : "S"}</div>
           <div className="chat-bubble">
-            <Badge variant="light" mb={6}>{message.role}</Badge>
+            <Group gap="xs" mb={6} justify="space-between" align="center">
+              <Badge variant="light">{message.role}</Badge>
+              <Text component="time" dateTime={message.createdAt} size="xs" c="dimmed">
+                {formatMessageTime(message.createdAt)}
+              </Text>
+            </Group>
             <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
           </div>
         </div>
@@ -139,7 +151,12 @@ function MessageList({
         <div className="chat-message assistant pending">
           <div className="chat-avatar">A</div>
           <div className="chat-bubble">
-            <Badge variant="light" mb={6}>assistant</Badge>
+            <Group gap="xs" mb={6} justify="space-between" align="center">
+              <Badge variant="light">assistant</Badge>
+              <Text component="time" dateTime={new Date().toISOString()} size="xs" c="dimmed">
+                now
+              </Text>
+            </Group>
             <Text size="sm" c="dimmed">Codex agent is thinking...</Text>
           </div>
         </div>
@@ -245,6 +262,17 @@ function formatDateTime(value: string): string {
     hour: "2-digit",
     minute: "2-digit"
   }).format(new Date(value));
+}
+
+function formatMessageTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(date);
 }
 
 function formatDuration(durationMs: number): string {


### PR DESCRIPTION
Closes #71

## Summary

- Show a readable sent time on every chat message.
- Scroll the chat message area to the newest message on load, refresh, session changes, and optimistic sends.
- Make the project chat panel use an internal scroll area so the project header stays visible while messages scroll.
- Adjust responsive chat header layout for narrow screens.

## Verification

- npm test
- npm run typecheck
- npm run build

## QA Notes

Please run the verification commands, then start npm run dev and open a project chat with enough messages to scroll. Confirm timestamps appear on user, assistant, and system messages; the chat opens at the latest message; sending a message keeps newest content visible; and the project header remains visible while scrolling the message list.