### PR TITLE
Make workflow progress stepper explicit

### DIFF
--- a/scripts/workflow-next-action.test.mjs
+++ b/scripts/workflow-next-action.test.mjs
@@ -50,7 +50,7 @@ describe("getWorkflowNextAction", () => {
   it("marks failed jobs as blocked", () => {
     const action = getWorkflowNextAction([job("issue_run", "failed")]);
 
-    assert.equal(action.title, "Blocked job needs attention");
+    assert.equal(action.title, "Resolve blocker before continuing");
     assert.equal(action.buttonLabel, null);
     assert.equal(action.disabledLabel, "Blocked");
     assert.equal(action.tone, "blocked");

--- a/scripts/workflow-progress.test.mjs
+++ b/scripts/workflow-progress.test.mjs
@@ -12,7 +12,7 @@ const issue = (overrides = {}) => ({
   ...overrides
 });
 
-const currentStep = (steps) => steps.find((step) => step.status === "current" || step.status === "blocked");
+const currentStep = (steps) => steps.find((step) => step.status === "current" || step.status === "running" || step.status === "blocked");
 const step = (steps, id) => steps.find((item) => item.id === id);
 
 describe("getWorkflowProgress", () => {
@@ -41,6 +41,26 @@ describe("getWorkflowProgress", () => {
 
     assert.equal(currentStep(steps).id, "developer");
     assert.equal(step(steps, "planning").status, "complete");
+  });
+
+  it("marks running workflow jobs on the planning step", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("created")],
+      jobs: [job("workflow_run", "running")]
+    });
+
+    assert.equal(currentStep(steps).id, "planning");
+    assert.equal(currentStep(steps).status, "running");
+  });
+
+  it("marks running developer jobs on the developer step", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("planned", [issue()])],
+      jobs: [job("issue_run", "running")]
+    });
+
+    assert.equal(currentStep(steps).id, "developer");
+    assert.equal(currentStep(steps).status, "running");
   });
 
   it("moves PR-backed issues to QA", () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -456,6 +456,43 @@ body {
   opacity: 0.72;
 }
 
+.workflow-progress-detail {
+  margin-top: 8px;
+}
+
+.workflow-progress-detail summary {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  color: #1d4ed8;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 760;
+  list-style: none;
+}
+
+.workflow-progress-detail summary::-webkit-details-marker {
+  display: none;
+}
+
+.workflow-progress-detail summary::after {
+  margin-left: 6px;
+  content: "+";
+  font-weight: 850;
+}
+
+.workflow-progress-detail[open] summary::after {
+  content: "-";
+}
+
+.workflow-progress-detail-body {
+  margin-top: 8px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid #e0e7f0;
+  border-radius: 12px;
+}
+
 .workflow-progress-action {
   margin-top: 12px;
   padding: 12px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -583,6 +583,17 @@ pre,
   border-radius: 16px;
 }
 
+.workflow-control-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 11px;
+  background: #ffffff;
+  border: 1px solid #dbe5f3;
+  border-radius: 14px;
+}
+
 .workflow-summary-card + .workflow-summary-card {
   margin-top: 2px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -387,40 +387,35 @@ pre,
 }
 
 .workflow-progress {
-  padding: 14px;
-  background: #ffffff;
-  border: 1px solid #d8e3f2;
-  border-radius: 16px;
+  padding: 0;
 }
 
 .workflow-progress-summary {
-  padding: 12px;
+  padding: 10px 12px;
   background: #f8fbff;
-  border: 1px solid #d8e3f2;
-  border-radius: 12px;
+  border-left: 4px solid #cbd5e1;
+  border-radius: 8px;
 }
 
 .workflow-progress-summary.current {
   background: #eff6ff;
-  border-color: #bfdbfe;
+  border-left-color: #2563eb;
 }
 
 .workflow-progress-summary.blocked {
   background: #fff1f2;
-  border-color: #fecdd3;
+  border-left-color: #dc2626;
 }
 
 .workflow-progress-summary.complete {
   background: #f0fdf4;
-  border-color: #bbf7d0;
+  border-left-color: #16a34a;
 }
 
 .workflow-progress-controls {
-  margin-top: 12px;
-  padding: 10px;
-  background: #f8fbff;
-  border: 1px solid #dbe5f3;
-  border-radius: 12px;
+  margin-top: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid #e5edf6;
 }
 
 .workflow-progress-step {
@@ -429,8 +424,7 @@ pre,
   gap: 12px;
   padding: 8px;
   position: relative;
-  border: 1px solid transparent;
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
 .workflow-progress-step:not(:last-child)::after {
@@ -445,12 +439,10 @@ pre,
 
 .workflow-progress-step.current {
   background: #eff6ff;
-  border-color: #bfdbfe;
 }
 
 .workflow-progress-step.blocked {
   background: #fff1f2;
-  border-color: #fecdd3;
 }
 
 .workflow-progress-marker {
@@ -524,33 +516,26 @@ pre,
 
 .workflow-progress-detail-body {
   margin-top: 8px;
-  padding: 10px;
-  background: rgba(255, 255, 255, 0.74);
-  border: 1px solid #e0e7f0;
-  border-radius: 12px;
+  padding: 2px 0 2px 10px;
+  border-left: 2px solid #dbe5f3;
 }
 
 .workflow-progress-action {
   margin-top: 12px;
-  padding: 12px;
-  background: #f8fbff;
-  border: 1px solid #d8e3f2;
-  border-radius: 12px;
+  padding: 12px 0 0;
+  border-top: 1px solid #e5edf6;
 }
 
 .workflow-progress-action.ready {
-  background: #eff6ff;
-  border-color: #bfdbfe;
+  border-top-color: #bfdbfe;
 }
 
 .workflow-progress-action.running {
-  background: #f0f9ff;
-  border-color: #bae6fd;
+  border-top-color: #bae6fd;
 }
 
 .workflow-progress-action.blocked {
-  background: #fff1f2;
-  border-color: #fecdd3;
+  border-top-color: #fecdd3;
 }
 
 .workflow-next-action-icon {
@@ -596,10 +581,36 @@ pre,
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 10px 11px;
-  background: #ffffff;
-  border: 1px solid #dbe5f3;
-  border-radius: 14px;
+  padding: 8px 0;
+  border-top: 1px solid #eef2f7;
+}
+
+.workflow-control-row:first-of-type {
+  border-top: 0;
+}
+
+.workflow-progress-detail-body .workflow-job-row,
+.workflow-progress-detail-body .session-row,
+.workflow-progress-detail-body .completed-workflow-row {
+  padding: 8px 0;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid #eef2f7;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.workflow-progress-detail-body .workflow-job-row:first-child,
+.workflow-progress-detail-body .session-row:first-child,
+.workflow-progress-detail-body .completed-workflow-row:first-child {
+  border-top: 0;
+}
+
+.workflow-progress-detail-body .session-row:hover,
+.workflow-progress-detail-body .completed-workflow-row:hover {
+  border-color: #eef2f7;
+  box-shadow: none;
+  transform: none;
 }
 
 .workflow-summary-card + .workflow-summary-card {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -415,6 +415,14 @@ pre,
   border-color: #bbf7d0;
 }
 
+.workflow-progress-controls {
+  margin-top: 12px;
+  padding: 10px;
+  background: #f8fbff;
+  border: 1px solid #dbe5f3;
+  border-radius: 12px;
+}
+
 .workflow-progress-step {
   display: grid;
   grid-template-columns: 30px minmax(0, 1fr);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -402,6 +402,11 @@ pre,
   border-left-color: #2563eb;
 }
 
+.workflow-progress-summary.running {
+  background: #f0f9ff;
+  border-left-color: #0284c7;
+}
+
 .workflow-progress-summary.blocked {
   background: #fff1f2;
   border-left-color: #dc2626;
@@ -441,6 +446,10 @@ pre,
   background: #eff6ff;
 }
 
+.workflow-progress-step.running {
+  background: #f0f9ff;
+}
+
 .workflow-progress-step.blocked {
   background: #fff1f2;
 }
@@ -472,6 +481,13 @@ pre,
   background: #2563eb;
   border-color: #bfdbfe;
   box-shadow: 0 0 0 3px #dbeafe;
+}
+
+.workflow-progress-step.running .workflow-progress-marker {
+  color: #ffffff;
+  background: #0284c7;
+  border-color: #bae6fd;
+  box-shadow: 0 0 0 3px #e0f2fe;
 }
 
 .workflow-progress-step.blocked .workflow-progress-marker {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -364,47 +364,89 @@ body {
   border-radius: 16px;
 }
 
+.workflow-progress-summary {
+  padding: 12px;
+  background: #f8fbff;
+  border: 1px solid #d8e3f2;
+  border-radius: 12px;
+}
+
+.workflow-progress-summary.current {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.workflow-progress-summary.blocked {
+  background: #fff1f2;
+  border-color: #fecdd3;
+}
+
+.workflow-progress-summary.complete {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
 .workflow-progress-step {
   display: grid;
-  grid-template-columns: 20px minmax(0, 1fr);
-  gap: 10px;
-  padding: 8px 0;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px;
   position: relative;
+  border: 1px solid transparent;
+  border-radius: 12px;
 }
 
 .workflow-progress-step:not(:last-child)::after {
   position: absolute;
-  top: 24px;
-  bottom: -8px;
-  left: 7px;
+  top: 38px;
+  bottom: -12px;
+  left: 22px;
   width: 2px;
   content: "";
   background: #dbe5f3;
 }
 
+.workflow-progress-step.current {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.workflow-progress-step.blocked {
+  background: #fff1f2;
+  border-color: #fecdd3;
+}
+
 .workflow-progress-marker {
+  display: grid;
+  place-items: center;
   position: relative;
   z-index: 1;
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
+  width: 30px;
+  height: 30px;
+  margin-top: 0;
+  color: #64748b;
   background: #ffffff;
   border: 2px solid #cbd5e1;
   border-radius: 50%;
+  font-size: 12px;
+  font-weight: 850;
 }
 
 .workflow-progress-step.complete .workflow-progress-marker {
+  color: #ffffff;
   background: #16a34a;
   border-color: #16a34a;
 }
 
 .workflow-progress-step.current .workflow-progress-marker {
+  color: #ffffff;
   background: #2563eb;
   border-color: #bfdbfe;
   box-shadow: 0 0 0 3px #dbeafe;
 }
 
 .workflow-progress-step.blocked .workflow-progress-marker {
+  color: #ffffff;
   background: #dc2626;
   border-color: #fecaca;
   box-shadow: 0 0 0 3px #fee2e2;
@@ -412,6 +454,29 @@ body {
 
 .workflow-progress-step.upcoming .workflow-progress-copy {
   opacity: 0.72;
+}
+
+.workflow-progress-action {
+  margin-top: 12px;
+  padding: 12px;
+  background: #f8fbff;
+  border: 1px solid #d8e3f2;
+  border-radius: 12px;
+}
+
+.workflow-progress-action.ready {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.workflow-progress-action.running {
+  background: #f0f9ff;
+  border-color: #bae6fd;
+}
+
+.workflow-progress-action.blocked {
+  background: #fff1f2;
+  border-color: #fecdd3;
 }
 
 .workflow-next-action-icon {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,7 +220,7 @@ body {
 
 .project-chat-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 360px;
+  grid-template-columns: minmax(520px, 1fr) minmax(430px, 34vw);
   gap: 18px;
   align-items: start;
 }
@@ -767,7 +767,7 @@ body {
   scrollbar-gutter: stable;
 }
 
-@media (max-width: 1040px) {
+@media (max-width: 1180px) {
   .layout {
     grid-template-columns: 1fr;
   }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
 import { AlertCircle, Bot, CheckCircle2, Clock, GitBranch, Info, Play, Wrench } from "lucide-react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
@@ -11,6 +11,7 @@ import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { findReadyForArchitectPayload } from "@/lib/pm-handoff";
 import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
+import type { AgentSessionRecord, IssueRecord, JobRecord, WorkflowRecord } from "@/lib/types";
 import { getWorkflowProgress, type WorkflowProgressStep } from "@/lib/workflow-progress";
 import { getWorkflowNextAction, type WorkflowNextAction } from "@/lib/workflow-next-action";
 
@@ -45,11 +46,26 @@ export default async function ProjectDetailPage({
   const queuedJobId = query.job ?? null;
   const queuedWorkflow = queuedWorkflowId ? workflows.find((workflow) => workflow.workflowId === queuedWorkflowId) ?? null : null;
   const queuedJob = queuedJobId ? jobs.find((job) => job.jobId === queuedJobId) ?? null : null;
-  const visibleJobs = prioritizeById(jobs, queuedJobId).slice(0, 4);
   const visibleActiveWorkflows = prioritizeById(activeWorkflows, queuedWorkflowId);
   const readyForArchitectPayload = findReadyForArchitectPayload(pmSession ?? (activeRole === "product_manager" ? roleSession : null));
   const nextAction = getWorkflowNextAction(jobs);
   const workflowProgress = getWorkflowProgress({ workflows, jobs });
+  const workflowStepDetails = buildWorkflowStepDetails({
+    projectId: project.projectId,
+    isInspectingIssueSession,
+    readyForArchitectPayload,
+    pmSession,
+    sessions,
+    dynamicSessions,
+    archivedSessions,
+    jobs,
+    activeWorkflows,
+    doneWorkflows,
+    visibleActiveWorkflows,
+    queuedWorkflow,
+    queuedJob,
+    queuedJobId
+  });
 
   return (
     <>
@@ -107,144 +123,7 @@ export default async function ProjectDetailPage({
             </Group>
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
-              {!isInspectingIssueSession && <ProjectHandoffForm projectId={project.projectId} payload={readyForArchitectPayload} />}
-              <WorkflowProgressList steps={workflowProgress} nextAction={nextAction} projectId={project.projectId} />
-              {query.queued === "1" && queuedWorkflow ? (
-                <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
-                  <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
-                  <Text size="xs" c="dimmed">
-                    {queuedWorkflow.trackingCode ?? queuedWorkflow.workflowId} is waiting in the workflow area below.
-                    {queuedJob ? ` Pending job: ${queuedJob.type} (${queuedJob.status}).` : ""}
-                  </Text>
-                </Alert>
-              ) : null}
-              {visibleJobs.map((job) => (
-                <div
-                  key={job.jobId}
-                  className="workflow-job-row"
-                  style={job.jobId === queuedJobId ? highlightedCardStyle : undefined}
-                >
-                  <Group justify="space-between" gap="xs" wrap="nowrap">
-                    <Text size="sm" fw={700}>{job.type}</Text>
-                    <Badge size="xs" variant="light">{job.status}</Badge>
-                  </Group>
-                  <Text size="xs" c="dimmed" mt={4}>
-                    Job {job.jobId}
-                    {job.payload.workflowId ? ` · workflow ${job.payload.workflowId}` : ""}
-                    {job.error ? ` · ${job.error}` : ""}
-                  </Text>
-                </div>
-              ))}
-              {!visibleJobs.length ? <Text c="dimmed" size="sm">No queued jobs yet.</Text> : null}
-              {visibleActiveWorkflows.map((workflow) => (
-                <div
-                  key={workflow.workflowId}
-                  className="workflow-summary-card"
-                  style={workflow.workflowId === queuedWorkflowId ? highlightedCardStyle : undefined}
-                >
-                  <Group justify="space-between" gap="xs">
-                    <div>
-                      <Text fw={700} size="sm">
-                        {workflow.trackingCode ?? workflow.workflowId} · {workflow.paused ? "paused" : workflow.status}
-                      </Text>
-                      <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
-                    </div>
-                    <Group gap={6}>
-                      <Button
-                        component="a"
-                        href={`/projects/${project.projectId}/workflows/${workflow.workflowId}`}
-                        variant="light"
-                        size="compact-xs"
-                        radius="xl"
-                      >
-                        Open
-                      </Button>
-                      <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
-                    </Group>
-                  </Group>
-                  {workflow.issues.map((issue) => {
-                    const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
-                    const qaStatus = getIssueQaStatus(issue, qaSession);
-                    return (
-                      <Group key={issue.issueId} gap={6} wrap="nowrap">
-                        <Text size="xs" c="dimmed" lineClamp={1}>
-                          {issue.issueId}: {issue.title} · {issue.developerRole ?? issue.assigneeRole}
-                          {issue.prState ? ` · PR ${issue.prState}` : ""}
-                        </Text>
-                        <Badge color={qaStatus.color} size="xs" variant="light">{qaStatus.label}</Badge>
-                      </Group>
-                    );
-                  })}
-                </div>
-              ))}
-              {doneWorkflows.length ? (
-                <details className="completed-workflows">
-                  <summary>
-                    Completed workflows <span>{doneWorkflows.length}</span>
-                  </summary>
-                  <Stack gap="xs" mt="xs">
-                    {doneWorkflows.slice(0, 6).map((workflow) => (
-                      <a key={workflow.workflowId} href={`/projects/${project.projectId}/workflows/${workflow.workflowId}`} className="completed-workflow-row">
-                        <Group justify="space-between" wrap="nowrap">
-                          <Text size="sm" fw={700} lineClamp={1}>{workflow.trackingCode ?? workflow.workflowId}</Text>
-                          <Badge size="xs" variant="light">done</Badge>
-                        </Group>
-                        <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
-                      </a>
-                    ))}
-                    {doneWorkflows.length > 6 ? (
-                      <Text size="xs" c="dimmed">Showing latest 6 completed workflows.</Text>
-                    ) : null}
-                  </Stack>
-                </details>
-              ) : null}
-              {!activeWorkflows.length && !doneWorkflows.length && <Text c="dimmed" size="sm">No workflows yet.</Text>}
-            </Stack>
-          </Paper>
-
-          <Paper mt="md">
-            <Group justify="space-between" p="md" className="section-header">
-              <div>
-                <Text fw={760}>Sessions</Text>
-                <Text size="sm" c="dimmed">Dynamic developer and QA contexts.</Text>
-              </div>
-              <Group gap="xs">
-                <Badge variant="light">{dynamicSessions.length} active</Badge>
-                {archivedSessions.length ? <Badge variant="outline">{archivedSessions.length} archived</Badge> : null}
-              </Group>
-            </Group>
-            <Stack p="md" gap="xs">
-              {dynamicSessions.map((session) => (
-                <a key={session.sessionKey} href={`/projects/${project.projectId}?session=${encodeURIComponent(session.sessionKey)}`} className="session-row">
-                  <Group justify="space-between" align="center" wrap="nowrap">
-                    <div>
-                      <Text size="sm" fw={720} lineClamp={1}>{session.title}</Text>
-                      <Text size="xs" c="dimmed" lineClamp={1}>
-                        {session.issueId ?? session.role}
-                        {session.developerRole ? ` · ${session.developerRole}` : ""}
-                        {session.durationMs != null ? ` · ${formatDuration(session.durationMs)}` : ""}
-                      </Text>
-                    </div>
-                    <Badge size="xs" variant="light">{session.status}</Badge>
-                  </Group>
-                  {session.currentStep ? <Text size="xs" c="dimmed" lineClamp={1}>{session.currentStep}</Text> : null}
-                  {session.ownedPaths?.length ? <Text size="xs" c="dimmed" lineClamp={1}>Paths: {session.ownedPaths.join(", ")}</Text> : null}
-                </a>
-              ))}
-              {archivedSessions.slice(0, 3).map((session) => (
-                <a key={session.sessionKey} href={`/projects/${project.projectId}?session=${encodeURIComponent(session.sessionKey)}`} className="session-row archived">
-                  <Group justify="space-between" align="center" wrap="nowrap">
-                    <div>
-                      <Text size="sm" fw={720} lineClamp={1}>{session.title}</Text>
-                      <Text size="xs" c="dimmed" lineClamp={1}>
-                        archived{session.archivedAt ? ` · ${formatDate(session.archivedAt)}` : ""}
-                      </Text>
-                    </div>
-                    <Badge size="xs" variant="outline">{session.status}</Badge>
-                  </Group>
-                </a>
-              ))}
-              {!dynamicSessions.length && <Text c="dimmed" size="sm">No dynamic sessions yet.</Text>}
+              <WorkflowProgressList steps={workflowProgress} nextAction={nextAction} projectId={project.projectId} stepDetails={workflowStepDetails} />
             </Stack>
           </Paper>
         </aside>
@@ -268,6 +147,207 @@ const highlightedCardStyle = {
   background: "#eff6ff"
 } satisfies CSSProperties;
 
+type ProjectHandoffPayload = ComponentProps<typeof ProjectHandoffForm>["payload"];
+
+function buildWorkflowStepDetails(input: {
+  projectId: string;
+  isInspectingIssueSession: boolean;
+  readyForArchitectPayload: ProjectHandoffPayload;
+  pmSession: AgentSessionRecord | undefined;
+  sessions: AgentSessionRecord[];
+  dynamicSessions: AgentSessionRecord[];
+  archivedSessions: AgentSessionRecord[];
+  jobs: JobRecord[];
+  activeWorkflows: WorkflowRecord[];
+  doneWorkflows: WorkflowRecord[];
+  visibleActiveWorkflows: WorkflowRecord[];
+  queuedWorkflow: WorkflowRecord | null;
+  queuedJob: JobRecord | null;
+  queuedJobId: string | null;
+}): Record<WorkflowProgressStep["id"], ReactNode> {
+  const developerSessions = input.dynamicSessions.filter((session) => session.role === "developer");
+  const qaSessions = input.dynamicSessions.filter((session) => session.role === "qa");
+
+  return {
+    requirement: (
+      <Stack gap="xs">
+        <Text size="xs" c="dimmed">PM chat is the source of the requirement before it becomes planned work.</Text>
+        {input.pmSession ? <SessionLink session={input.pmSession} /> : <Text size="xs" c="dimmed">No PM session has been recorded yet.</Text>}
+        {!input.isInspectingIssueSession ? <ProjectHandoffForm projectId={input.projectId} payload={input.readyForArchitectPayload} /> : null}
+      </Stack>
+    ),
+    planning: (
+      <Stack gap="xs">
+        {input.queuedWorkflow ? (
+          <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
+            <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
+            <Text size="xs" c="dimmed">
+              {input.queuedWorkflow.trackingCode ?? input.queuedWorkflow.workflowId} is waiting for the planning step.
+              {input.queuedJob ? ` Pending job: ${input.queuedJob.type} (${input.queuedJob.status}).` : ""}
+            </Text>
+          </Alert>
+        ) : null}
+        {renderJobRows(input.jobs.filter((job) => job.type === "workflow_run"), input.queuedJobId)}
+        {renderSessionRows(input.sessions.filter((session) => session.role === "architect"))}
+      </Stack>
+    ),
+    developer: (
+      <Stack gap="xs">
+        {renderJobRows(input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
+        {renderWorkflowCards(input.projectId, input.visibleActiveWorkflows, input.sessions)}
+        {renderSessionRows(developerSessions)}
+      </Stack>
+    ),
+    qa: (
+      <Stack gap="xs">
+        {renderQaIssueRows(input.activeWorkflows, input.sessions)}
+        {renderSessionRows(qaSessions)}
+      </Stack>
+    ),
+    merge: (
+      <Stack gap="xs">
+        {renderMergeIssueRows(input.activeWorkflows)}
+      </Stack>
+    ),
+    done: (
+      <Stack gap="xs">
+        {renderCompletedWorkflowRows(input.projectId, input.doneWorkflows)}
+        {renderSessionRows(input.archivedSessions.slice(0, 4), true)}
+      </Stack>
+    )
+  };
+}
+
+function renderJobRows(jobs: JobRecord[], queuedJobId: string | null): ReactNode {
+  if (!jobs.length) return <Text size="xs" c="dimmed">No jobs recorded for this step.</Text>;
+  return jobs.slice(0, 4).map((job) => (
+    <div
+      key={job.jobId}
+      className="workflow-job-row"
+      style={job.jobId === queuedJobId ? highlightedCardStyle : undefined}
+    >
+      <Group justify="space-between" gap="xs" wrap="nowrap">
+        <Text size="sm" fw={700}>{job.type}</Text>
+        <Badge size="xs" variant="light">{job.status}</Badge>
+      </Group>
+      <Text size="xs" c="dimmed" mt={4}>
+        Job {job.jobId}
+        {job.payload.workflowId ? ` · workflow ${job.payload.workflowId}` : ""}
+        {job.error ? ` · ${job.error}` : ""}
+      </Text>
+    </div>
+  ));
+}
+
+function renderWorkflowCards(projectId: string, workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
+  if (!workflows.length) return <Text size="xs" c="dimmed">No active workflow details for this step.</Text>;
+  return workflows.map((workflow) => (
+    <div key={workflow.workflowId} className="workflow-summary-card">
+      <Group justify="space-between" gap="xs">
+        <div>
+          <Text fw={700} size="sm">
+            {workflow.trackingCode ?? workflow.workflowId} · {workflow.paused ? "paused" : workflow.status}
+          </Text>
+          <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
+        </div>
+        <Group gap={6}>
+          <Button component="a" href={`/projects/${projectId}/workflows/${workflow.workflowId}`} variant="light" size="compact-xs" radius="xl">
+            Open
+          </Button>
+          <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
+        </Group>
+      </Group>
+      {workflow.issues.map((issue) => {
+        const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
+        const qaStatus = getIssueQaStatus(issue, qaSession);
+        return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={qaStatus} />;
+      })}
+    </div>
+  ));
+}
+
+function renderQaIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
+  const issues = workflows.flatMap((workflow) => workflow.issues).filter((issue) => issue.prUrl || issue.prState || issue.qaSessionId);
+  if (!issues.length) return <Text size="xs" c="dimmed">No QA-ready issues yet.</Text>;
+  return issues.map((issue) => {
+    const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
+    return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={getIssueQaStatus(issue, qaSession)} />;
+  });
+}
+
+function renderMergeIssueRows(workflows: WorkflowRecord[]): ReactNode {
+  const issues = workflows.flatMap((workflow) => workflow.issues).filter((issue) => hasAnyLabel(issue, ["qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"]));
+  if (!issues.length) return <Text size="xs" c="dimmed">No QA-passed or ready-to-merge issues yet.</Text>;
+  return issues.map((issue) => (
+    <div key={issue.issueId} className="workflow-job-row">
+      <Group justify="space-between" gap="xs" wrap="nowrap">
+        <Text size="sm" fw={700} lineClamp={1}>{issue.title}</Text>
+        <Badge size="xs" color="green" variant="light">ready</Badge>
+      </Group>
+      <Text size="xs" c="dimmed" mt={4}>
+        {issue.githubIssueNumber ? `Issue #${issue.githubIssueNumber}` : issue.issueId}
+        {issue.prState ? ` · PR ${issue.prState}` : ""}
+      </Text>
+    </div>
+  ));
+}
+
+function renderCompletedWorkflowRows(projectId: string, workflows: WorkflowRecord[]): ReactNode {
+  if (!workflows.length) return <Text size="xs" c="dimmed">No completed workflows yet.</Text>;
+  return workflows.slice(0, 6).map((workflow) => (
+    <a key={workflow.workflowId} href={`/projects/${projectId}/workflows/${workflow.workflowId}`} className="completed-workflow-row">
+      <Group justify="space-between" wrap="nowrap">
+        <Text size="sm" fw={700} lineClamp={1}>{workflow.trackingCode ?? workflow.workflowId}</Text>
+        <Badge size="xs" variant="light">done</Badge>
+      </Group>
+      <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
+    </a>
+  ));
+}
+
+function renderSessionRows(sessions: AgentSessionRecord[], archived = false): ReactNode {
+  if (!sessions.length) return <Text size="xs" c="dimmed">No sessions recorded for this step.</Text>;
+  return sessions.map((session) => <SessionLink key={session.sessionKey} session={session} archived={archived || Boolean(session.archivedAt)} />);
+}
+
+function IssueStatusRow({ issue, qaStatus }: { issue: IssueRecord; qaStatus: ReturnType<typeof getIssueQaStatus> }) {
+  return (
+    <Group gap={6} wrap="nowrap">
+      <Text size="xs" c="dimmed" lineClamp={1}>
+        {issue.githubIssueNumber ? `#${issue.githubIssueNumber}` : issue.issueId}: {issue.title}
+        {issue.prState ? ` · PR ${issue.prState}` : ""}
+      </Text>
+      <Badge color={qaStatus.color} size="xs" variant="light">{qaStatus.label}</Badge>
+    </Group>
+  );
+}
+
+function SessionLink({ session, archived = false }: { session: AgentSessionRecord; archived?: boolean }) {
+  return (
+    <a href={`/projects/${session.projectId}?session=${encodeURIComponent(session.sessionKey)}`} className={`session-row${archived ? " archived" : ""}`}>
+      <Group justify="space-between" align="center" wrap="nowrap">
+        <div>
+          <Text size="sm" fw={720} lineClamp={1}>{session.title}</Text>
+          <Text size="xs" c="dimmed" lineClamp={1}>
+            {archived ? "archived" : session.issueId ?? session.role}
+            {session.developerRole ? ` · ${session.developerRole}` : ""}
+            {session.durationMs != null ? ` · ${formatDuration(session.durationMs)}` : ""}
+            {archived && session.archivedAt ? ` · ${formatDate(session.archivedAt)}` : ""}
+          </Text>
+        </div>
+        <Badge size="xs" variant={archived ? "outline" : "light"}>{session.status}</Badge>
+      </Group>
+      {session.currentStep ? <Text size="xs" c="dimmed" lineClamp={1}>{session.currentStep}</Text> : null}
+      {session.ownedPaths?.length ? <Text size="xs" c="dimmed" lineClamp={1}>Paths: {session.ownedPaths.join(", ")}</Text> : null}
+    </a>
+  );
+}
+
+function hasAnyLabel(issue: IssueRecord, expected: string[]): boolean {
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
+  return expected.some((label) => labels.has(label));
+}
+
 function renderWorkflowNextActionIcon(action: WorkflowNextAction): ReactNode {
   switch (action.icon) {
     case "clock":
@@ -286,11 +366,13 @@ function renderWorkflowNextActionIcon(action: WorkflowNextAction): ReactNode {
 function WorkflowProgressList({
   steps,
   nextAction,
-  projectId
+  projectId,
+  stepDetails
 }: {
   steps: WorkflowProgressStep[];
   nextAction: WorkflowNextAction;
   projectId: string;
+  stepDetails: Record<WorkflowProgressStep["id"], ReactNode>;
 }) {
   const activeIndex = getActiveWorkflowStepIndex(steps);
   const activeStep = steps[activeIndex];
@@ -324,6 +406,12 @@ function WorkflowProgressList({
                 </Badge>
               </Group>
               <Text size="xs" c="dimmed" mt={2}>{step.detail}</Text>
+              <details className="workflow-progress-detail" open={step.status === "current" || step.status === "blocked"}>
+                <summary>View step details</summary>
+                <div className="workflow-progress-detail-body">
+                  {stepDetails[step.id]}
+                </div>
+              </details>
             </div>
           </div>
         ))}

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -123,7 +123,13 @@ export default async function ProjectDetailPage({
             </Group>
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
-              <WorkflowProgressList steps={workflowProgress} nextAction={nextAction} projectId={project.projectId} stepDetails={workflowStepDetails} />
+              <WorkflowProgressList
+                steps={workflowProgress}
+                nextAction={nextAction}
+                projectId={project.projectId}
+                activeWorkflows={visibleActiveWorkflows}
+                stepDetails={workflowStepDetails}
+              />
             </Stack>
           </Paper>
         </aside>
@@ -178,7 +184,6 @@ function buildWorkflowStepDetails(input: {
     ),
     planning: (
       <Stack gap="xs">
-        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {input.queuedWorkflow ? (
           <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
             <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
@@ -194,7 +199,6 @@ function buildWorkflowStepDetails(input: {
     ),
     developer: (
       <Stack gap="xs">
-        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderJobRows(input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
         {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
@@ -202,14 +206,12 @@ function buildWorkflowStepDetails(input: {
     ),
     qa: (
       <Stack gap="xs">
-        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderQaIssueRows(input.activeWorkflows, input.sessions)}
         {renderSessionRows(qaSessions)}
       </Stack>
     ),
     merge: (
       <Stack gap="xs">
-        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderMergeIssueRows(input.activeWorkflows)}
       </Stack>
     ),
@@ -378,11 +380,13 @@ function WorkflowProgressList({
   steps,
   nextAction,
   projectId,
+  activeWorkflows,
   stepDetails
 }: {
   steps: WorkflowProgressStep[];
   nextAction: WorkflowNextAction;
   projectId: string;
+  activeWorkflows: WorkflowRecord[];
   stepDetails: Record<WorkflowProgressStep["id"], ReactNode>;
 }) {
   const activeIndex = getActiveWorkflowStepIndex(steps);
@@ -402,6 +406,14 @@ function WorkflowProgressList({
           </Badge>
         </Group>
       </div>
+      {activeWorkflows.length ? (
+        <div className="workflow-progress-controls">
+          <Text size="xs" fw={800} tt="uppercase" c="dimmed">Workflow controls</Text>
+          <Stack gap="xs" mt="xs">
+            {renderWorkflowActionRows(projectId, activeWorkflows)}
+          </Stack>
+        </div>
+      ) : null}
 
       <Stack gap={0} mt="sm">
         {steps.map((step, index) => (

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -108,36 +108,7 @@ export default async function ProjectDetailPage({
             <Stack p="md">
               <ProjectAutoRunJob projectId={project.projectId} enabled={query.autorun === "1"} />
               {!isInspectingIssueSession && <ProjectHandoffForm projectId={project.projectId} payload={readyForArchitectPayload} />}
-              <WorkflowProgressList steps={workflowProgress} />
-              <div className="workflow-next-action">
-                <Group justify="space-between" gap="sm" align="flex-start">
-                  <Group gap="sm" align="flex-start" wrap="nowrap">
-                    <div className={`workflow-next-action-icon ${nextAction.tone}`}>
-                      {renderWorkflowNextActionIcon(nextAction)}
-                    </div>
-                    <div>
-                      <Group gap="xs">
-                        <Text fw={760}>{nextAction.title}</Text>
-                        <Badge size="xs" variant="light">{nextAction.phase}</Badge>
-                      </Group>
-                      <Text size="sm" c="dimmed" mt={4}>{nextAction.description}</Text>
-                      <Group gap={6} mt="xs">
-                        <Badge size="xs" variant="outline">{nextAction.planningPending} planning pending</Badge>
-                        <Badge size="xs" variant="outline">{nextAction.developerPending} developer pending</Badge>
-                        {nextAction.runningCount ? <Badge size="xs" color="blue" variant="light">{nextAction.runningCount} running</Badge> : null}
-                        {nextAction.failedCount ? <Badge size="xs" color="red" variant="light">{nextAction.failedCount} blocked</Badge> : null}
-                      </Group>
-                    </div>
-                  </Group>
-                  {nextAction.buttonLabel ? (
-                    <ProjectRunJobsForm projectId={project.projectId} label={nextAction.buttonLabel} />
-                  ) : (
-                    <Button type="button" variant="light" size="xs" radius="xl" disabled leftSection={<Play size={14} />}>
-                      {nextAction.disabledLabel}
-                    </Button>
-                  )}
-                </Group>
-              </div>
+              <WorkflowProgressList steps={workflowProgress} nextAction={nextAction} projectId={project.projectId} />
               {query.queued === "1" && queuedWorkflow ? (
                 <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
                   <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
@@ -312,20 +283,42 @@ function renderWorkflowNextActionIcon(action: WorkflowNextAction): ReactNode {
   }
 }
 
-function WorkflowProgressList({ steps }: { steps: WorkflowProgressStep[] }) {
+function WorkflowProgressList({
+  steps,
+  nextAction,
+  projectId
+}: {
+  steps: WorkflowProgressStep[];
+  nextAction: WorkflowNextAction;
+  projectId: string;
+}) {
+  const activeIndex = getActiveWorkflowStepIndex(steps);
+  const activeStep = steps[activeIndex];
+
   return (
     <div className="workflow-progress">
-      <Group justify="space-between" gap="xs" mb="xs">
-        <Text fw={760}>Current workflow step</Text>
-        <Badge size="xs" variant="light">{steps.find((step) => step.status === "current" || step.status === "blocked")?.label ?? "Workflow"}</Badge>
-      </Group>
-      <Stack gap={0}>
-        {steps.map((step) => (
+      <div className={`workflow-progress-summary ${activeStep.status}`}>
+        <Text size="xs" fw={800} tt="uppercase" c="dimmed">Workflow progress</Text>
+        <Group justify="space-between" gap="xs" align="flex-start" mt={4}>
+          <div>
+            <Text fw={840}>Step {activeIndex + 1} of {steps.length}</Text>
+            <Text size="sm" c="dimmed">{activeStep.label.replace(/^\d+\.\s*/, "")}</Text>
+          </div>
+          <Badge color={workflowProgressStatusColor(activeStep.status)} variant="light">
+            {workflowProgressStatusLabel(activeStep.status)}
+          </Badge>
+        </Group>
+      </div>
+
+      <Stack gap={0} mt="sm">
+        {steps.map((step, index) => (
           <div key={step.id} className={`workflow-progress-step ${step.status}`}>
-            <div className="workflow-progress-marker" aria-hidden="true" />
+            <div className="workflow-progress-marker" aria-label={`Step ${index + 1}`}>
+              {index + 1}
+            </div>
             <div className="workflow-progress-copy">
               <Group gap="xs" justify="space-between" align="flex-start">
-                <Text size="sm" fw={760}>{step.label}</Text>
+                <Text size="sm" fw={step.status === "current" || step.status === "blocked" ? 850 : 760}>{step.label}</Text>
                 <Badge size="xs" color={workflowProgressStatusColor(step.status)} variant={step.status === "upcoming" ? "outline" : "light"}>
                   {workflowProgressStatusLabel(step.status)}
                 </Badge>
@@ -335,8 +328,45 @@ function WorkflowProgressList({ steps }: { steps: WorkflowProgressStep[] }) {
           </div>
         ))}
       </Stack>
+
+      <div className={`workflow-progress-action ${nextAction.tone}`}>
+        <Group justify="space-between" gap="sm" align="flex-start">
+          <Group gap="sm" align="flex-start" wrap="nowrap">
+            <div className={`workflow-next-action-icon ${nextAction.tone}`}>
+              {renderWorkflowNextActionIcon(nextAction)}
+            </div>
+            <div>
+              <Group gap="xs">
+                <Text fw={800}>{nextAction.title}</Text>
+                <Badge size="xs" variant="light">{nextAction.phase}</Badge>
+              </Group>
+              <Text size="sm" c="dimmed" mt={4}>{nextAction.description}</Text>
+              <Group gap={6} mt="xs">
+                <Badge size="xs" variant="outline">{nextAction.planningPending} planning pending</Badge>
+                <Badge size="xs" variant="outline">{nextAction.developerPending} developer pending</Badge>
+                {nextAction.runningCount ? <Badge size="xs" color="blue" variant="light">{nextAction.runningCount} running</Badge> : null}
+                {nextAction.failedCount ? <Badge size="xs" color="red" variant="light">{nextAction.failedCount} blocked</Badge> : null}
+              </Group>
+            </div>
+          </Group>
+          {nextAction.buttonLabel ? (
+            <ProjectRunJobsForm projectId={projectId} label={nextAction.buttonLabel} />
+          ) : (
+            <Button type="button" variant="light" size="xs" radius="xl" disabled leftSection={<Play size={14} />}>
+              {nextAction.disabledLabel}
+            </Button>
+          )}
+        </Group>
+      </div>
     </div>
   );
+}
+
+function getActiveWorkflowStepIndex(steps: WorkflowProgressStep[]): number {
+  const activeIndex = steps.findIndex((step) => step.status === "current" || step.status === "blocked");
+  if (activeIndex >= 0) return activeIndex;
+  const doneIndex = steps.findIndex((step) => step.id === "done" && step.status === "complete");
+  return doneIndex >= 0 ? doneIndex : 0;
 }
 
 function workflowProgressStatusLabel(status: WorkflowProgressStep["status"]): string {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -178,6 +178,7 @@ function buildWorkflowStepDetails(input: {
     ),
     planning: (
       <Stack gap="xs">
+        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {input.queuedWorkflow ? (
           <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
             <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
@@ -193,6 +194,7 @@ function buildWorkflowStepDetails(input: {
     ),
     developer: (
       <Stack gap="xs">
+        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderJobRows(input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
         {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
@@ -200,12 +202,14 @@ function buildWorkflowStepDetails(input: {
     ),
     qa: (
       <Stack gap="xs">
+        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderQaIssueRows(input.activeWorkflows, input.sessions)}
         {renderSessionRows(qaSessions)}
       </Stack>
     ),
     merge: (
       <Stack gap="xs">
+        {renderWorkflowActionRows(input.projectId, input.visibleActiveWorkflows)}
         {renderMergeIssueRows(input.activeWorkflows)}
       </Stack>
     ),
@@ -216,6 +220,30 @@ function buildWorkflowStepDetails(input: {
       </Stack>
     )
   };
+}
+
+function renderWorkflowActionRows(projectId: string, workflows: WorkflowRecord[]): ReactNode {
+  if (!workflows.length) return <Text size="xs" c="dimmed">No active workflow controls for this step.</Text>;
+  return workflows.map((workflow) => (
+    <div key={workflow.workflowId} className="workflow-control-row">
+      <div>
+        <Text size="sm" fw={760} lineClamp={1}>{workflow.trackingCode ?? workflow.workflowId}</Text>
+        <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
+      </div>
+      <Group gap={6} wrap="nowrap">
+        <Button
+          component="a"
+          href={`/projects/${projectId}/workflows/${workflow.workflowId}`}
+          variant="light"
+          size="compact-xs"
+          radius="xl"
+        >
+          Open
+        </Button>
+        <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
+      </Group>
+    </div>
+  ));
 }
 
 function renderJobRows(jobs: JobRecord[], queuedJobId: string | null): ReactNode {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -423,13 +423,13 @@ function WorkflowProgressList({
             </div>
             <div className="workflow-progress-copy">
               <Group gap="xs" justify="space-between" align="flex-start">
-                <Text size="sm" fw={step.status === "current" || step.status === "blocked" ? 850 : 760}>{step.label}</Text>
+                <Text size="sm" fw={step.status === "current" || step.status === "running" || step.status === "blocked" ? 850 : 760}>{step.label}</Text>
                 <Badge size="xs" color={workflowProgressStatusColor(step.status)} variant={step.status === "upcoming" ? "outline" : "light"}>
                   {workflowProgressStatusLabel(step.status)}
                 </Badge>
               </Group>
               <Text size="xs" c="dimmed" mt={2}>{step.detail}</Text>
-              <details className="workflow-progress-detail" open={step.status === "current" || step.status === "blocked"}>
+              <details className="workflow-progress-detail" open={step.status === "current" || step.status === "running" || step.status === "blocked"}>
                 <summary>View step details</summary>
                 <div className="workflow-progress-detail-body">
                   {stepDetails[step.id]}
@@ -474,7 +474,7 @@ function WorkflowProgressList({
 }
 
 function getActiveWorkflowStepIndex(steps: WorkflowProgressStep[]): number {
-  const activeIndex = steps.findIndex((step) => step.status === "current" || step.status === "blocked");
+  const activeIndex = steps.findIndex((step) => step.status === "current" || step.status === "running" || step.status === "blocked");
   if (activeIndex >= 0) return activeIndex;
   const doneIndex = steps.findIndex((step) => step.id === "done" && step.status === "complete");
   return doneIndex >= 0 ? doneIndex : 0;
@@ -486,6 +486,8 @@ function workflowProgressStatusLabel(status: WorkflowProgressStep["status"]): st
       return "Done";
     case "current":
       return "Current";
+    case "running":
+      return "Running";
     case "blocked":
       return "Blocked";
     case "upcoming":
@@ -499,6 +501,8 @@ function workflowProgressStatusColor(status: WorkflowProgressStep["status"]): st
       return "green";
     case "current":
       return "blue";
+    case "running":
+      return "cyan";
     case "blocked":
       return "red";
     case "upcoming":

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -194,7 +194,7 @@ function buildWorkflowStepDetails(input: {
     developer: (
       <Stack gap="xs">
         {renderJobRows(input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
-        {renderWorkflowCards(input.projectId, input.visibleActiveWorkflows, input.sessions)}
+        {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
       </Stack>
     ),
@@ -239,31 +239,14 @@ function renderJobRows(jobs: JobRecord[], queuedJobId: string | null): ReactNode
   ));
 }
 
-function renderWorkflowCards(projectId: string, workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
-  if (!workflows.length) return <Text size="xs" c="dimmed">No active workflow details for this step.</Text>;
-  return workflows.map((workflow) => (
-    <div key={workflow.workflowId} className="workflow-summary-card">
-      <Group justify="space-between" gap="xs">
-        <div>
-          <Text fw={700} size="sm">
-            {workflow.trackingCode ?? workflow.workflowId} · {workflow.paused ? "paused" : workflow.status}
-          </Text>
-          <Text size="xs" c="dimmed" lineClamp={1}>{workflow.userRequirement}</Text>
-        </div>
-        <Group gap={6}>
-          <Button component="a" href={`/projects/${projectId}/workflows/${workflow.workflowId}`} variant="light" size="compact-xs" radius="xl">
-            Open
-          </Button>
-          <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
-        </Group>
-      </Group>
-      {workflow.issues.map((issue) => {
-        const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
-        const qaStatus = getIssueQaStatus(issue, qaSession);
-        return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={qaStatus} />;
-      })}
-    </div>
-  ));
+function renderDeveloperIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (!issues.length) return <Text size="xs" c="dimmed">No developer issues planned yet.</Text>;
+  return issues.map((issue) => {
+    const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
+    const qaStatus = getIssueQaStatus(issue, qaSession);
+    return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={qaStatus} />;
+  });
 }
 
 function renderQaIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {

--- a/src/lib/workflow-next-action.ts
+++ b/src/lib/workflow-next-action.ts
@@ -73,9 +73,9 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
 
   if (failedCount) {
     return {
-      title: "Blocked job needs attention",
+      title: "Resolve blocker before continuing",
       phase: "Blocked",
-      description: "A previous job failed or timed out. Inspect the session, fix the blocker, then retry from the workflow or session controls.",
+      description: "Open the related step details, inspect the failed session, fix the blocker, then retry from the workflow or session controls.",
       buttonLabel: null,
       disabledLabel: "Blocked",
       tone: "blocked",

--- a/src/lib/workflow-progress.ts
+++ b/src/lib/workflow-progress.ts
@@ -1,7 +1,7 @@
 import type { IssueRecord, JobRecord, WorkflowRecord } from "@/lib/types";
 
 export type WorkflowProgressStepId = "requirement" | "planning" | "developer" | "qa" | "merge" | "done";
-export type WorkflowProgressStepStatus = "complete" | "current" | "blocked" | "upcoming";
+export type WorkflowProgressStepStatus = "complete" | "current" | "running" | "blocked" | "upcoming";
 
 export type WorkflowProgressStep = {
   id: WorkflowProgressStepId;
@@ -50,15 +50,33 @@ export function getWorkflowProgress(input: {
   const hasActiveWorkflow = workflows.some((workflow) => workflow.status !== "done");
   const hasDoneWorkflow = workflows.some((workflow) => workflow.status === "done");
   const blockedStep = getBlockedStep(workflows, jobs, issues);
-  const currentStep = blockedStep ?? getCurrentStep({ hasAnyWorkflow, hasActiveWorkflow, hasDoneWorkflow, issues, jobs });
+  const runningStep = blockedStep ? null : getRunningStep(jobs);
+  const currentStep = blockedStep ?? runningStep ?? getCurrentStep({ hasAnyWorkflow, hasActiveWorkflow, hasDoneWorkflow, issues, jobs });
   const currentIndex = stepOrder.indexOf(currentStep);
 
   return stepOrder.map((id, index) => ({
     id,
     label: stepCopy[id].label,
     detail: stepCopy[id].detail,
-    status: blockedStep === id ? "blocked" : index < currentIndex || isDoneComplete(id, hasDoneWorkflow, hasActiveWorkflow) ? "complete" : id === currentStep ? "current" : "upcoming"
+    status: getStepStatus({ id, index, currentIndex, blockedStep, runningStep, currentStep, hasDoneWorkflow, hasActiveWorkflow })
   }));
+}
+
+function getStepStatus(input: {
+  id: WorkflowProgressStepId;
+  index: number;
+  currentIndex: number;
+  blockedStep: WorkflowProgressStepId | null;
+  runningStep: WorkflowProgressStepId | null;
+  currentStep: WorkflowProgressStepId;
+  hasDoneWorkflow: boolean;
+  hasActiveWorkflow: boolean;
+}): WorkflowProgressStepStatus {
+  if (input.blockedStep === input.id) return "blocked";
+  if (input.runningStep === input.id) return "running";
+  if (input.index < input.currentIndex || isDoneComplete(input.id, input.hasDoneWorkflow, input.hasActiveWorkflow)) return "complete";
+  if (input.id === input.currentStep) return "current";
+  return "upcoming";
 }
 
 function getBlockedStep(
@@ -72,6 +90,12 @@ function getBlockedStep(
   if (issues.some((issue) => hasAnyIssueLabel(issue, ["qa-failed", "taskix:qa-failed"]))) return "qa";
   const blockedIssue = issues.find((issue) => hasAnyIssueLabel(issue, ["taskix:blocked"]));
   if (blockedIssue) return blockedIssue.prUrl || blockedIssue.prState ? "qa" : "developer";
+  return null;
+}
+
+function getRunningStep(jobs: Pick<JobRecord, "status" | "type">[]): WorkflowProgressStepId | null {
+  if (jobs.some((job) => job.status === "running" && job.type === "workflow_run")) return "planning";
+  if (jobs.some((job) => job.status === "running" && job.type === "issue_run")) return "developer";
   return null;
 }
 


### PR DESCRIPTION
Closes #79

## Summary

- Replace the generic workflow progress card with an explicit six-step stepper.
- Show Step X of 6 in the workflow progress header with the current step name.
- Number every step visibly from 1 through 6.
- Highlight current and blocked steps with full-row styling instead of only a small marker.
- Move the next-action details and Run Jobs button into the same progress module so the operator can see what to do next.

## Verification

- npm test
- npm run typecheck
- npm run build

## QA Notes

Please run the verification commands, then inspect project detail pages in empty, planning, developer, QA, merge, blocked, and completed states. Confirm the Workflows panel clearly shows six numbered steps, Step X of 6, the current or blocked position, and the next action in the same module.