### PR TITLE
Update visible app header label

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <div className="mark">TB</div>
               <div>
                 <Text fw={800} size="md" c="white" lh={1.15}>
-                  Taskix Console
+                  Taskix Management
                 </Text>
                 <Text size="xs" c="blue.1">
                   Project routing, Codex sessions, GitHub orchestration


### PR DESCRIPTION
## Summary
- Change the rendered web app header label from `Taskix Console` to `Taskix Management`.
- Preserve the existing header layout, styling, metadata title, routes, and unrelated product copy.

Closes #88

## Verification
- `npm run typecheck` passed.
- `npm run build` failed when inherited shell environment had a non-standard `NODE_ENV`; Next compiled and typechecked, then failed prerendering `/_global-error`.
- `env -u NODE_ENV npm run build` passed.

## Recovery/Ready-to-Merge Evidence
- Not applicable: this change does not validate Taskix recovery or ready-to-merge behavior.
- No generated PR merge was performed.