### PR TITLE
Close GitHub issue after manual merge

### DIFF
--- a/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
+++ b/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { mergePullRequestWithGh } from "@/lib/github-local";
+import { closeIssueWithGh, mergePullRequestWithGh } from "@/lib/github-local";
 import { getProject, listProjectWorkflows, saveWorkflow } from "@/lib/store";
 
 export async function POST(_request: Request, { params }: { params: Promise<{ projectId: string; issueId: string }> }) {
@@ -18,6 +18,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ pr
   const isReady = labels.has("qa-passed") || labels.has("taskix:qa-passed") || labels.has("taskix:ready-to-merge");
   if (!isReady) return NextResponse.json({ error: "Issue is not QA-passed or ready to merge." }, { status: 409 });
 
+  const mergedLabels = ["taskix:merged"];
+  let closeIssueWarning: string | null = null;
+
   try {
     await mergePullRequestWithGh(project.githubRepo, issue.prUrl);
   } catch (error) {
@@ -25,17 +28,29 @@ export async function POST(_request: Request, { params }: { params: Promise<{ pr
     return NextResponse.json({ error: message }, { status: 502 });
   }
 
-  const mergedLabels = ["taskix:merged"];
   issue.prState = "MERGED";
-  issue.githubState = "CLOSED";
   issue.labels = [...new Set([...(issue.labels ?? []), ...mergedLabels])];
   issue.prLabels = [...new Set([...(issue.prLabels ?? []), ...mergedLabels])];
   workflow.timeline.push(`Merged PR ${issue.prUrl} for issue ${issue.issueId}.`);
+
+  if (issue.githubIssueNumber) {
+    try {
+      await closeIssueWithGh(project.githubRepo, issue.githubIssueNumber, `Closed after PR ${issue.prUrl} was merged by Taskix.`);
+      issue.githubState = "CLOSED";
+      workflow.timeline.push(`Closed GitHub issue #${issue.githubIssueNumber} after merge.`);
+    } catch (error) {
+      closeIssueWarning = error instanceof Error ? error.message : "GitHub issue close failed.";
+      workflow.timeline.push(`GitHub issue #${issue.githubIssueNumber} close failed after merge: ${closeIssueWarning}`);
+    }
+  } else {
+    issue.githubState = "CLOSED";
+  }
+
   if (workflow.issues.every((item) => item.prState === "MERGED" || item.githubState === "CLOSED")) {
     workflow.status = "done";
     workflow.timeline.push("Workflow completed after all issue PRs merged.");
   }
   await saveWorkflow(workflow);
 
-  return NextResponse.json({ ok: true, merged: true, issueId, prUrl: issue.prUrl });
+  return NextResponse.json({ ok: true, merged: true, issueClosed: !closeIssueWarning, warning: closeIssueWarning, issueId, prUrl: issue.prUrl });
 }

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -199,6 +199,12 @@ export async function mergePullRequestWithGh(repo: string, prUrl: string): Promi
   await execFileAsync("gh", ["pr", "merge", prUrl, "--repo", repo, "--merge"]);
 }
 
+export async function closeIssueWithGh(repo: string, issueNumber: number, comment?: string): Promise<void> {
+  const args = ["issue", "close", String(issueNumber), "--repo", repo];
+  if (comment) args.push("--comment", comment);
+  await execFileAsync("gh", args);
+}
+
 export async function getIssueSnapshotWithGh(repo: string, issueNumber: number): Promise<GhIssueSnapshot> {
   const { stdout: issueStdout } = await execFileAsync("gh", ["issue", "view", String(issueNumber), "--repo", repo, "--json", "number,url,state,labels"]);
   const issue = JSON.parse(issueStdout) as { number: number; url: string; state: string; labels: Array<{ name: string }> };


### PR DESCRIPTION
Closes #90

## Summary
- Add a GitHub issue close helper for local gh operations.
- After Step 5 manual Merge PR succeeds, explicitly close the linked GitHub issue when githubIssueNumber is present.
- Keep local workflow state accurate if issue close fails after the PR has already merged.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Validate a ready-to-merge workflow issue with an open PR: clicking Merge PR merges the PR, closes the linked GitHub issue, and updates the local workflow to done. Also validate non-ready issues still cannot be merged.