### PR TITLE
Update web header label to Gitdex Console

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <div className="mark">TB</div>
               <div>
                 <Text fw={800} size="md" c="white" lh={1.15}>
-                  Taskix Hub
+                  Gitdex Console
                 </Text>
                 <Text size="xs" c="blue.1">
                   Project routing, Codex sessions, GitHub orchestration


### PR DESCRIPTION
Closes #104

## Summary
- Updated the visible topbar header label to `Gitdex Console`.
- Preserved the existing header component structure, layout, styling, routes, metadata, package names, product identifiers, and unrelated copy.

## Verification
- `npm run typecheck` passed.
- `npm run build` passed.

## QA Notes
- The current base branch did not contain the exact `Taskix Management` text; the visible topbar header label was `Taskix Hub` in `src/app/layout.tsx`.
- The visible header now renders `Gitdex Console` in the same Mantine `Text` element and layout.