### PR TITLE
Add focused verification for header label

### DIFF
--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { HEADER_LABEL } from "../src/components/header-label.ts";
+
+assert.equal(HEADER_LABEL, "Gitdex Console");
+
+const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+
+assert.match(layoutSource, /import \{ HEADER_LABEL \} from "@\/components\/header-label";/);
+assert.match(layoutSource, /\{HEADER_LABEL\}/);
+
+console.log("header label verification passed");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Badge, Code, Group, Text } from "@mantine/core";
 import { getSettings } from "@/lib/settings";
 import { listProjects, listWorkflows } from "@/lib/store";
+import { HEADER_LABEL } from "@/components/header-label";
 import { Providers } from "@/components/Providers";
 import { ShellLayout } from "@/components/ShellLayout";
 import "@mantine/core/styles.css";
@@ -24,7 +25,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <div className="mark">TB</div>
               <div>
                 <Text fw={800} size="md" c="white" lh={1.15}>
-                  Taskix Hub
+                  {HEADER_LABEL}
                 </Text>
                 <Text size="xs" c="blue.1">
                   Project routing, Codex sessions, GitHub orchestration

--- a/src/components/header-label.ts
+++ b/src/components/header-label.ts
@@ -1,0 +1,1 @@
+export const HEADER_LABEL = "Gitdex Console";


### PR DESCRIPTION
Closes #105

## Summary
- Add a shared header label constant for the visible app header.
- Add a focused Node test that verifies the header label value and root layout usage.
- Preserve existing header layout and unrelated copy.

## Verification
- npm test
- npm run typecheck
- npm run build

## QA Notes
Validate that the header still displays Gitdex Console and that the new focused test covers the label source and layout usage.