### PR TITLE
Widen project workflow sidebar

### DIFF
--- a/scripts/workflow-progress.test.mjs
+++ b/scripts/workflow-progress.test.mjs
@@ -81,6 +81,17 @@ describe("getWorkflowProgress", () => {
     assert.equal(currentStep(steps).id, "merge");
   });
 
+  it("shows completed workflows on done even when issues retain QA-passed labels", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("done", [issue({ labels: ["qa-passed"], prLabels: ["taskix:ready-to-merge"], prState: "MERGED" })])],
+      jobs: []
+    });
+
+    assert.equal(currentStep(steps), undefined);
+    assert.equal(step(steps, "merge").status, "complete");
+    assert.equal(step(steps, "done").status, "complete");
+  });
+
   it("shows failed developer jobs as blocked", () => {
     const steps = getWorkflowProgress({
       workflows: [workflow("in_progress", [issue()])],

--- a/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
+++ b/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { mergePullRequestWithGh } from "@/lib/github-local";
+import { getProject, listProjectWorkflows, saveWorkflow } from "@/lib/store";
+
+export async function POST(_request: Request, { params }: { params: Promise<{ projectId: string; issueId: string }> }) {
+  const { projectId, issueId } = await params;
+  const project = await getProject(projectId);
+  if (!project) return NextResponse.json({ error: "Project not found." }, { status: 404 });
+
+  const workflows = await listProjectWorkflows(project.projectId);
+  const workflow = workflows.find((item) => item.issues.some((issue) => issue.issueId === issueId));
+  const issue = workflow?.issues.find((item) => item.issueId === issueId);
+  if (!workflow || !issue) return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+  if (!issue.prUrl) return NextResponse.json({ error: "Issue has no pull request to merge." }, { status: 400 });
+  if (issue.prState === "MERGED") return NextResponse.json({ ok: true, merged: true, issueId, prUrl: issue.prUrl });
+
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
+  const isReady = labels.has("qa-passed") || labels.has("taskix:qa-passed") || labels.has("taskix:ready-to-merge");
+  if (!isReady) return NextResponse.json({ error: "Issue is not QA-passed or ready to merge." }, { status: 409 });
+
+  try {
+    await mergePullRequestWithGh(project.githubRepo, issue.prUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "PR merge failed.";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const mergedLabels = ["taskix:merged"];
+  issue.prState = "MERGED";
+  issue.githubState = "CLOSED";
+  issue.labels = [...new Set([...(issue.labels ?? []), ...mergedLabels])];
+  issue.prLabels = [...new Set([...(issue.prLabels ?? []), ...mergedLabels])];
+  workflow.timeline.push(`Merged PR ${issue.prUrl} for issue ${issue.issueId}.`);
+  if (workflow.issues.every((item) => item.prState === "MERGED" || item.githubState === "CLOSED")) {
+    workflow.status = "done";
+    workflow.timeline.push("Workflow completed after all issue PRs merged.");
+  }
+  await saveWorkflow(workflow);
+
+  return NextResponse.json({ ok: true, merged: true, issueId, prUrl: issue.prUrl });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -872,6 +872,17 @@ pre,
   scrollbar-gutter: stable;
 }
 
+@media (max-width: 1320px) {
+  .project-chat-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .project-context {
+    position: static;
+    max-height: none;
+  }
+}
+
 @media (max-width: 1180px) {
   .layout {
     grid-template-columns: 1fr;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -262,7 +262,7 @@ pre,
 
 .project-chat-layout {
   display: grid;
-  grid-template-columns: minmax(520px, 1fr) minmax(430px, 34vw);
+  grid-template-columns: minmax(480px, 1fr) minmax(520px, clamp(520px, 40vw, 680px));
   gap: 18px;
   align-items: start;
 }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -133,7 +133,7 @@ export default async function ProjectDetailPage({
                 steps={workflowProgress}
                 nextAction={nextAction}
                 projectId={project.projectId}
-                activeWorkflows={visibleActiveWorkflows}
+                workflows={visibleActiveWorkflows.length ? visibleActiveWorkflows : doneWorkflows.slice(0, 3)}
                 stepDetails={workflowStepDetails}
               />
             </Stack>
@@ -231,7 +231,7 @@ function buildWorkflowStepDetails(input: {
 }
 
 function renderWorkflowActionRows(projectId: string, workflows: WorkflowRecord[]): ReactNode {
-  if (!workflows.length) return <Text size="xs" c="dimmed">No active workflow controls for this step.</Text>;
+  if (!workflows.length) return <Text size="xs" c="dimmed">No workflow entries for this project yet.</Text>;
   return workflows.map((workflow) => (
     <div key={workflow.workflowId} className="workflow-control-row">
       <div>
@@ -248,7 +248,7 @@ function renderWorkflowActionRows(projectId: string, workflows: WorkflowRecord[]
         >
           Open
         </Button>
-        <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} />
+        {workflow.status !== "done" ? <WorkflowPauseButton workflowId={workflow.workflowId} paused={Boolean(workflow.paused)} /> : null}
       </Group>
     </div>
   ));
@@ -386,13 +386,13 @@ function WorkflowProgressList({
   steps,
   nextAction,
   projectId,
-  activeWorkflows,
+  workflows,
   stepDetails
 }: {
   steps: WorkflowProgressStep[];
   nextAction: WorkflowNextAction;
   projectId: string;
-  activeWorkflows: WorkflowRecord[];
+  workflows: WorkflowRecord[];
   stepDetails: Record<WorkflowProgressStep["id"], ReactNode>;
 }) {
   const activeIndex = getActiveWorkflowStepIndex(steps);
@@ -412,11 +412,11 @@ function WorkflowProgressList({
           </Badge>
         </Group>
       </div>
-      {activeWorkflows.length ? (
+      {workflows.length ? (
         <div className="workflow-progress-controls">
-          <Text size="xs" fw={800} tt="uppercase" c="dimmed">Workflow controls</Text>
+          <Text size="xs" fw={800} tt="uppercase" c="dimmed">Workflow entries</Text>
           <Stack gap="xs" mt="xs">
-            {renderWorkflowActionRows(projectId, activeWorkflows)}
+            {renderWorkflowActionRows(projectId, workflows)}
           </Stack>
         </div>
       ) : null}

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -6,6 +6,7 @@ import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
+import { ProjectMergePrButton } from "@/components/ProjectMergePrButton";
 import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
@@ -244,7 +245,7 @@ function buildWorkflowStepDetails(input: {
     ),
     merge: (
       <Stack gap="xs">
-        {renderMergeIssueRows(input.activeWorkflows)}
+        {renderMergeIssueRows(input.projectId, input.activeWorkflows)}
       </Stack>
     ),
     done: (
@@ -320,19 +321,24 @@ function renderQaIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRe
   });
 }
 
-function renderMergeIssueRows(workflows: WorkflowRecord[]): ReactNode {
+function renderMergeIssueRows(projectId: string, workflows: WorkflowRecord[]): ReactNode {
   const issues = workflows.flatMap((workflow) => workflow.issues).filter((issue) => hasAnyLabel(issue, ["qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"]));
   if (!issues.length) return <Text size="xs" c="dimmed">No QA-passed or ready-to-merge issues yet.</Text>;
   return issues.map((issue) => (
     <div key={issue.issueId} className="workflow-job-row">
       <Group justify="space-between" gap="xs" wrap="nowrap">
-        <Text size="sm" fw={700} lineClamp={1}>{issue.title}</Text>
-        <Badge size="xs" color="green" variant="light">ready</Badge>
+        <div style={{ minWidth: 0 }}>
+          <Text size="sm" fw={700} lineClamp={1}>{issue.title}</Text>
+          <Text size="xs" c="dimmed" mt={4}>
+            {issue.githubIssueNumber ? `Issue #${issue.githubIssueNumber}` : issue.issueId}
+            {issue.prState ? ` · PR ${issue.prState}` : ""}
+          </Text>
+        </div>
+        <Group gap={6} wrap="nowrap">
+          <Badge size="xs" color="green" variant="light">ready</Badge>
+          {issue.prUrl && issue.prState !== "MERGED" ? <ProjectMergePrButton projectId={projectId} issueId={issue.issueId} /> : null}
+        </Group>
       </Group>
-      <Text size="xs" c="dimmed" mt={4}>
-        {issue.githubIssueNumber ? `Issue #${issue.githubIssueNumber}` : issue.issueId}
-        {issue.prState ? ` · PR ${issue.prState}` : ""}
-      </Text>
     </div>
   ));
 }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -48,19 +48,24 @@ export default async function ProjectDetailPage({
   const queuedWorkflow = queuedWorkflowId ? workflows.find((workflow) => workflow.workflowId === queuedWorkflowId) ?? null : null;
   const queuedJob = queuedJobId ? jobs.find((job) => job.jobId === queuedJobId) ?? null : null;
   const visibleActiveWorkflows = prioritizeById(activeWorkflows, queuedWorkflowId);
+  const workflowPanelWorkflows = visibleActiveWorkflows.length ? visibleActiveWorkflows : doneWorkflows.slice(0, 3);
+  const workflowPanelJobs = filterJobsForWorkflows(jobs, workflowPanelWorkflows);
+  const workflowPanelSessions = filterSessionsForWorkflows(sessions, workflowPanelWorkflows);
+  const workflowPanelDynamicSessions = workflowPanelSessions.filter((session) => session.role !== "product_manager" && session.role !== "architect" && session.role !== "devops" && !session.archivedAt);
+  const workflowPanelArchivedSessions = workflowPanelSessions.filter((session) => session.role !== "product_manager" && session.role !== "architect" && session.role !== "devops" && session.archivedAt);
   const readyForArchitectPayload = findReadyForArchitectPayload(pmSession ?? (activeRole === "product_manager" ? roleSession : null));
-  const nextAction = getWorkflowNextAction(jobs);
-  const workflowProgress = getWorkflowProgress({ workflows, jobs });
+  const nextAction = getWorkflowNextAction(workflowPanelJobs);
+  const workflowProgress = getWorkflowProgress({ workflows: workflowPanelWorkflows, jobs: workflowPanelJobs });
   const workflowStepDetails = buildWorkflowStepDetails({
     projectId: project.projectId,
     isInspectingIssueSession,
     readyForArchitectPayload,
     pmSession,
-    sessions,
-    dynamicSessions,
-    archivedSessions,
-    jobs,
-    activeWorkflows,
+    sessions: workflowPanelSessions,
+    dynamicSessions: workflowPanelDynamicSessions,
+    archivedSessions: workflowPanelArchivedSessions,
+    jobs: workflowPanelJobs,
+    activeWorkflows: visibleActiveWorkflows,
     doneWorkflows,
     visibleActiveWorkflows,
     queuedWorkflow,
@@ -133,7 +138,7 @@ export default async function ProjectDetailPage({
                 steps={workflowProgress}
                 nextAction={nextAction}
                 projectId={project.projectId}
-                workflows={visibleActiveWorkflows.length ? visibleActiveWorkflows : doneWorkflows.slice(0, 3)}
+                workflows={workflowPanelWorkflows}
                 stepDetails={workflowStepDetails}
               />
             </Stack>
@@ -151,6 +156,27 @@ function prioritizeById<T extends { workflowId?: string; jobId?: string }>(items
     const rightSelected = right.workflowId === selectedId || right.jobId === selectedId;
     if (leftSelected === rightSelected) return 0;
     return leftSelected ? -1 : 1;
+  });
+}
+
+function filterJobsForWorkflows(jobs: JobRecord[], workflows: WorkflowRecord[]): JobRecord[] {
+  const workflowIds = new Set(workflows.map((workflow) => workflow.workflowId));
+  if (!workflowIds.size) return [];
+  return jobs.filter((job) => workflowIds.has(job.payload.workflowId));
+}
+
+function filterSessionsForWorkflows(sessions: AgentSessionRecord[], workflows: WorkflowRecord[]): AgentSessionRecord[] {
+  const workflowIds = new Set(workflows.map((workflow) => workflow.workflowId));
+  const issueSessionIds = new Set(
+    workflows.flatMap((workflow) => workflow.issues.flatMap((issue) => [issue.issueId, issue.developerSessionId, issue.qaSessionId].filter(Boolean) as string[]))
+  );
+  if (!workflowIds.size) return sessions.filter((session) => session.role === "product_manager" || session.role === "architect" || session.role === "devops");
+
+  return sessions.filter((session) => {
+    if (session.role === "product_manager" || session.role === "architect" || session.role === "devops") return true;
+    if (session.workflowId && workflowIds.has(session.workflowId)) return true;
+    if (session.issueId && issueSessionIds.has(session.issueId)) return true;
+    return issueSessionIds.has(session.sessionKey);
   });
 }
 

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -407,9 +407,14 @@ function WorkflowProgressList({
             <Text fw={840}>Step {activeIndex + 1} of {steps.length}</Text>
             <Text size="sm" c="dimmed">{activeStep.label.replace(/^\d+\.\s*/, "")}</Text>
           </div>
-          <Badge color={workflowProgressStatusColor(activeStep.status)} variant="light">
-            {workflowProgressStatusLabel(activeStep.status)}
-          </Badge>
+          <Stack gap={6} align="flex-end">
+            <Badge color={workflowProgressStatusColor(activeStep.status)} variant="light">
+              {workflowProgressStatusLabel(activeStep.status)}
+            </Badge>
+            {nextAction.buttonLabel ? (
+              <ProjectRunJobsForm projectId={projectId} label={nextAction.buttonLabel} />
+            ) : null}
+          </Stack>
         </Group>
       </div>
       {workflows.length ? (

--- a/src/components/ProjectMergePrButton.tsx
+++ b/src/components/ProjectMergePrButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Button, Group, Text } from "@mantine/core";
+import { GitMerge } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function ProjectMergePrButton({
+  projectId,
+  issueId
+}: {
+  projectId: string;
+  issueId: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [messageColor, setMessageColor] = useState<"dimmed" | "red" | "green">("dimmed");
+
+  async function mergePr() {
+    setPending(true);
+    setMessage("");
+    try {
+      const response = await fetch(`/api/projects/${projectId}/issues/${issueId}/merge`, { method: "POST" });
+      const result = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(result.error ?? "Merge request failed");
+      setMessage("Merged");
+      setMessageColor("green");
+      router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Merge request failed");
+      setMessageColor("red");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Group gap={6} wrap="nowrap">
+      <Button
+        type="button"
+        color="green"
+        variant="filled"
+        size="sm"
+        radius="md"
+        leftSection={<GitMerge size={14} />}
+        loading={pending}
+        onClick={mergePr}
+      >
+        Merge PR
+      </Button>
+      {message ? (
+        <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>
+          {message}
+        </Text>
+      ) : null}
+    </Group>
+  );
+}

--- a/src/components/ProjectRunJobsForm.tsx
+++ b/src/components/ProjectRunJobsForm.tsx
@@ -60,9 +60,9 @@ export function ProjectRunJobsForm({
     <Group gap={6} wrap="nowrap">
       <Button
         type="button"
-        variant="light"
-        size="xs"
-        radius="xl"
+        variant="filled"
+        size="sm"
+        radius="md"
         leftSection={<Play size={14} />}
         loading={pending}
         disabled={disabled}

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -195,6 +195,10 @@ export async function removeLabelsWithGh(repo: string, target: number | string, 
   await execFileAsync("gh", ["issue", "edit", String(target), "--repo", repo, "--remove-label", labels.join(",")]);
 }
 
+export async function mergePullRequestWithGh(repo: string, prUrl: string): Promise<void> {
+  await execFileAsync("gh", ["pr", "merge", prUrl, "--repo", repo, "--merge"]);
+}
+
 export async function getIssueSnapshotWithGh(repo: string, issueNumber: number): Promise<GhIssueSnapshot> {
   const { stdout: issueStdout } = await execFileAsync("gh", ["issue", "view", String(issueNumber), "--repo", repo, "--json", "number,url,state,labels"]);
   const issue = JSON.parse(issueStdout) as { number: number; url: string; state: string; labels: Array<{ name: string }> };

--- a/src/lib/workflow-progress.ts
+++ b/src/lib/workflow-progress.ts
@@ -107,6 +107,7 @@ function getCurrentStep(input: {
   jobs: Pick<JobRecord, "status" | "type">[];
 }): WorkflowProgressStepId {
   if (!input.hasAnyWorkflow && !input.jobs.length) return "requirement";
+  if (!input.hasActiveWorkflow && input.hasDoneWorkflow) return "done";
   if (input.jobs.some((job) => job.status !== "done" && job.type === "workflow_run")) return "planning";
   if (input.jobs.some((job) => job.status !== "done" && job.type === "issue_run")) return "developer";
   if (input.issues.some((issue) => hasAnyIssueLabel(issue, ["taskix:ready-to-merge"]))) return "merge";
@@ -114,7 +115,6 @@ function getCurrentStep(input: {
   if (input.issues.some((issue) => issue.prUrl || issue.prState)) return "qa";
   if (input.issues.length) return "developer";
   if (input.hasActiveWorkflow) return "planning";
-  if (input.hasDoneWorkflow) return "done";
   return "requirement";
 }
 


### PR DESCRIPTION
Closes #86

## Summary
- Increase the project detail workflow/right rail from the previous 430px/34vw sizing to a clearly wider 520px minimum.
- Let the rail scale up to 40vw with a 680px cap.
- Keep the chat column usable with a 480px desktop minimum and preserve existing responsive stacking.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Please open a project detail page on desktop and confirm the right Workflows sidebar is visibly wider than before, step details have more room, chat remains usable, and the layout still stacks correctly on narrower widths.