### PR TITLE
Detect and retry stalled Codex jobs

### DIFF
--- a/src/app/api/projects/[projectId]/jobs/[jobId]/retry/route.ts
+++ b/src/app/api/projects/[projectId]/jobs/[jobId]/retry/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { createJob, getJob, getProject, getWorkflow, saveJob, saveWorkflow } from "@/lib/store";
+
+export async function POST(_request: Request, context: { params: Promise<unknown> }) {
+  const { projectId, jobId } = await context.params as { projectId: string; jobId: string };
+  const [project, job] = await Promise.all([getProject(projectId), getJob(jobId)]);
+  if (!project) return NextResponse.json({ error: "Project not found." }, { status: 404 });
+  if (!job || job.projectId !== project.projectId) return NextResponse.json({ error: "Job not found." }, { status: 404 });
+  if (job.status !== "failed") return NextResponse.json({ error: "Only failed or stalled jobs can be retried." }, { status: 409 });
+
+  const now = new Date().toISOString();
+  job.error = job.error ? `Retry queued after failure: ${job.error}` : "Retry queued after stalled job.";
+  job.updatedAt = now;
+  job.runtime = { ...(job.runtime ?? {}), finishedAt: job.runtime?.finishedAt ?? now };
+  await saveJob(job);
+
+  const retryJob = await createJob({
+    projectId: project.projectId,
+    type: job.type,
+    payload: job.payload
+  });
+
+  const workflow = await getWorkflow(job.payload.workflowId);
+  if (workflow) {
+    workflow.status = "in_progress";
+    workflow.timeline.push(`Retry queued for ${job.type} job ${job.jobId}.`);
+    await saveWorkflow(workflow);
+  }
+
+  return NextResponse.json({ ok: true, jobId: retryJob.jobId, runStatus: retryJob.status });
+}

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -7,6 +7,7 @@ import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
 import { ProjectMergePrButton } from "@/components/ProjectMergePrButton";
+import { ProjectRetryJobButton } from "@/components/ProjectRetryJobButton";
 import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
@@ -238,14 +239,14 @@ function buildWorkflowStepDetails(input: {
           </Alert>
         ) : null}
         {renderStepRunAction(input.projectId, input.jobs, "workflow_run", "Run Architect Planning")}
-        {renderJobRows(input.jobs.filter((job) => job.type === "workflow_run"), input.queuedJobId)}
+        {renderJobRows(input.projectId, input.jobs.filter((job) => job.type === "workflow_run"), input.queuedJobId)}
         {renderSessionRows(input.sessions.filter((session) => session.role === "architect"))}
       </Stack>
     ),
     developer: (
       <Stack gap="xs">
         {renderStepRunAction(input.projectId, input.jobs, "issue_run", "Run Developer Jobs")}
-        {renderJobRows(input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
+        {renderJobRows(input.projectId, input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
         {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
       </Stack>
@@ -326,7 +327,7 @@ function renderWorkflowActionRows(projectId: string, workflows: WorkflowRecord[]
   ));
 }
 
-function renderJobRows(jobs: JobRecord[], queuedJobId: string | null): ReactNode {
+function renderJobRows(projectId: string, jobs: JobRecord[], queuedJobId: string | null): ReactNode {
   if (!jobs.length) return <Text size="xs" c="dimmed">No jobs recorded for this step.</Text>;
   return jobs.slice(0, 4).map((job) => (
     <div
@@ -336,11 +337,15 @@ function renderJobRows(jobs: JobRecord[], queuedJobId: string | null): ReactNode
     >
       <Group justify="space-between" gap="xs" wrap="nowrap">
         <Text size="sm" fw={700}>{job.type}</Text>
-        <Badge size="xs" variant="light">{job.status}</Badge>
+        <Group gap={6} wrap="nowrap">
+          <Badge size="xs" color={job.status === "failed" ? "red" : undefined} variant="light">{job.status}</Badge>
+          {job.status === "failed" ? <ProjectRetryJobButton projectId={projectId} jobId={job.jobId} /> : null}
+        </Group>
       </Group>
       <Text size="xs" c="dimmed" mt={4}>
         Job {job.jobId}
         {job.payload.workflowId ? ` · workflow ${job.payload.workflowId}` : ""}
+        {job.runtime?.lastHeartbeatAt ? ` · last heartbeat ${formatDate(job.runtime.lastHeartbeatAt)}` : ""}
         {job.error ? ` · ${job.error}` : ""}
       </Text>
     </div>

--- a/src/components/ProjectRetryJobButton.tsx
+++ b/src/components/ProjectRetryJobButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Button } from "@mantine/core";
+import { RotateCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function ProjectRetryJobButton({ projectId, jobId }: { projectId: string; jobId: string }) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  async function retryJob() {
+    setPending(true);
+    try {
+      await fetch(`/api/projects/${projectId}/jobs/${jobId}/retry`, { method: "POST" });
+      router.refresh();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Button type="button" variant="light" color="red" size="compact-xs" radius="xl" leftSection={<RotateCcw size={14} />} loading={pending} onClick={retryJob}>
+      Retry
+    </Button>
+  );
+}

--- a/src/lib/codex.ts
+++ b/src/lib/codex.ts
@@ -6,6 +6,8 @@ import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { developerRoleIds, developerRoleProfile, formatDeveloperRoleCatalog } from "@/lib/developer-roles";
 import { expectedDeveloperBaseBranch } from "@/lib/issue-run-policy";
+import { getActiveJobId } from "@/lib/job-runtime";
+import { touchJobRuntime } from "@/lib/store";
 import type { ArchitectPrReviewResult, ArchitectReviewResult, DeveloperIssueResult, DeveloperResult, IssueSpec, QaPrReviewResult, QaResult } from "@/lib/types";
 import { dataDir, rootDir } from "@/lib/paths";
 import type { Settings } from "@/lib/types";
@@ -616,6 +618,8 @@ Summarize code review outcome, merge readiness, and deployment status according 
       let stdout = "";
       let stderr = "";
       let settled = false;
+      const activeJobId = getActiveJobId();
+      if (activeJobId) void touchJobRuntime(activeJobId, { pid: child.pid ?? null });
       const timeout = setTimeout(() => {
         if (settled) return;
         settled = true;
@@ -624,9 +628,11 @@ Summarize code review outcome, merge readiness, and deployment status according 
       }, codexTimeoutMs);
       child.stdout.on("data", (chunk) => {
         stdout += String(chunk);
+        if (activeJobId) void touchJobRuntime(activeJobId, { output: true });
       });
       child.stderr.on("data", (chunk) => {
         stderr += String(chunk);
+        if (activeJobId) void touchJobRuntime(activeJobId, { output: true });
       });
       child.on("error", () => {
         if (settled) return;

--- a/src/lib/job-runner.ts
+++ b/src/lib/job-runner.ts
@@ -1,13 +1,16 @@
 import { runWorkflow, runWorkflowIssue, syncWorkflowFromGitHub } from "@/lib/orchestrator";
-import { claimNextPendingJob, getProject, getWorkflow, saveJob } from "@/lib/store";
+import { runWithJobRuntime } from "@/lib/job-runtime";
+import { claimNextPendingJob, getJob, getProject, getWorkflow, saveJob } from "@/lib/store";
 import type { JobRecord } from "@/lib/types";
 
 export async function runNextJob(projectId?: string): Promise<{ job: JobRecord | null; ran: boolean }> {
   const job = await claimNextPendingJob(projectId);
   if (!job) return { job: null, ran: false };
+  let skipped = false;
 
   try {
-    if (job.type === "workflow_run" || job.type === "issue_run") {
+    await runWithJobRuntime(job.jobId, async () => {
+      if (job.type !== "workflow_run" && job.type !== "issue_run") return;
       const project = job.projectId ? await getProject(job.projectId) : null;
       const workflow = await getWorkflow(job.payload.workflowId);
       if (workflow?.paused) {
@@ -15,7 +18,8 @@ export async function runNextJob(projectId?: string): Promise<{ job: JobRecord |
         job.error = "Workflow is paused";
         job.updatedAt = new Date().toISOString();
         await saveJob(job);
-        return { job, ran: false };
+        skipped = true;
+        return;
       }
       if (job.type === "issue_run" && job.payload.issueId) {
         await runWorkflowIssue(job.payload.workflowId, job.payload.issueId, project);
@@ -23,15 +27,19 @@ export async function runNextJob(projectId?: string): Promise<{ job: JobRecord |
         await runWorkflow(job.payload.workflowId, project);
       }
       await syncWorkflowFromGitHub(job.payload.workflowId, project);
+    });
+    if (!skipped) {
+      job.status = "done";
+      job.error = null;
     }
-    job.status = "done";
-    job.error = null;
   } catch (error) {
     job.status = "failed";
     job.error = error instanceof Error ? error.message : "Unknown job failure";
   }
 
+  const latestJob = await getJob(job.jobId);
   job.updatedAt = new Date().toISOString();
+  job.runtime = { ...(job.runtime ?? {}), ...(latestJob?.runtime ?? {}), finishedAt: skipped ? latestJob?.runtime?.finishedAt ?? job.runtime?.finishedAt ?? null : job.updatedAt };
   await saveJob(job);
-  return { job, ran: true };
+  return { job, ran: !skipped };
 }

--- a/src/lib/job-runtime.ts
+++ b/src/lib/job-runtime.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const jobRuntime = new AsyncLocalStorage<string>();
+
+export function runWithJobRuntime<T>(jobId: string, callback: () => Promise<T>): Promise<T> {
+  return jobRuntime.run(jobId, callback);
+}
+
+export function getActiveJobId(): string | null {
+  return jobRuntime.getStore() ?? null;
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -3,7 +3,7 @@ import { getDb } from "@/lib/db";
 import { deleteProjectLocalState } from "@/lib/project-delete";
 import type { AgentSessionRecord, JobRecord, JobType, ProjectRecord, Role, WorkflowRecord } from "@/lib/types";
 
-const RUNNING_JOB_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const RUNNING_JOB_TIMEOUT_MS = 15 * 60 * 1000;
 
 export async function listProjects(): Promise<ProjectRecord[]> {
   const rows = getDb().prepare("SELECT payload FROM projects ORDER BY created_at ASC").all() as { payload: string }[];
@@ -136,7 +136,28 @@ export async function saveJob(job: JobRecord): Promise<void> {
     .run(job.jobId, job.projectId ?? null, job.type, job.status, job.createdAt, job.updatedAt, JSON.stringify(job));
 }
 
+export async function getJob(jobId: string): Promise<JobRecord | null> {
+  const row = getDb().prepare("SELECT payload FROM jobs WHERE job_id = ?").get(jobId) as { payload: string } | undefined;
+  return row ? (JSON.parse(row.payload) as JobRecord) : null;
+}
+
+export async function touchJobRuntime(jobId: string, input: { pid?: number | null; output?: boolean } = {}): Promise<void> {
+  const job = await getJob(jobId);
+  if (!job || job.status !== "running") return;
+  const now = new Date().toISOString();
+  job.runtime = {
+    ...(job.runtime ?? {}),
+    pid: input.pid ?? job.runtime?.pid ?? null,
+    startedAt: job.runtime?.startedAt ?? job.updatedAt ?? now,
+    lastHeartbeatAt: now,
+    lastOutputAt: input.output ? now : job.runtime?.lastOutputAt ?? null
+  };
+  job.updatedAt = now;
+  await saveJob(job);
+}
+
 export async function listJobs(projectId?: string): Promise<JobRecord[]> {
+  await recoverStaleRunningJobs(projectId);
   const rows = projectId
     ? getDb().prepare("SELECT payload FROM jobs WHERE project_id = ? ORDER BY created_at DESC").all(projectId) as { payload: string }[]
     : getDb().prepare("SELECT payload FROM jobs ORDER BY created_at DESC").all() as { payload: string }[];
@@ -154,7 +175,16 @@ export async function claimNextPendingJob(projectId?: string): Promise<JobRecord
   const job = JSON.parse(row.payload) as JobRecord;
   job.status = "running";
   job.attempts += 1;
-  job.updatedAt = new Date().toISOString();
+  const now = new Date().toISOString();
+  job.updatedAt = now;
+  job.runtime = {
+    ...(job.runtime ?? {}),
+    pid: null,
+    startedAt: now,
+    lastHeartbeatAt: now,
+    lastOutputAt: null,
+    finishedAt: null
+  };
   await saveJob(job);
   return job;
 }
@@ -167,12 +197,13 @@ async function recoverStaleRunningJobs(projectId?: string): Promise<void> {
 
   for (const row of rows) {
     const job = JSON.parse(row.payload) as JobRecord;
-    const updatedAt = new Date(job.updatedAt).getTime();
-    if (!Number.isFinite(updatedAt) || now - updatedAt < RUNNING_JOB_TIMEOUT_MS) continue;
+    const heartbeatAt = new Date(job.runtime?.lastHeartbeatAt ?? job.updatedAt).getTime();
+    if (!Number.isFinite(heartbeatAt) || now - heartbeatAt < RUNNING_JOB_TIMEOUT_MS) continue;
 
     job.status = "failed";
-    job.error = `Job timed out after ${Math.round(RUNNING_JOB_TIMEOUT_MS / 60000)} minutes without an update. Retry the workflow job.`;
+    job.error = `Job stalled after ${Math.round(RUNNING_JOB_TIMEOUT_MS / 60000)} minutes without Codex output or heartbeat. Retry the workflow job.`;
     job.updatedAt = new Date().toISOString();
+    job.runtime = { ...(job.runtime ?? {}), finishedAt: job.updatedAt };
     await saveJob(job);
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -206,6 +206,13 @@ export type JobRecord = {
   updatedAt: string;
   attempts: number;
   error?: string | null;
+  runtime?: {
+    pid?: number | null;
+    startedAt?: string | null;
+    lastHeartbeatAt?: string | null;
+    lastOutputAt?: string | null;
+    finishedAt?: string | null;
+  };
   payload: {
     workflowId: string;
     issueId?: string | null;


### PR DESCRIPTION
Closes #107

## Summary
- Track Codex job runtime metadata, including pid, startedAt, heartbeat, last output, and finishedAt.
- Refresh job heartbeat when Codex emits stdout/stderr output.
- Mark running jobs failed after 15 minutes without heartbeat so they no longer block Run Jobs indefinitely.
- Add a step-level Retry button for failed/stalled jobs, backed by a job retry API that queues a replacement pending job.
- Preserve existing Run Jobs behavior for pending jobs.

## Verification
- npm test
- npm run typecheck
- npm run build

Note: the first typecheck run hit stale .next generated route types; build regenerated them and the follow-up typecheck passed.

## QA Notes
Validate a failed/stalled workflow job appears in the relevant workflow step with its last heartbeat/error and a Retry button. Clicking Retry should create a new pending job for the same workflow/issue and allow Run Jobs to continue. Existing pending/running/done jobs should keep their current behavior.