### PR TITLE
Fix triage grouping for closed blocked issues

### DIFF
--- a/scripts/triage-classifier.test.mjs
+++ b/scripts/triage-classifier.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyTriageIssue } from "../src/lib/triage-classifier.ts";
+
+const classify = (overrides = {}) => classifyTriageIssue({
+  issueState: "OPEN",
+  issueLabels: [],
+  primaryLinkedPrState: null,
+  primaryLinkedPrLabels: [],
+  ...overrides
+});
+
+describe("classifyTriageIssue", () => {
+  it("keeps closed blocked issues in blocked instead of done", () => {
+    assert.equal(classify({
+      issueState: "CLOSED",
+      issueLabels: ["taskix:blocked"]
+    }), "blocked");
+  });
+
+  it("keeps closed QA-failed issues in blocked instead of done", () => {
+    assert.equal(classify({
+      issueState: "CLOSED",
+      issueLabels: ["taskix:qa-failed"]
+    }), "blocked");
+
+    assert.equal(classify({
+      issueState: "CLOSED",
+      issueLabels: ["qa-failed"]
+    }), "blocked");
+  });
+
+  it("treats linked PR failed labels as blocked even when the issue is closed", () => {
+    assert.equal(classify({
+      issueState: "CLOSED",
+      primaryLinkedPrLabels: ["taskix:qa-failed"]
+    }), "blocked");
+  });
+
+  it("still marks closed unblocked issues as done", () => {
+    assert.equal(classify({
+      issueState: "CLOSED",
+      issueLabels: ["qa-passed"]
+    }), "done");
+  });
+
+  it("keeps merged linked PRs as done when no blocked labels exist", () => {
+    assert.equal(classify({
+      primaryLinkedPrState: "MERGED",
+      primaryLinkedPrLabels: ["taskix:qa-passed"]
+    }), "done");
+  });
+});

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { allTaskixLabels, roleLabel } from "@/lib/github-labels";
 import { dataDir } from "@/lib/paths";
-import type { IssueSpec, ProjectTriageGroup, ProjectTriageItem } from "@/lib/types";
+import { classifyTriageIssue } from "@/lib/triage-classifier";
+import type { IssueSpec, ProjectTriageItem } from "@/lib/types";
 
 const execFileAsync = promisify(execFile);
 
@@ -116,25 +117,6 @@ async function listLinkedPullRequestsWithGh(repo: string, issueNumber: number): 
 
 function pickPrimaryPullRequest(prs: GhTriagePr[]): GhTriagePr | null {
   return prs.find((pr) => pr.state === "OPEN") ?? prs[0] ?? null;
-}
-
-function classifyTriageIssue(input: {
-  issueState: string;
-  issueLabels: string[];
-  primaryLinkedPrState: string | null;
-  primaryLinkedPrLabels: string[];
-}): ProjectTriageGroup {
-  const labels = new Set([...input.issueLabels, ...input.primaryLinkedPrLabels].map((label) => label.toLowerCase()));
-  if (input.issueState === "CLOSED" || input.primaryLinkedPrState === "MERGED" || hasAnyLabel(labels, ["taskix:merged"])) return "done";
-  if (hasAnyLabel(labels, ["taskix:blocked", "qa-failed", "taskix:qa-failed"])) return "blocked";
-  if (hasAnyLabel(labels, ["taskix:need-qa", "qa-running", "taskix:qa-running"])) return "needs_qa";
-  if (hasAnyLabel(labels, ["taskix:ready-to-merge", "qa-passed", "taskix:qa-passed"])) return "ready_to_merge";
-  if (hasAnyLabel(labels, ["taskix:dev-running", "taskix:pr-opened"]) || input.primaryLinkedPrState === "OPEN") return "in_progress";
-  return "untracked";
-}
-
-function hasAnyLabel(labels: Set<string>, expected: string[]): boolean {
-  return expected.some((label) => labels.has(label));
 }
 
 export async function ensureTaskixLabels(repo: string): Promise<void> {

--- a/src/lib/triage-classifier.ts
+++ b/src/lib/triage-classifier.ts
@@ -1,0 +1,20 @@
+import type { ProjectTriageGroup } from "@/lib/types";
+
+export function classifyTriageIssue(input: {
+  issueState: string;
+  issueLabels: string[];
+  primaryLinkedPrState: string | null;
+  primaryLinkedPrLabels: string[];
+}): ProjectTriageGroup {
+  const labels = new Set([...input.issueLabels, ...input.primaryLinkedPrLabels].map((label) => label.toLowerCase()));
+  if (hasAnyLabel(labels, ["taskix:blocked", "qa-failed", "taskix:qa-failed"])) return "blocked";
+  if (input.issueState === "CLOSED" || input.primaryLinkedPrState === "MERGED" || hasAnyLabel(labels, ["taskix:merged"])) return "done";
+  if (hasAnyLabel(labels, ["taskix:need-qa", "qa-running", "taskix:qa-running"])) return "needs_qa";
+  if (hasAnyLabel(labels, ["taskix:ready-to-merge", "qa-passed", "taskix:qa-passed"])) return "ready_to_merge";
+  if (hasAnyLabel(labels, ["taskix:dev-running", "taskix:pr-opened"]) || input.primaryLinkedPrState === "OPEN") return "in_progress";
+  return "untracked";
+}
+
+function hasAnyLabel(labels: Set<string>, expected: string[]): boolean {
+  return expected.some((label) => labels.has(label));
+}


### PR DESCRIPTION
Closes #73

## Summary

- Move GitHub triage classification into a reusable pure helper.
- Make blocked and QA-failed labels take precedence over closed/merged done classification.
- Add deterministic Node tests covering closed blocked and QA-failed issue cases, including failed labels from linked PRs.

## Verification

- npm test
- npm run typecheck
- npm run build

## QA Notes

Please run the verification commands and confirm closed issues with taskix:blocked, qa-failed, or taskix:qa-failed are grouped as blocked instead of done by GET /api/projects/[projectId]/triage.