### PR TITLE
Unify project agent chat timeline

### DIFF
--- a/scripts/chat-routing.test.mjs
+++ b/scripts/chat-routing.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import { chatRoleLabel, parseChatTarget } from "../src/lib/chat-routing.ts";
+
+assert.deepEqual(parseChatTarget("ship this"), {
+  role: "product_manager",
+  message: "ship this",
+  mention: null
+});
+
+assert.deepEqual(parseChatTarget("@PM clarify scope"), {
+  role: "product_manager",
+  message: "clarify scope",
+  mention: "PM"
+});
+
+assert.deepEqual(parseChatTarget("@architect review the plan"), {
+  role: "architect",
+  message: "review the plan",
+  mention: "architect"
+});
+
+assert.deepEqual(parseChatTarget("@devops check deploy"), {
+  role: "devops",
+  message: "check deploy",
+  mention: "devops"
+});
+
+assert.deepEqual(parseChatTarget("@qa run cases"), {
+  role: "product_manager",
+  message: "@qa run cases",
+  mention: "qa"
+});
+
+assert.equal(chatRoleLabel("product_manager"), "PM");
+assert.equal(chatRoleLabel("developer", "Header issue", "web_developer"), "Developer: web_developer");
+assert.equal(chatRoleLabel("qa", "QA: main flow"), "QA: main flow");
+
+console.log("chat routing simulation passed");

--- a/src/app/api/projects/[projectId]/chat/route.ts
+++ b/src/app/api/projects/[projectId]/chat/route.ts
@@ -1,22 +1,24 @@
 import { NextResponse } from "next/server";
 import { CodexClient } from "@/lib/codex";
+import { chatRoleLabel, parseChatTarget } from "@/lib/chat-routing";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, getAgentSession, getProject, saveProject } from "@/lib/store";
-import type { Role } from "@/lib/types";
 
 export async function POST(request: Request, { params }: { params: Promise<{ projectId: string }> }) {
   const { projectId } = await params;
   const form = await request.formData();
-  const role = String(form.get("role") ?? "product_manager") as Role;
-  const message = String(form.get("message") ?? "").trim();
-  if (!message) return redirect(request, `/projects/${projectId}?role=${role}&error=${encodeURIComponent("Message is required.")}`);
-  if (role !== "product_manager" && role !== "architect" && role !== "devops") {
-    return redirect(request, `/projects/${projectId}?error=${encodeURIComponent("Only PM, architect, and DevOps chat are supported here.")}`);
+  const rawMessage = String(form.get("message") ?? "").trim();
+  const target = parseChatTarget(rawMessage);
+  if (!target.message) return redirect(request, `/projects/${projectId}?error=${encodeURIComponent("Message is required.")}`);
+  if (target.mention && target.message === rawMessage) {
+    return redirect(request, `/projects/${projectId}?error=${encodeURIComponent(`@${target.mention} is not a supported chat target yet. Use @PM, @architect, or @devops.`)}`);
   }
 
   const [project, settings] = await Promise.all([getProject(projectId), getSettings()]);
   if (!project) return redirect(request, `/projects?error=${encodeURIComponent("Project not found.")}`);
 
+  const role = target.role;
+  const message = target.message;
   const sessionKey = `${project.projectId}:${role}`;
   const existing = await getAgentSession(sessionKey);
   const codex = new CodexClient(settings);
@@ -45,7 +47,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ pro
     sessionKey,
     projectId: project.projectId,
     role,
-    title: role === "product_manager" ? "Project Manager" : role === "architect" ? "Architect" : "DevOps",
+    title: chatRoleLabel(role),
     sessionId: result.sessionId ?? currentSessionId ?? existing?.sessionId ?? null,
     messages: [
       { role: "user", content: message, createdAt: now },
@@ -53,7 +55,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ pro
     ]
   });
 
-  return redirect(request, `/projects/${project.projectId}?role=${role}`);
+  return redirect(request, `/projects/${project.projectId}`);
 }
 
 function redirect(request: Request, location: string): NextResponse {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
-import { Bot, GitBranch, Info, ListTodo, Wrench } from "lucide-react";
+import { Bot, GitBranch, Info, ListTodo } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
@@ -90,12 +90,11 @@ export default async function ProjectDetailPage({
               </Text>
             </div>
             <Group gap="xs">
-              <Button component="a" href={`/projects/${project.projectId}?role=product_manager`} variant={!isInspectingIssueSession && activeRole === "product_manager" ? "filled" : "light"} leftSection={<Bot size={16} />}>PM</Button>
-              <Button component="a" href={`/projects/${project.projectId}?role=architect`} variant={!isInspectingIssueSession && activeRole === "architect" ? "filled" : "light"} leftSection={<GitBranch size={16} />}>Architect</Button>
-              <Button component="a" href={`/projects/${project.projectId}?role=devops`} variant={!isInspectingIssueSession && activeRole === "devops" ? "filled" : "light"} leftSection={<Wrench size={16} />}>DevOps</Button>
+              <Badge variant="light" leftSection={<Bot size={12} />}>All agents</Badge>
+              {isInspectingIssueSession ? <Badge variant="outline">Read-only session</Badge> : null}
             </Group>
           </div>
-          <ProjectChatArea projectId={project.projectId} activeRole={activeRole} session={roleSession} readOnly={isInspectingIssueSession} />
+          <ProjectChatArea projectId={project.projectId} sessions={sessions} inspectedSession={activeSession} readOnly={isInspectingIssueSession} />
         </Paper>
 
         <aside className="project-context">

--- a/src/components/ProjectChatArea.tsx
+++ b/src/components/ProjectChatArea.tsx
@@ -5,38 +5,44 @@ import { AlertTriangle, LoaderCircle, Send } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { FormEvent, KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
-import type { AgentMessage, AgentSessionRecord, Role } from "@/lib/types";
+import { chatRoleLabel, parseChatTarget } from "@/lib/chat-routing";
+import type { AgentMessage, AgentSessionRecord } from "@/lib/types";
 
-type ChatRole = Extract<Role, "product_manager" | "architect" | "devops">;
+type TimelineMessage = AgentMessage & {
+  sessionKey: string;
+  sourceLabel: string;
+  sourceRole: AgentSessionRecord["role"];
+  session: AgentSessionRecord | null;
+};
 
 export function ProjectChatArea({
   projectId,
-  activeRole,
-  session,
+  sessions,
+  inspectedSession,
   readOnly
 }: {
   projectId: string;
-  activeRole: ChatRole;
-  session: AgentSessionRecord | null;
+  sessions: AgentSessionRecord[];
+  inspectedSession: AgentSessionRecord | null;
   readOnly: boolean;
 }) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pending, setPending] = useState(false);
-  const [optimisticMessage, setOptimisticMessage] = useState<AgentMessage | null>(null);
-  const target = activeRole === "product_manager" ? "PM" : activeRole === "architect" ? "Architect" : "DevOps";
+  const [optimisticMessage, setOptimisticMessage] = useState<TimelineMessage | null>(null);
+  const visibleSessions = readOnly && inspectedSession ? [inspectedSession] : sessions;
 
   useEffect(() => {
     setPending(false);
     setOptimisticMessage(null);
-  }, [session?.updatedAt, activeRole]);
+  }, [sessions, inspectedSession?.updatedAt, readOnly]);
 
   useEffect(() => {
     const scroll = scrollRef.current;
     if (!scroll) return;
     scroll.scrollTop = scroll.scrollHeight;
-  }, [session?.sessionKey, session?.updatedAt, session?.messages.length, optimisticMessage?.createdAt, pending]);
+  }, [visibleSessions, optimisticMessage?.createdAt, pending]);
 
   async function submitMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -46,9 +52,19 @@ export function ProjectChatArea({
     const formData = new FormData(form);
     const message = String(formData.get("message") ?? "").trim();
     if (!message) return;
+    const target = parseChatTarget(message);
+    const targetLabel = chatRoleLabel(target.role);
 
     setPending(true);
-    setOptimisticMessage({ role: "user", content: message, createdAt: new Date().toISOString() });
+    setOptimisticMessage({
+      role: "user",
+      content: target.message,
+      createdAt: new Date().toISOString(),
+      sessionKey: `pending:${target.role}`,
+      sourceLabel: `You → ${targetLabel}`,
+      sourceRole: target.role,
+      session: null
+    });
     form.reset();
 
     const response = await fetch(form.action, {
@@ -56,7 +72,7 @@ export function ProjectChatArea({
       body: formData,
       redirect: "follow"
     });
-    const destination = response.url ? new URL(response.url).pathname + new URL(response.url).search : `/projects/${projectId}?role=${activeRole}`;
+    const destination = response.url ? new URL(response.url).pathname + new URL(response.url).search : `/projects/${projectId}`;
     router.push(destination);
     router.refresh();
   }
@@ -70,16 +86,15 @@ export function ProjectChatArea({
   return (
     <>
       <div ref={scrollRef} className="chat-scroll">
-        <MessageList projectId={projectId} session={session} optimisticMessage={optimisticMessage} pending={pending} />
+        <MessageList projectId={projectId} sessions={visibleSessions} inspectedSession={readOnly ? inspectedSession : null} optimisticMessage={optimisticMessage} pending={pending} />
       </div>
       {!readOnly && (
         <div className="chat-composer">
           <form ref={formRef} method="post" action={`/api/projects/${projectId}/chat`} className="chat-composer-form" onSubmit={submitMessage}>
-            <input type="hidden" name="role" value={activeRole} />
             <Textarea
               name="message"
-              aria-label={`Message ${target}`}
-              placeholder="Describe the requirement, paste context, or ask for the next step..."
+              aria-label="Message project agents"
+              placeholder="@PM clarify scope, @architect review the plan, @devops check deployment..."
               autosize
               minRows={2}
               maxRows={7}
@@ -97,7 +112,7 @@ export function ProjectChatArea({
                   </>
                 ) : (
                   <Text size="xs" c="dimmed">
-                    Sending to <Code>{target}</Code>
+                    Default target <Code>PM</Code>
                   </Text>
                 )}
               </div>
@@ -114,16 +129,27 @@ export function ProjectChatArea({
 
 function MessageList({
   projectId,
-  session,
+  sessions,
+  inspectedSession,
   optimisticMessage,
   pending
 }: {
   projectId: string;
-  session: AgentSessionRecord | null;
-  optimisticMessage: AgentMessage | null;
+  sessions: AgentSessionRecord[];
+  inspectedSession: AgentSessionRecord | null;
+  optimisticMessage: TimelineMessage | null;
   pending: boolean;
 }) {
-  const messages = [...(session?.messages ?? []), ...(optimisticMessage ? [optimisticMessage] : [])];
+  const messages = [
+    ...sessions.flatMap((session) => session.messages.map((message) => ({
+      ...message,
+      sessionKey: session.sessionKey,
+      sourceLabel: message.role === "user" ? `You → ${chatRoleLabel(session.role, session.title, session.developerRole)}` : chatRoleLabel(session.role, session.title, session.developerRole),
+      sourceRole: session.role,
+      session
+    } satisfies TimelineMessage))),
+    ...(optimisticMessage ? [optimisticMessage] : [])
+  ].sort((left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime());
 
   if (!messages.length) {
     return <Text c="dimmed" ta="center" mt="xl">No messages yet.</Text>;
@@ -131,14 +157,17 @@ function MessageList({
 
   return (
     <Stack gap="md">
-      {session && <SessionRuntime projectId={projectId} session={session} />}
-      <Text size="sm" c="dimmed" ta="center">Session ID: <Code>{session?.sessionId ?? "local context only"}</Code></Text>
+      {inspectedSession ? <SessionRuntime projectId={projectId} session={inspectedSession} /> : null}
       {messages.map((message, index) => (
-        <div key={`${message.createdAt}-${index}`} className={`chat-message ${message.role}`}>
-          <div className="chat-avatar">{message.role === "user" ? "U" : message.role === "assistant" ? "A" : "S"}</div>
+        <div key={`${message.sessionKey}-${message.createdAt}-${index}`} className={`chat-message ${message.role}`}>
+          <div className="chat-avatar">{chatAvatarText(message)}</div>
           <div className="chat-bubble">
             <Group gap="xs" mb={6} justify="space-between" align="center">
-              <Badge variant="light">{message.role}</Badge>
+              <Group gap={6}>
+                <Badge variant="light">{message.sourceLabel}</Badge>
+                {message.session?.workflowId ? <Badge size="xs" variant="outline">{message.session.workflowId}</Badge> : null}
+                {message.session?.issueId ? <Badge size="xs" variant="outline">{message.session.issueId}</Badge> : null}
+              </Group>
               <Text component="time" dateTime={message.createdAt} size="xs" c="dimmed">
                 {formatMessageTime(message.createdAt)}
               </Text>
@@ -163,6 +192,16 @@ function MessageList({
       )}
     </Stack>
   );
+}
+
+function chatAvatarText(message: TimelineMessage): string {
+  if (message.role === "user") return "U";
+  if (message.sourceRole === "product_manager") return "PM";
+  if (message.sourceRole === "architect") return "AR";
+  if (message.sourceRole === "devops") return "DO";
+  if (message.sourceRole === "developer") return "DV";
+  if (message.sourceRole === "qa") return "QA";
+  return message.role === "assistant" ? "A" : "S";
 }
 
 function SessionRuntime({ projectId, session }: { projectId: string; session: AgentSessionRecord }) {

--- a/src/lib/chat-routing.ts
+++ b/src/lib/chat-routing.ts
@@ -1,0 +1,35 @@
+import type { Role } from "@/lib/types";
+
+export type ChatTargetRole = Extract<Role, "product_manager" | "architect" | "devops">;
+
+const mentionTargets: Record<string, ChatTargetRole> = {
+  pm: "product_manager",
+  product_manager: "product_manager",
+  productmanager: "product_manager",
+  architect: "architect",
+  arch: "architect",
+  devops: "devops",
+  ops: "devops"
+};
+
+export function parseChatTarget(input: string): { role: ChatTargetRole; message: string; mention: string | null } {
+  const trimmed = input.trim();
+  const match = trimmed.match(/^@([a-zA-Z_][\w-]*)\b\s*/);
+  if (!match) return { role: "product_manager", message: trimmed, mention: null };
+
+  const mention = match[1].toLowerCase();
+  const role = mentionTargets[mention];
+  if (!role) return { role: "product_manager", message: trimmed, mention: match[1] };
+
+  const message = trimmed.slice(match[0].length).trim();
+  return { role, message, mention: match[1] };
+}
+
+export function chatRoleLabel(role: Role, title?: string | null, developerRole?: string | null): string {
+  if (role === "product_manager") return "PM";
+  if (role === "architect") return "Architect";
+  if (role === "devops") return "DevOps";
+  if (role === "qa") return title && title !== "QA" ? (title.toLowerCase().startsWith("qa") ? title : `QA: ${title}`) : "QA";
+  if (role === "developer") return developerRole ? `Developer: ${developerRole}` : title ? `Developer: ${title}` : "Developer";
+  return title ?? "System";
+}


### PR DESCRIPTION
Closes #100

## Summary
- Replace role-tab chat with a unified all-agent project timeline.
- Merge PM, architect, DevOps, developer, QA, and session messages chronologically with source labels and timestamps.
- Route manual messages by @PM, @architect, and @devops prefixes; unmentioned messages default to PM.
- Preserve read-only single-session inspection when opening an agent session link.
- Add chat routing tests for mention parsing and role labels.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Validate a project with PM, architect, developer, and QA sessions: the main project chat should show all messages in chronological order with role/source labels. Send an unmentioned message and confirm it routes to PM. Send @architect and @devops messages and confirm they append to the correct agent sessions. Open a developer or QA session link and confirm the view is read-only and scoped to that session.