### PR TITLE
Ensure workflow PRs target main

### DIFF
--- a/scripts/issue-run-policy.test.mjs
+++ b/scripts/issue-run-policy.test.mjs
@@ -7,6 +7,8 @@ process.chdir(mkdtempSync(`${tmpdir()}/taskix-issue-run-policy-`));
 
 import {
   expectedDeveloperBranch,
+  expectedDeveloperBaseBranch,
+  isRecoverablePrBase,
   manualDeployArchitectPolicyDecision,
   manualDeployFinalLabelPlan,
   prRecoveryBranches
@@ -17,6 +19,10 @@ const issueNumber = 123;
 const expectedBranch = `taskix/${workflowCode}-issue-${issueNumber}`;
 
 assert.equal(expectedDeveloperBranch(workflowCode, issueNumber), expectedBranch);
+assert.equal(expectedDeveloperBaseBranch(), "main");
+assert.equal(isRecoverablePrBase("main"), true);
+assert.equal(isRecoverablePrBase("issue-86-wider-workflow-rail"), false);
+assert.equal(isRecoverablePrBase(null), false);
 
 assert.deepEqual(
   prRecoveryBranches({ developerBranch: "", workflowCode, issueNumberOrId: issueNumber }),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <div className="mark">TB</div>
               <div>
                 <Text fw={800} size="md" c="white" lh={1.15}>
-                  Taskix Console
+                  Taskix Management
                 </Text>
                 <Text size="xs" c="blue.1">
                   Project routing, Codex sessions, GitHub orchestration

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { developerRoleIds, developerRoleProfile, formatDeveloperRoleCatalog } from "@/lib/developer-roles";
+import { expectedDeveloperBaseBranch } from "@/lib/issue-run-policy";
 import type { ArchitectPrReviewResult, ArchitectReviewResult, DeveloperIssueResult, DeveloperResult, IssueSpec, QaPrReviewResult, QaResult } from "@/lib/types";
 import { dataDir, rootDir } from "@/lib/paths";
 import type { Settings } from "@/lib/types";
@@ -295,7 +296,7 @@ Implementation must stay within owned paths unless the issue explicitly calls ou
         testsRun: []
       };
     }
-    const baseBranch = await currentAppBranch();
+    const baseBranch = expectedDeveloperBaseBranch();
     const prompt = `${rolePrompts.developer}
 
 GitHub repo: ${input.repo}
@@ -685,22 +686,12 @@ function sanitizePathSegment(value: string): string {
 }
 
 async function checkoutWorkspaceBase(workspaceDir: string): Promise<void> {
-  const branch = await currentAppBranch();
-  if (!branch) return;
+  const branch = expectedDeveloperBaseBranch();
   try {
     await execFileAsync("git", ["-C", workspaceDir, "fetch", "origin", branch]);
     await execFileAsync("git", ["-C", workspaceDir, "checkout", "-B", branch, `origin/${branch}`]);
   } catch {
-    // If the running app branch is not available remotely, keep the clone's default branch.
-  }
-}
-
-async function currentAppBranch(): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync("git", ["-C", rootDir, "branch", "--show-current"]);
-    return stdout.trim() || null;
-  } catch {
-    return null;
+    // If the target branch is not available remotely, keep the clone's default branch.
   }
 }
 

--- a/src/lib/issue-run-policy.ts
+++ b/src/lib/issue-run-policy.ts
@@ -12,6 +12,14 @@ export function expectedDeveloperBranch(workflowCode: string, issueNumberOrId: n
   return `taskix/${workflowCode}-issue-${issueNumberOrId}`;
 }
 
+export function expectedDeveloperBaseBranch(): string {
+  return "main";
+}
+
+export function isRecoverablePrBase(baseBranch: string | null | undefined, expectedBaseBranch = expectedDeveloperBaseBranch()): boolean {
+  return baseBranch === expectedBaseBranch;
+}
+
 export function prRecoveryBranches(input: {
   developerBranch?: string | null;
   workflowCode: string;

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
 import { addLabelsWithGh, createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
-import { expectedDeveloperBranch, manualDeployArchitectPolicyDecision, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
+import { expectedDeveloperBaseBranch, expectedDeveloperBranch, isRecoverablePrBase, manualDeployArchitectPolicyDecision, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -501,6 +501,7 @@ async function recoverDeveloperPullRequest(
       const existingPrUrl = await findPullRequestByHeadWithGh(repo, candidateBranch);
       if (!existingPrUrl) continue;
       const details = await readPullRequestRefs(repo, existingPrUrl);
+      if (!isRecoverablePrBase(details.base, expectedDeveloperBaseBranch())) continue;
       return {
         prUrl: existingPrUrl,
         branch: details.head ?? candidateBranch,
@@ -514,6 +515,7 @@ async function recoverDeveloperPullRequest(
     const linkedPr = choosePrimaryPr(snapshot.linkedPrs);
     if (!linkedPr) return null;
     const details = await readPullRequestRefs(repo, linkedPr.url);
+    if (!isRecoverablePrBase(details.base, expectedDeveloperBaseBranch())) return null;
     return {
       prUrl: linkedPr.url,
       branch: details.head ?? expectedDeveloperBranch(displayWorkflowCode(workflow), issue.githubIssueNumber ?? issue.issueId),


### PR DESCRIPTION
Closes #92

## Summary
- Restore the missed header label update from PR #89 on main.
- Make developer workspaces check out the fixed developer base branch, main, instead of the currently running Taskix app branch.
- Ignore recovered PRs whose base branch is not main so Taskix does not adopt PRs merged into feature branches.

## Verification
- npm test
- npm run typecheck
- npm run build

Note: the first typecheck run failed on stale .next generated types before build regenerated them; rerunning after build passed.