### PR TITLE
Show workflow step progress on project page

### DIFF
--- a/scripts/workflow-progress.test.mjs
+++ b/scripts/workflow-progress.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getWorkflowProgress } from "../src/lib/workflow-progress.ts";
+
+const workflow = (status, issues = []) => ({ status, issues });
+const job = (type, status) => ({ type, status });
+const issue = (overrides = {}) => ({
+  labels: [],
+  prLabels: [],
+  prUrl: null,
+  prState: null,
+  ...overrides
+});
+
+const currentStep = (steps) => steps.find((step) => step.status === "current" || step.status === "blocked");
+const step = (steps, id) => steps.find((item) => item.id === id);
+
+describe("getWorkflowProgress", () => {
+  it("starts empty projects at PM requirement", () => {
+    const steps = getWorkflowProgress({ workflows: [], jobs: [] });
+
+    assert.equal(currentStep(steps).id, "requirement");
+    assert.equal(step(steps, "planning").status, "upcoming");
+  });
+
+  it("marks planning current when architect work is queued", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("created")],
+      jobs: [job("workflow_run", "pending")]
+    });
+
+    assert.equal(currentStep(steps).id, "planning");
+    assert.equal(step(steps, "requirement").status, "complete");
+  });
+
+  it("marks developer current when issue work is queued", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("planned", [issue()])],
+      jobs: [job("issue_run", "pending")]
+    });
+
+    assert.equal(currentStep(steps).id, "developer");
+    assert.equal(step(steps, "planning").status, "complete");
+  });
+
+  it("moves PR-backed issues to QA", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("in_progress", [issue({ prUrl: "https://example.test/pr/1", prState: "OPEN" })])],
+      jobs: []
+    });
+
+    assert.equal(currentStep(steps).id, "qa");
+  });
+
+  it("moves QA-passed issues to ready to merge", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("in_progress", [issue({ labels: ["qa-passed"], prState: "OPEN" })])],
+      jobs: []
+    });
+
+    assert.equal(currentStep(steps).id, "merge");
+  });
+
+  it("shows failed developer jobs as blocked", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("in_progress", [issue()])],
+      jobs: [job("issue_run", "failed")]
+    });
+
+    assert.equal(currentStep(steps).id, "developer");
+    assert.equal(currentStep(steps).status, "blocked");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -357,6 +357,63 @@ body {
   border-radius: 16px;
 }
 
+.workflow-progress {
+  padding: 14px;
+  background: #ffffff;
+  border: 1px solid #d8e3f2;
+  border-radius: 16px;
+}
+
+.workflow-progress-step {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 10px;
+  padding: 8px 0;
+  position: relative;
+}
+
+.workflow-progress-step:not(:last-child)::after {
+  position: absolute;
+  top: 24px;
+  bottom: -8px;
+  left: 7px;
+  width: 2px;
+  content: "";
+  background: #dbe5f3;
+}
+
+.workflow-progress-marker {
+  position: relative;
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  background: #ffffff;
+  border: 2px solid #cbd5e1;
+  border-radius: 50%;
+}
+
+.workflow-progress-step.complete .workflow-progress-marker {
+  background: #16a34a;
+  border-color: #16a34a;
+}
+
+.workflow-progress-step.current .workflow-progress-marker {
+  background: #2563eb;
+  border-color: #bfdbfe;
+  box-shadow: 0 0 0 3px #dbeafe;
+}
+
+.workflow-progress-step.blocked .workflow-progress-marker {
+  background: #dc2626;
+  border-color: #fecaca;
+  box-shadow: 0 0 0 3px #fee2e2;
+}
+
+.workflow-progress-step.upcoming .workflow-progress-copy {
+  opacity: 0.72;
+}
+
 .workflow-next-action-icon {
   display: grid;
   flex: 0 0 auto;

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -11,6 +11,7 @@ import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { findReadyForArchitectPayload } from "@/lib/pm-handoff";
 import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
+import { getWorkflowProgress, type WorkflowProgressStep } from "@/lib/workflow-progress";
 import { getWorkflowNextAction, type WorkflowNextAction } from "@/lib/workflow-next-action";
 
 export default async function ProjectDetailPage({
@@ -48,6 +49,7 @@ export default async function ProjectDetailPage({
   const visibleActiveWorkflows = prioritizeById(activeWorkflows, queuedWorkflowId);
   const readyForArchitectPayload = findReadyForArchitectPayload(pmSession ?? (activeRole === "product_manager" ? roleSession : null));
   const nextAction = getWorkflowNextAction(jobs);
+  const workflowProgress = getWorkflowProgress({ workflows, jobs });
 
   return (
     <>
@@ -106,6 +108,7 @@ export default async function ProjectDetailPage({
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
               {!isInspectingIssueSession && <ProjectHandoffForm projectId={project.projectId} payload={readyForArchitectPayload} />}
+              <WorkflowProgressList steps={workflowProgress} />
               <div className="workflow-next-action">
                 <Group justify="space-between" gap="sm" align="flex-start">
                   <Group gap="sm" align="flex-start" wrap="nowrap">
@@ -306,6 +309,59 @@ function renderWorkflowNextActionIcon(action: WorkflowNextAction): ReactNode {
       return <AlertCircle size={18} />;
     case "check":
       return <CheckCircle2 size={18} />;
+  }
+}
+
+function WorkflowProgressList({ steps }: { steps: WorkflowProgressStep[] }) {
+  return (
+    <div className="workflow-progress">
+      <Group justify="space-between" gap="xs" mb="xs">
+        <Text fw={760}>Current workflow step</Text>
+        <Badge size="xs" variant="light">{steps.find((step) => step.status === "current" || step.status === "blocked")?.label ?? "Workflow"}</Badge>
+      </Group>
+      <Stack gap={0}>
+        {steps.map((step) => (
+          <div key={step.id} className={`workflow-progress-step ${step.status}`}>
+            <div className="workflow-progress-marker" aria-hidden="true" />
+            <div className="workflow-progress-copy">
+              <Group gap="xs" justify="space-between" align="flex-start">
+                <Text size="sm" fw={760}>{step.label}</Text>
+                <Badge size="xs" color={workflowProgressStatusColor(step.status)} variant={step.status === "upcoming" ? "outline" : "light"}>
+                  {workflowProgressStatusLabel(step.status)}
+                </Badge>
+              </Group>
+              <Text size="xs" c="dimmed" mt={2}>{step.detail}</Text>
+            </div>
+          </div>
+        ))}
+      </Stack>
+    </div>
+  );
+}
+
+function workflowProgressStatusLabel(status: WorkflowProgressStep["status"]): string {
+  switch (status) {
+    case "complete":
+      return "Done";
+    case "current":
+      return "Current";
+    case "blocked":
+      return "Blocked";
+    case "upcoming":
+      return "Next";
+  }
+}
+
+function workflowProgressStatusColor(status: WorkflowProgressStep["status"]): string {
+  switch (status) {
+    case "complete":
+      return "green";
+    case "current":
+      return "blue";
+    case "blocked":
+      return "red";
+    case "upcoming":
+      return "gray";
   }
 }
 

--- a/src/lib/workflow-progress.ts
+++ b/src/lib/workflow-progress.ts
@@ -1,0 +1,104 @@
+import type { IssueRecord, JobRecord, WorkflowRecord } from "@/lib/types";
+
+export type WorkflowProgressStepId = "requirement" | "planning" | "developer" | "qa" | "merge" | "done";
+export type WorkflowProgressStepStatus = "complete" | "current" | "blocked" | "upcoming";
+
+export type WorkflowProgressStep = {
+  id: WorkflowProgressStepId;
+  label: string;
+  detail: string;
+  status: WorkflowProgressStepStatus;
+};
+
+const stepOrder: WorkflowProgressStepId[] = ["requirement", "planning", "developer", "qa", "merge", "done"];
+
+const stepCopy: Record<WorkflowProgressStepId, { label: string; detail: string }> = {
+  requirement: {
+    label: "1. PM requirement",
+    detail: "Capture the request in chat, then queue it for architect planning."
+  },
+  planning: {
+    label: "2. Architect planning",
+    detail: "Split the request into GitHub issues and developer-owned work."
+  },
+  developer: {
+    label: "3. Developer PR",
+    detail: "Run one planned developer issue and create a pull request."
+  },
+  qa: {
+    label: "4. QA validation",
+    detail: "Run automated tests first, then verify the targeted browser flow."
+  },
+  merge: {
+    label: "5. Ready to merge",
+    detail: "Wait for QA pass and architect merge readiness."
+  },
+  done: {
+    label: "6. Done",
+    detail: "The workflow is complete or there is no active work left."
+  }
+};
+
+export function getWorkflowProgress(input: {
+  workflows: Pick<WorkflowRecord, "status" | "issues">[];
+  jobs: Pick<JobRecord, "status" | "type">[];
+}): WorkflowProgressStep[] {
+  const workflows = input.workflows;
+  const jobs = input.jobs;
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  const hasAnyWorkflow = workflows.length > 0;
+  const hasActiveWorkflow = workflows.some((workflow) => workflow.status !== "done");
+  const hasDoneWorkflow = workflows.some((workflow) => workflow.status === "done");
+  const blockedStep = getBlockedStep(workflows, jobs, issues);
+  const currentStep = blockedStep ?? getCurrentStep({ hasAnyWorkflow, hasActiveWorkflow, hasDoneWorkflow, issues, jobs });
+  const currentIndex = stepOrder.indexOf(currentStep);
+
+  return stepOrder.map((id, index) => ({
+    id,
+    label: stepCopy[id].label,
+    detail: stepCopy[id].detail,
+    status: blockedStep === id ? "blocked" : index < currentIndex || isDoneComplete(id, hasDoneWorkflow, hasActiveWorkflow) ? "complete" : id === currentStep ? "current" : "upcoming"
+  }));
+}
+
+function getBlockedStep(
+  workflows: Pick<WorkflowRecord, "status">[],
+  jobs: Pick<JobRecord, "status" | "type">[],
+  issues: Pick<IssueRecord, "labels" | "prLabels" | "prUrl" | "prState">[]
+): WorkflowProgressStepId | null {
+  if (jobs.some((job) => job.status === "failed" && job.type === "workflow_run")) return "planning";
+  if (jobs.some((job) => job.status === "failed" && job.type === "issue_run")) return "developer";
+  if (workflows.some((workflow) => workflow.status === "blocked")) return "developer";
+  if (issues.some((issue) => hasAnyIssueLabel(issue, ["qa-failed", "taskix:qa-failed"]))) return "qa";
+  const blockedIssue = issues.find((issue) => hasAnyIssueLabel(issue, ["taskix:blocked"]));
+  if (blockedIssue) return blockedIssue.prUrl || blockedIssue.prState ? "qa" : "developer";
+  return null;
+}
+
+function getCurrentStep(input: {
+  hasAnyWorkflow: boolean;
+  hasActiveWorkflow: boolean;
+  hasDoneWorkflow: boolean;
+  issues: Pick<IssueRecord, "labels" | "prLabels" | "prUrl" | "prState">[];
+  jobs: Pick<JobRecord, "status" | "type">[];
+}): WorkflowProgressStepId {
+  if (!input.hasAnyWorkflow && !input.jobs.length) return "requirement";
+  if (input.jobs.some((job) => job.status !== "done" && job.type === "workflow_run")) return "planning";
+  if (input.jobs.some((job) => job.status !== "done" && job.type === "issue_run")) return "developer";
+  if (input.issues.some((issue) => hasAnyIssueLabel(issue, ["taskix:ready-to-merge"]))) return "merge";
+  if (input.issues.some((issue) => hasAnyIssueLabel(issue, ["qa-passed", "taskix:qa-passed"]))) return "merge";
+  if (input.issues.some((issue) => issue.prUrl || issue.prState)) return "qa";
+  if (input.issues.length) return "developer";
+  if (input.hasActiveWorkflow) return "planning";
+  if (input.hasDoneWorkflow) return "done";
+  return "requirement";
+}
+
+function isDoneComplete(id: WorkflowProgressStepId, hasDoneWorkflow: boolean, hasActiveWorkflow: boolean): boolean {
+  return id === "done" && hasDoneWorkflow && !hasActiveWorkflow;
+}
+
+function hasAnyIssueLabel(issue: Pick<IssueRecord, "labels" | "prLabels">, expected: string[]): boolean {
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
+  return expected.some((label) => labels.has(label));
+}


### PR DESCRIPTION
Closes #75

## Summary

- Add a six-step workflow progress panel to the project detail Workflows sidebar.
- Show PM requirement, architect planning, developer PR, QA validation, ready to merge, and done states.
- Mark each step as Done, Current, Blocked, or Next based on workflows, jobs, and issue labels.
- Keep the existing next action, job cards, workflow cards, sync, and session areas below the clearer progress view.
- Add deterministic tests for workflow progress derivation.

## Verification

- npm test
- npm run typecheck
- npm run build

## QA Notes

Please run the verification commands, then open projects in empty, planning/developer pending, blocked, PR/QA, and completed states. Confirm the right-side Workflows panel clearly shows where the project is and what the operator should do next.