### PR TITLE
Add local project delete action

### DIFF
--- a/scripts/issue-run-policy.test.mjs
+++ b/scripts/issue-run-policy.test.mjs
@@ -1,4 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import process from "node:process";
+
+process.chdir(mkdtempSync(`${tmpdir()}/taskix-issue-run-policy-`));
+
 import {
   expectedDeveloperBranch,
   manualDeployArchitectPolicyDecision,

--- a/scripts/project-delete.test.mjs
+++ b/scripts/project-delete.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+
+process.chdir(mkdtempSync(`${tmpdir()}/taskix-project-delete-`));
+
+const { deleteProjectLocalState } = await import("../src/lib/project-delete.ts");
+
+describe("deleteProjectLocalState", () => {
+  it("removes a project and its local Taskix state", async () => {
+    const database = createTestDatabase();
+    const project = {
+      projectId: "project-delete-test",
+      slug: "delete-me",
+      name: "Delete Me",
+      githubRepo: "Taskix-AI/Taskix"
+    };
+    database.prepare("INSERT INTO projects (project_id, slug, created_at, payload) VALUES (?, ?, ?, ?)").run(project.projectId, project.slug, new Date().toISOString(), JSON.stringify(project));
+    database.prepare("INSERT INTO chat_projects (chat_id, project_id) VALUES (?, ?)").run(12345, project.projectId);
+    database.prepare("INSERT INTO workflows (workflow_id, created_at, payload) VALUES (?, ?, ?)").run("wf-delete-test", new Date().toISOString(), JSON.stringify({
+      workflowId: "wf-delete-test",
+      trackingCode: "WF-DELETE",
+      userRequirement: "delete test",
+      status: "created",
+      chatId: 12345,
+      createdAt: new Date().toISOString(),
+      projectId: project.projectId,
+      projectName: project.name,
+      issues: [],
+      timeline: []
+    }));
+    database.prepare("INSERT INTO jobs (job_id, project_id, type, status, created_at, updated_at, payload) VALUES (?, ?, ?, ?, ?, ?, ?)").run("job-delete-test", project.projectId, "workflow_run", "pending", new Date().toISOString(), new Date().toISOString(), JSON.stringify({
+      jobId: "job-delete-test",
+      projectId: project.projectId,
+      type: "workflow_run",
+      status: "pending",
+      payload: { workflowId: "wf-delete-test" }
+    }));
+    database.prepare("INSERT INTO agent_sessions (session_key, project_id, role, updated_at, payload) VALUES (?, ?, ?, ?, ?)").run(`${project.projectId}:product_manager`, project.projectId, "product_manager", new Date().toISOString(), JSON.stringify({
+      sessionKey: `${project.projectId}:product_manager`,
+      projectId: project.projectId,
+      role: "product_manager",
+      title: "Project Manager",
+      status: "active",
+      messages: [{ role: "user", content: "hello", createdAt: new Date().toISOString() }]
+    }));
+
+    deleteProjectLocalState(database, project);
+
+    assert.equal(count(database, "projects", "project_id", project.projectId), 0);
+    assert.equal(count(database, "chat_projects", "project_id", project.projectId), 0);
+    assert.equal(count(database, "workflows", "workflow_id", "wf-delete-test"), 0);
+    assert.equal(count(database, "jobs", "project_id", project.projectId), 0);
+    assert.equal(count(database, "agent_sessions", "project_id", project.projectId), 0);
+  });
+});
+
+function createTestDatabase() {
+  mkdirSync("data", { recursive: true });
+  const database = new DatabaseSync(join("data", "delete-test.sqlite"));
+  database.exec(`
+    CREATE TABLE projects (project_id TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, created_at TEXT NOT NULL, payload TEXT NOT NULL);
+    CREATE TABLE workflows (workflow_id TEXT PRIMARY KEY, created_at TEXT NOT NULL, payload TEXT NOT NULL);
+    CREATE TABLE chat_projects (chat_id INTEGER PRIMARY KEY, project_id TEXT NOT NULL);
+    CREATE TABLE agent_sessions (session_key TEXT PRIMARY KEY, project_id TEXT NOT NULL, role TEXT NOT NULL, updated_at TEXT NOT NULL, payload TEXT NOT NULL);
+    CREATE TABLE jobs (job_id TEXT PRIMARY KEY, project_id TEXT, type TEXT NOT NULL, status TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, payload TEXT NOT NULL);
+  `);
+  return database;
+}
+
+function count(database, table, column, value) {
+  const row = database.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE ${column} = ?`).get(value);
+  return row.count;
+}

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { deleteProject, getProject } from "@/lib/store";
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+  const deleted = await deleteProject(projectId);
+  if (!deleted) return NextResponse.json({ ok: false, error: "Project not found." }, { status: 404 });
+  return NextResponse.json({ ok: true, projectId: deleted.projectId, slug: deleted.slug });
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+  const form = await request.formData();
+  const action = String(form.get("_action") ?? "");
+  if (action !== "delete") return redirect(request, `/projects/${projectId}?error=${encodeURIComponent("Unsupported project action.")}`);
+
+  const project = await getProject(projectId);
+  if (!project) return redirect(request, `/projects?error=${encodeURIComponent("Project not found.")}`);
+
+  const confirmation = String(form.get("confirmation") ?? "").trim();
+  if (confirmation !== project.slug) {
+    return redirect(request, `/projects/${project.projectId}?error=${encodeURIComponent(`Type ${project.slug} to delete this project.`)}`);
+  }
+
+  await deleteProject(project.projectId);
+  return redirect(request, `/projects?message=${encodeURIComponent(`Project ${project.name} deleted locally.`)}`);
+}
+
+function redirect(request: Request, location: string): NextResponse {
+  return NextResponse.redirect(new URL(location, request.url), { status: 303 });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,6 +237,21 @@ pre,
   padding: 16px;
 }
 
+.project-danger-zone {
+  margin-top: 8px;
+  padding-top: 10px;
+  border-top: 1px solid #fee2e2;
+}
+
+.project-delete-form {
+  margin-top: 8px;
+}
+
+.project-delete-form.compact {
+  min-width: 210px;
+  margin-top: 0;
+}
+
 .section-title {
   margin: 4px 0 -4px;
   color: var(--mantine-color-dimmed);

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Bot, CheckCircle2, Clock, GitBranch, Info, Play, Wrench } 
 import type { CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
+import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
 import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
@@ -92,6 +93,11 @@ export default async function ProjectDetailPage({
               <Text size="sm">DevOps: <Code>{project.devopsSessionId ?? "new"}</Code></Text>
               <Text size="sm">Agents: <Code>{project.agentsFilePath}</Code></Text>
               <Text size="sm">Agents update: <Code>{project.updateAgentsFile ? "enabled" : "skipped"}</Code></Text>
+              <div className="project-danger-zone">
+                <Text size="xs" fw={780} c="red">Delete local project</Text>
+                <Text size="xs" c="dimmed">Type <Code>{project.slug}</Code> to remove this local project and its local Taskix state. GitHub data is not deleted.</Text>
+                <ProjectDeleteForm projectId={project.projectId} slug={project.slug} />
+              </div>
             </Stack>
           </Paper>
 

--- a/src/components/ProjectDeleteForm.tsx
+++ b/src/components/ProjectDeleteForm.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button, Group, TextInput } from "@mantine/core";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+export function ProjectDeleteForm({
+  projectId,
+  slug,
+  compact = false
+}: {
+  projectId: string;
+  slug: string;
+  compact?: boolean;
+}) {
+  const [confirmation, setConfirmation] = useState("");
+  const canDelete = confirmation === slug;
+
+  return (
+    <form method="post" action={`/api/projects/${projectId}`} className={compact ? "project-delete-form compact" : "project-delete-form"}>
+      <input type="hidden" name="_action" value="delete" />
+      <Group gap="xs" align="end" wrap="nowrap">
+        <TextInput
+          name="confirmation"
+          aria-label={`Type ${slug} to delete project`}
+          placeholder={slug}
+          size="xs"
+          value={confirmation}
+          onChange={(event) => setConfirmation(event.currentTarget.value)}
+        />
+        <Button
+          type="submit"
+          color="red"
+          variant="light"
+          size="xs"
+          radius="xl"
+          leftSection={<Trash2 size={14} />}
+          disabled={!canDelete}
+        >
+          Delete
+        </Button>
+      </Group>
+    </form>
+  );
+}

--- a/src/components/Tables.tsx
+++ b/src/components/Tables.tsx
@@ -11,6 +11,7 @@ import {
   TableTr,
   Text
 } from "@mantine/core";
+import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
 import { getWorkflowQaStatus } from "@/lib/qa-status";
 import type { ProjectRecord, WorkflowRecord } from "@/lib/types";
 
@@ -95,6 +96,7 @@ export function ProjectsTable({ projects }: { projects: ProjectTableRecord[] }) 
             <TableTh>Repo</TableTh>
             <TableTh>Deploy</TableTh>
             <TableTh>PM Session</TableTh>
+            <TableTh>Delete</TableTh>
           </TableTr>
         </TableThead>
         <TableTbody>
@@ -130,11 +132,14 @@ export function ProjectsTable({ projects }: { projects: ProjectTableRecord[] }) 
                 <TableTd>
                   <a className="row-link" href={`/projects/${project.projectId}`}>{project.projectManagerSessionId ?? "new"}</a>
                 </TableTd>
+                <TableTd>
+                  <ProjectDeleteForm projectId={project.projectId} slug={project.slug} compact />
+                </TableTd>
               </TableTr>
             ))
           ) : (
             <TableTr>
-              <TableTd colSpan={7}>
+              <TableTd colSpan={8}>
                 <Text c="dimmed" ta="center" py="md">
                   No projects yet.
                 </Text>

--- a/src/lib/project-delete.ts
+++ b/src/lib/project-delete.ts
@@ -1,0 +1,30 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { ProjectRecord, WorkflowRecord } from "@/lib/types";
+
+export function deleteProjectLocalState(database: DatabaseSync, project: ProjectRecord): void {
+  const workflowIds = listProjectWorkflowIds(database, project.projectId);
+  database.exec("BEGIN");
+  try {
+    database.prepare("DELETE FROM projects WHERE project_id = ?").run(project.projectId);
+    database.prepare("DELETE FROM chat_projects WHERE project_id = ?").run(project.projectId);
+    database.prepare("DELETE FROM jobs WHERE project_id = ?").run(project.projectId);
+    database.prepare("DELETE FROM agent_sessions WHERE project_id = ?").run(project.projectId);
+    for (const workflowId of workflowIds) {
+      database.prepare("DELETE FROM workflows WHERE workflow_id = ?").run(workflowId);
+    }
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function listProjectWorkflowIds(database: DatabaseSync, projectId: string): string[] {
+  const rows = database.prepare("SELECT workflow_id, payload FROM workflows").all() as { workflow_id: string; payload: string }[];
+  return rows
+    .filter((row) => {
+      const workflow = JSON.parse(row.payload) as WorkflowRecord;
+      return workflow.projectId === projectId;
+    })
+    .map((row) => row.workflow_id);
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { getDb } from "@/lib/db";
+import { deleteProjectLocalState } from "@/lib/project-delete";
 import type { AgentSessionRecord, JobRecord, JobType, ProjectRecord, Role, WorkflowRecord } from "@/lib/types";
 
 const RUNNING_JOB_TIMEOUT_MS = 2 * 60 * 60 * 1000;
@@ -17,6 +18,13 @@ export async function getProject(projectId: string): Promise<ProjectRecord | nul
 export async function getProjectBySlug(slug: string): Promise<ProjectRecord | null> {
   const row = getDb().prepare("SELECT payload FROM projects WHERE slug = ?").get(slug) as { payload: string } | undefined;
   return row ? normalizeProject(JSON.parse(row.payload) as ProjectRecord) : null;
+}
+
+export async function deleteProject(projectId: string): Promise<ProjectRecord | null> {
+  const project = await getProject(projectId);
+  if (!project) return null;
+  deleteProjectLocalState(getDb(), project);
+  return project;
 }
 
 export async function createProject(input: {


### PR DESCRIPTION
Closes #81

## Summary
- Add local project deletion with slug confirmation.
- Add DELETE/POST project API route.
- Delete local project row, chat bindings, jobs, sessions, and project workflows.
- Add project list and detail delete controls.
- Keep GitHub repository/issues/PRs untouched.
- Add deterministic SQLite deletion tests.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Please create a throwaway project, confirm wrong slug blocks deletion, correct slug deletes locally, project disappears, direct URL no longer loads, and no GitHub remote data is deleted.