### PR TITLE
Show Codex execution logs in agent chat

### DIFF
--- a/src/app/api/projects/[projectId]/chat/route.ts
+++ b/src/app/api/projects/[projectId]/chat/route.ts
@@ -49,6 +49,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ pro
     role,
     title: chatRoleLabel(role),
     sessionId: result.sessionId ?? currentSessionId ?? existing?.sessionId ?? null,
+    executionLogs: result.executionLog ? [{
+      title: `${chatRoleLabel(role)} Codex execution`,
+      content: result.executionLog,
+      createdAt: new Date().toISOString(),
+      status: "ok"
+    }] : [],
     messages: [
       { role: "user", content: message, createdAt: now },
       { role: "assistant", content: result.text, createdAt: new Date().toISOString() }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -813,6 +813,34 @@ pre,
   line-height: var(--leading-tight);
 }
 
+.execution-log-bubble details {
+  margin: 0;
+}
+
+.execution-log-bubble summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.execution-log-bubble summary::-webkit-details-marker {
+  display: none;
+}
+
+.execution-log-content {
+  max-height: 360px;
+  margin: 12px 0 0;
+  padding: 12px;
+  overflow: auto;
+  color: #1f2937;
+  background: #f8fafc;
+  border: 1px solid #dbe5f3;
+  border-radius: 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
 .project-context {
   position: sticky;
   top: 18px;

--- a/src/components/ProjectChatArea.tsx
+++ b/src/components/ProjectChatArea.tsx
@@ -9,10 +9,19 @@ import { chatRoleLabel, parseChatTarget } from "@/lib/chat-routing";
 import type { AgentMessage, AgentSessionRecord } from "@/lib/types";
 
 type TimelineMessage = AgentMessage & {
+  kind: "message";
   sessionKey: string;
   sourceLabel: string;
   sourceRole: AgentSessionRecord["role"];
   session: AgentSessionRecord | null;
+};
+
+type TimelineExecutionLog = NonNullable<AgentSessionRecord["executionLogs"]>[number] & {
+  kind: "execution-log";
+  sessionKey: string;
+  sourceLabel: string;
+  sourceRole: AgentSessionRecord["role"];
+  session: AgentSessionRecord;
 };
 
 export function ProjectChatArea({
@@ -58,6 +67,7 @@ export function ProjectChatArea({
     setPending(true);
     setOptimisticMessage({
       role: "user",
+      kind: "message",
       content: target.message,
       createdAt: new Date().toISOString(),
       sessionKey: `pending:${target.role}`,
@@ -143,11 +153,20 @@ function MessageList({
   const messages = [
     ...sessions.flatMap((session) => session.messages.map((message) => ({
       ...message,
+      kind: "message",
       sessionKey: session.sessionKey,
       sourceLabel: message.role === "user" ? `You → ${chatRoleLabel(session.role, session.title, session.developerRole)}` : chatRoleLabel(session.role, session.title, session.developerRole),
       sourceRole: session.role,
       session
     } satisfies TimelineMessage))),
+    ...sessions.flatMap((session) => (session.executionLogs ?? []).map((log) => ({
+      ...log,
+      kind: "execution-log",
+      sessionKey: session.sessionKey,
+      sourceLabel: chatRoleLabel(session.role, session.title, session.developerRole),
+      sourceRole: session.role,
+      session
+    } satisfies TimelineExecutionLog))),
     ...(optimisticMessage ? [optimisticMessage] : [])
   ].sort((left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime());
 
@@ -159,22 +178,26 @@ function MessageList({
     <Stack gap="md">
       {inspectedSession ? <SessionRuntime projectId={projectId} session={inspectedSession} /> : null}
       {messages.map((message, index) => (
-        <div key={`${message.sessionKey}-${message.createdAt}-${index}`} className={`chat-message ${message.role}`}>
-          <div className="chat-avatar">{chatAvatarText(message)}</div>
-          <div className="chat-bubble">
-            <Group gap="xs" mb={6} justify="space-between" align="center">
-              <Group gap={6}>
-                <Badge variant="light">{message.sourceLabel}</Badge>
-                {message.session?.workflowId ? <Badge size="xs" variant="outline">{message.session.workflowId}</Badge> : null}
-                {message.session?.issueId ? <Badge size="xs" variant="outline">{message.session.issueId}</Badge> : null}
-              </Group>
-              <Text component="time" dateTime={message.createdAt} size="xs" c="dimmed">
-                {formatMessageTime(message.createdAt)}
-              </Text>
-            </Group>
-            <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
-          </div>
-        </div>
+        message.kind === "execution-log"
+          ? <ExecutionLogItem key={`${message.sessionKey}-log-${message.createdAt}-${index}`} log={message} />
+          : (
+            <div key={`${message.sessionKey}-${message.createdAt}-${index}`} className={`chat-message ${message.role}`}>
+              <div className="chat-avatar">{chatAvatarText(message)}</div>
+              <div className="chat-bubble">
+                <Group gap="xs" mb={6} justify="space-between" align="center">
+                  <Group gap={6}>
+                    <Badge variant="light">{message.sourceLabel}</Badge>
+                    {message.session?.workflowId ? <Badge size="xs" variant="outline">{message.session.workflowId}</Badge> : null}
+                    {message.session?.issueId ? <Badge size="xs" variant="outline">{message.session.issueId}</Badge> : null}
+                  </Group>
+                  <Text component="time" dateTime={message.createdAt} size="xs" c="dimmed">
+                    {formatMessageTime(message.createdAt)}
+                  </Text>
+                </Group>
+                <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
+              </div>
+            </div>
+          )
       ))}
       {pending && (
         <div className="chat-message assistant pending">
@@ -194,14 +217,39 @@ function MessageList({
   );
 }
 
-function chatAvatarText(message: TimelineMessage): string {
-  if (message.role === "user") return "U";
+function ExecutionLogItem({ log }: { log: TimelineExecutionLog }) {
+  return (
+    <div className="chat-message system">
+      <div className="chat-avatar">{chatAvatarText(log)}</div>
+      <div className="chat-bubble execution-log-bubble">
+        <details>
+          <summary>
+            <Group gap="xs" justify="space-between" wrap="nowrap">
+              <Group gap={6}>
+                <Badge variant="light">{log.sourceLabel}</Badge>
+                <Badge size="xs" color={log.status === "failed" ? "red" : "green"} variant="light">execution log</Badge>
+              </Group>
+              <Text component="time" dateTime={log.createdAt} size="xs" c="dimmed">
+                {formatMessageTime(log.createdAt)}
+              </Text>
+            </Group>
+            <Text size="sm" fw={760} mt={6}>{log.title}</Text>
+          </summary>
+          <pre className="execution-log-content">{log.content || "No Codex execution output captured."}</pre>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+function chatAvatarText(message: TimelineMessage | TimelineExecutionLog): string {
+  if (message.kind === "message" && message.role === "user") return "U";
   if (message.sourceRole === "product_manager") return "PM";
   if (message.sourceRole === "architect") return "AR";
   if (message.sourceRole === "devops") return "DO";
   if (message.sourceRole === "developer") return "DV";
   if (message.sourceRole === "qa") return "QA";
-  return message.role === "assistant" ? "A" : "S";
+  return message.kind === "message" && message.role === "assistant" ? "A" : "S";
 }
 
 function SessionRuntime({ projectId, session }: { projectId: string; session: AgentSessionRecord }) {

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -10,7 +10,7 @@ import type { ArchitectPrReviewResult, ArchitectReviewResult, DeveloperIssueResu
 import { dataDir, rootDir } from "@/lib/paths";
 import type { Settings } from "@/lib/types";
 
-type CodexTextResult = { text: string; sessionId?: string | null };
+type CodexTextResult = { text: string; sessionId?: string | null; executionLog?: string };
 type RunJsonOptions = { cwd?: string };
 type RunCodexOptions = { cwd?: string };
 const execFileAsync = promisify(execFile);
@@ -332,12 +332,13 @@ Execution rules:
 
 Return JSON with summary, branch, prUrl, changedFiles, testsRun.`;
     const result = await this.runJsonResult<DeveloperIssueResult>(prompt, schema, { cwd: workspaceDir });
-    return result.value ?? {
+    return result.value ? { ...result.value, executionLog: result.executionLog } : {
       summary: `Developer runner did not complete issue #${input.issueNumber}.${result.error ? `\n\nCodex error:\n${result.error}` : ""}`,
       branch: "",
       prUrl: "",
       changedFiles: [],
-      testsRun: []
+      testsRun: [],
+      executionLog: result.executionLog
     };
   }
 
@@ -372,11 +373,13 @@ Required GitHub label behavior:
 - If auto deploy is enabled and QA has passed, verify repository checks and branch state, then still stop at decision "ready_to_merge" without merging.
 
 Return JSON with decision, summary, labelsApplied, comments.`;
-    return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {
+    const result = await this.runJsonResult<ArchitectPrReviewResult>(prompt, schema);
+    return result.value ? { ...result.value, executionLog: result.executionLog } : {
       decision: "blocked",
       summary: `Architect runner did not complete PR review for ${input.prUrl}.`,
       labelsApplied: [],
-      comments: []
+      comments: [],
+      executionLog: result.executionLog
     };
   }
 
@@ -411,11 +414,13 @@ Rules:
 - Return "blocked" if readiness cannot be determined from available GitHub state.
 
 Return JSON with decision, summary, labelsApplied, comments. Set labelsApplied to an empty array.`;
-    return (await this.runJson<ArchitectPrReviewResult>(prompt, schema)) ?? {
+    const result = await this.runJsonResult<ArchitectPrReviewResult>(prompt, schema);
+    return result.value ? { ...result.value, executionLog: result.executionLog } : {
       decision: "blocked",
       summary: `Architect runner did not complete manual ready review for ${input.prUrl}.`,
       labelsApplied: [],
-      comments: []
+      comments: [],
+      executionLog: result.executionLog
     };
   }
 
@@ -446,12 +451,14 @@ Required GitHub label behavior:
 - If failed, comment findings on the PR, add taskix:qa-failed, and remove taskix:qa-running.
 
 Return JSON with passed, summary, findings, labelsApplied, testsRun.`;
-    return (await this.runJson<QaPrReviewResult>(prompt, schema)) ?? {
+    const result = await this.runJsonResult<QaPrReviewResult>(prompt, schema);
+    return result.value ? { ...result.value, executionLog: result.executionLog } : {
       passed: false,
       summary: `QA runner did not complete PR review for ${input.prUrl}.`,
       findings: ["QA runner did not return a result."],
       labelsApplied: [],
-      testsRun: []
+      testsRun: [],
+      executionLog: result.executionLog
     };
   }
 
@@ -557,7 +564,7 @@ Summarize code review outcome, merge readiness, and deployment status according 
     return (await this.runJsonResult<T>(prompt, schema)).value;
   }
 
-  private async runJsonResult<T>(prompt: string, schema: object, options: RunJsonOptions = {}): Promise<{ value: T | null; error: string | null }> {
+  private async runJsonResult<T>(prompt: string, schema: object, options: RunJsonOptions = {}): Promise<{ value: T | null; error: string | null; executionLog: string }> {
     const tmp = await this.tmpDir();
     const schemaPath = path.join(tmp, "schema.json");
     const outputPath = path.join(tmp, "output.json");
@@ -575,11 +582,12 @@ Summarize code review outcome, merge readiness, and deployment status according 
       outputPath,
       prompt
     ], { cwd: options.cwd });
-    if (!result.ok) return { value: null, error: result.stderr.trim() || "Codex exited with a non-zero status." };
+    const executionLog = formatCodexExecutionLog(result.stdout, result.stderr);
+    if (!result.ok) return { value: null, error: result.stderr.trim() || "Codex exited with a non-zero status.", executionLog };
     try {
-      return { value: JSON.parse(await readFile(outputPath, "utf8")) as T, error: null };
+      return { value: JSON.parse(await readFile(outputPath, "utf8")) as T, error: null, executionLog };
     } catch {
-      return { value: null, error: "Codex completed but did not produce valid JSON output." };
+      return { value: null, error: "Codex completed but did not produce valid JSON output.", executionLog };
     }
   }
 
@@ -590,13 +598,13 @@ Summarize code review outcome, merge readiness, and deployment status according 
     const result = await this.runCodex(args);
     if (!result.ok) return null;
     try {
-      return { text: (await readFile(outputPath, "utf8")).trim(), sessionId: extractSessionId(result.stderr) ?? sessionId };
+      return { text: (await readFile(outputPath, "utf8")).trim(), sessionId: extractSessionId(result.stderr) ?? sessionId, executionLog: formatCodexExecutionLog(result.stdout, result.stderr) };
     } catch {
       return null;
     }
   }
 
-  private async runCodex(args: string[], options: RunCodexOptions = {}): Promise<{ ok: boolean; stderr: string }> {
+  private async runCodex(args: string[], options: RunCodexOptions = {}): Promise<{ ok: boolean; stdout: string; stderr: string }> {
     const codexHome = this.settings.codexHome;
     await mkdir(codexHome, { recursive: true });
     return new Promise((resolve) => {
@@ -605,14 +613,18 @@ Summarize code review outcome, merge readiness, and deployment status according 
         env: { ...process.env, CODEX_HOME: codexHome },
         stdio: ["ignore", "pipe", "pipe"]
       });
+      let stdout = "";
       let stderr = "";
       let settled = false;
       const timeout = setTimeout(() => {
         if (settled) return;
         settled = true;
         child.kill("SIGTERM");
-        resolve({ ok: false, stderr: `${stderr}\nCodex timed out after ${Math.round(codexTimeoutMs / 1000)} seconds.` });
+        resolve({ ok: false, stdout, stderr: `${stderr}\nCodex timed out after ${Math.round(codexTimeoutMs / 1000)} seconds.` });
       }, codexTimeoutMs);
+      child.stdout.on("data", (chunk) => {
+        stdout += String(chunk);
+      });
       child.stderr.on("data", (chunk) => {
         stderr += String(chunk);
       });
@@ -620,13 +632,13 @@ Summarize code review outcome, merge readiness, and deployment status according 
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        resolve({ ok: false, stderr });
+        resolve({ ok: false, stdout, stderr });
       });
       child.on("close", (code) => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        resolve({ ok: code === 0, stderr });
+        resolve({ ok: code === 0, stdout, stderr });
       });
     });
   }
@@ -668,6 +680,14 @@ function objectSchema(properties: Record<string, unknown>): object {
 function extractSessionId(stderr: string): string | null {
   const line = stderr.split("\n").find((item) => item.toLowerCase().includes("session id:"));
   return line?.split(":").slice(1).join(":").trim() || null;
+}
+
+function formatCodexExecutionLog(stdout: string, stderr: string): string {
+  const sections = [
+    stdout.trim() ? `stdout\n${stdout.trim()}` : "",
+    stderr.trim() ? `stderr\n${stderr.trim()}` : ""
+  ].filter(Boolean);
+  return sections.join("\n\n");
 }
 
 function approvalArgs(policy: string): string[] {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -322,6 +322,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
       labels: developerResult.prUrl ? ["taskix:pr-opened", "taskix:architect-review"] : ["taskix:blocked"],
       closedAt: closeAt,
       archivedAt: closeAt,
+      executionLogs: developerResult.executionLog ? [{
+        title: `Developer Codex execution for ${issue.title}`,
+        content: developerResult.executionLog,
+        createdAt: finishedAt,
+        status: developerResult.prUrl ? "ok" : "failed"
+      }] : [],
       messages: [
         { role: "assistant", content: `Summary: ${developerResult.summary}\nBranch: ${developerResult.branch || "none"}\nPR: ${developerResult.prUrl || "none"}\nTests: ${developerResult.testsRun.join(", ") || "none"}`, createdAt: new Date().toISOString() }
       ]
@@ -354,6 +360,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
       title: "Architect",
       workflowId: workflow.workflowId,
       issueId: issue.issueId,
+      executionLogs: architectReview.executionLog ? [{
+        title: `Architect Codex review for ${issue.title}`,
+        content: architectReview.executionLog,
+        createdAt: new Date().toISOString(),
+        status: architectReview.decision === "blocked" || architectReview.decision === "changes_requested" ? "failed" : "ok"
+      }] : [],
       messages: [
         { role: "user", content: `Review PR for issue ${issue.issueId}: ${developerResult.prUrl}`, createdAt: new Date().toISOString() },
         { role: "assistant", content: `Decision: ${architectReview.decision}\n${architectReview.summary}\nLabels: ${architectReview.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }
@@ -416,6 +428,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
       labels: qaResult.labelsApplied,
       closedAt: qaCloseAt,
       archivedAt: qaCloseAt,
+      executionLogs: qaResult.executionLog ? [{
+        title: `QA Codex execution for ${issue.title}`,
+        content: qaResult.executionLog,
+        createdAt: qaFinishedAt,
+        status: qaResult.passed ? "ok" : "failed"
+      }] : [],
       messages: [
           { role: "assistant", content: `Passed: ${qaResult.passed}\n${qaResult.summary}\nFindings:\n${qaResult.findings.map((finding) => `- ${finding}`).join("\n") || "- none"}\nLabels: ${qaResult.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }
       ]
@@ -432,6 +450,12 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
           title: "Architect",
           workflowId: workflow.workflowId,
           issueId: issue.issueId,
+          executionLogs: architectReview.executionLog ? [{
+            title: `Architect final Codex review for ${issue.title}`,
+            content: architectReview.executionLog,
+            createdAt: new Date().toISOString(),
+            status: architectReview.decision === "blocked" || architectReview.decision === "changes_requested" ? "failed" : "ok"
+          }] : [],
           messages: [
             { role: "user", content: `QA passed PR ${developerResult.prUrl}. Perform final review/merge for issue ${issue.issueId}.`, createdAt: new Date().toISOString() },
             { role: "assistant", content: `Decision: ${architectReview.decision}\n${architectReview.summary}\nLabels: ${architectReview.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -217,6 +217,7 @@ export async function appendAgentMessages(input: {
   closedAt?: string | null;
   archivedAt?: string | null;
   status?: AgentSessionRecord["status"];
+  executionLogs?: NonNullable<AgentSessionRecord["executionLogs"]>;
   messages: AgentSessionRecord["messages"];
 }): Promise<AgentSessionRecord> {
   const now = new Date().toISOString();
@@ -244,6 +245,7 @@ export async function appendAgentMessages(input: {
     closedAt: input.closedAt ?? existing?.closedAt ?? null,
     archivedAt: input.archivedAt ?? existing?.archivedAt ?? null,
     messages: [...(existing?.messages ?? []), ...input.messages],
+    executionLogs: [...(existing?.executionLogs ?? []), ...(input.executionLogs ?? [])],
     updatedAt: now
   };
   await saveAgentSession(session);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export type DeveloperIssueResult = {
   prUrl: string;
   changedFiles: string[];
   testsRun: string[];
+  executionLog?: string;
 };
 
 export type ArchitectPrReviewDecision = "need_qa" | "ready_to_merge" | "changes_requested" | "merged" | "blocked";
@@ -75,6 +76,7 @@ export type ArchitectPrReviewResult = {
   summary: string;
   labelsApplied: string[];
   comments: string[];
+  executionLog?: string;
 };
 
 export type QaPrReviewResult = {
@@ -83,6 +85,7 @@ export type QaPrReviewResult = {
   findings: string[];
   labelsApplied: string[];
   testsRun: string[];
+  executionLog?: string;
 };
 
 export type QaResult = {
@@ -160,6 +163,13 @@ export type AgentMessage = {
   createdAt: string;
 };
 
+export type AgentExecutionLog = {
+  title: string;
+  content: string;
+  createdAt: string;
+  status?: "ok" | "failed";
+};
+
 export type AgentSessionRecord = {
   sessionKey: string;
   projectId: string;
@@ -183,6 +193,7 @@ export type AgentSessionRecord = {
   closedAt?: string | null;
   archivedAt?: string | null;
   messages: AgentMessage[];
+  executionLogs?: AgentExecutionLog[];
   updatedAt: string;
 };
 


### PR DESCRIPTION
Closes #102

## Summary
- Persist Codex stdout/stderr-style execution output as session execution logs.
- Capture logs for manual PM/architect/DevOps chat calls and workflow developer, QA, and Codex-backed architect review runs.
- Render execution logs in the unified project chat as compact expandable blocks instead of normal chat spam.
- Keep existing summary messages visible in the chronological timeline.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Validate a manual @PM/@architect/@devops chat: after the agent responds, the unified chat should include an expandable execution log block near that response. Validate a workflow developer or QA run: the agent summary remains visible and a separate execution log block can be expanded to inspect captured Codex output. Existing sessions without executionLogs should render normally.