### PR TITLE
Add step-level workflow recovery controls

### DIFF
--- a/scripts/workflow-recovery.test.mjs
+++ b/scripts/workflow-recovery.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  recoveryReasonForDeveloperStep,
+  recoveryReasonForJobs,
+  recoveryReasonForMergeStep,
+  recoveryReasonForQaStep
+} from "../src/lib/workflow-recovery.ts";
+
+const workflow = (issues = []) => ({ issues });
+const issue = (overrides = {}) => ({
+  branch: null,
+  labels: [],
+  prLabels: [],
+  prState: null,
+  prUrl: null,
+  ...overrides
+});
+const job = (type, status) => ({ type, status });
+const session = (status) => ({ status });
+
+describe("workflow recovery reasons", () => {
+  it("shows QA recovery when an open PR has no QA labels", () => {
+    const reason = recoveryReasonForQaStep([
+      workflow([issue({ prUrl: "https://github.com/Taskix-AI/Taskix/pull/111", prState: "OPEN" })])
+    ], []);
+
+    assert.match(reason, /QA labels are missing/);
+  });
+
+  it("shows QA recovery when only open PR state is known", () => {
+    const reason = recoveryReasonForQaStep([
+      workflow([issue({ prState: "OPEN" })])
+    ], []);
+
+    assert.match(reason, /QA labels are missing/);
+  });
+
+  it("does not show missing-label QA recovery once QA has passed", () => {
+    const reason = recoveryReasonForQaStep([
+      workflow([issue({ labels: ["qa-passed"], prUrl: "https://example.test/pr/1", prState: "OPEN" })])
+    ], []);
+
+    assert.equal(reason, null);
+  });
+
+  it("shows QA wait recovery for issues needing QA", () => {
+    const reason = recoveryReasonForQaStep([
+      workflow([issue({ labels: ["taskix:need-qa"], prUrl: "https://example.test/pr/1", prState: "OPEN" })])
+    ], []);
+
+    assert.match(reason, /waiting on QA labels/);
+  });
+
+  it("shows planning recovery for failed jobs", () => {
+    assert.match(recoveryReasonForJobs([job("workflow_run", "failed")]), /planning job failed/);
+  });
+
+  it("shows developer recovery for failed jobs and blocked sessions", () => {
+    assert.match(recoveryReasonForDeveloperStep([], [job("issue_run", "failed")], []), /developer job failed/);
+    assert.match(recoveryReasonForDeveloperStep([], [], [session("blocked")]), /developer session is blocked/);
+  });
+
+  it("shows merge recovery for QA-passed open PRs", () => {
+    const reason = recoveryReasonForMergeStep([
+      workflow([issue({ labels: ["qa-passed"], prState: "OPEN" })])
+    ]);
+
+    assert.match(reason, /ready/);
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -558,6 +558,16 @@ pre,
   border-bottom: 1px solid #eef2f7;
 }
 
+.workflow-recovery-panel {
+  padding: 10px 0;
+  border-bottom: 1px solid #eef2f7;
+}
+
+.workflow-recovery-panel svg {
+  color: #dc2626;
+  flex: 0 0 auto;
+}
+
 .workflow-control-row {
   display: flex;
   align-items: center;

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
-import { Bot, GitBranch, Info, ListTodo } from "lucide-react";
+import { Bot, GitBranch, Info, ListTodo, RefreshCw, RotateCcw } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
@@ -218,6 +218,8 @@ function buildWorkflowStepDetails(input: {
 }): Record<WorkflowProgressStep["id"], ReactNode> {
   const developerSessions = input.dynamicSessions.filter((session) => session.role === "developer");
   const qaSessions = input.dynamicSessions.filter((session) => session.role === "qa");
+  const planningJobs = input.jobs.filter((job) => job.type === "workflow_run");
+  const developerJobs = input.jobs.filter((job) => job.type === "issue_run");
 
   return {
     requirement: (
@@ -229,6 +231,14 @@ function buildWorkflowStepDetails(input: {
     ),
     planning: (
       <Stack gap="xs">
+        {renderStepRecovery({
+          projectId: input.projectId,
+          title: "Recover architect planning",
+          reason: recoveryReasonForJobs(planningJobs),
+          jobs: planningJobs,
+          sessions: input.sessions.filter((session) => session.role === "architect"),
+          syncLabel: "Sync planning state"
+        })}
         {input.queuedWorkflow ? (
           <Alert icon={<GitBranch size={16} />} color="blue" variant="light">
             <Text size="sm" fw={700}>Workflow queued for architect planning</Text>
@@ -239,26 +249,50 @@ function buildWorkflowStepDetails(input: {
           </Alert>
         ) : null}
         {renderStepRunAction(input.projectId, input.jobs, "workflow_run", "Run Architect Planning")}
-        {renderJobRows(input.projectId, input.jobs.filter((job) => job.type === "workflow_run"), input.queuedJobId)}
+        {renderJobRows(input.projectId, planningJobs, input.queuedJobId)}
         {renderSessionRows(input.sessions.filter((session) => session.role === "architect"))}
       </Stack>
     ),
     developer: (
       <Stack gap="xs">
+        {renderStepRecovery({
+          projectId: input.projectId,
+          title: "Recover developer PR",
+          reason: recoveryReasonForDeveloperStep(input.visibleActiveWorkflows, developerJobs, developerSessions),
+          jobs: developerJobs,
+          sessions: developerSessions,
+          syncLabel: "Recover PR from GitHub"
+        })}
         {renderStepRunAction(input.projectId, input.jobs, "issue_run", "Run Developer Jobs")}
-        {renderJobRows(input.projectId, input.jobs.filter((job) => job.type === "issue_run"), input.queuedJobId)}
+        {renderJobRows(input.projectId, developerJobs, input.queuedJobId)}
         {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
       </Stack>
     ),
     qa: (
       <Stack gap="xs">
+        {renderStepRecovery({
+          projectId: input.projectId,
+          title: "Recover QA validation",
+          reason: recoveryReasonForQaStep(input.activeWorkflows, qaSessions),
+          jobs: [],
+          sessions: qaSessions,
+          syncLabel: "Sync QA labels"
+        })}
         {renderQaIssueRows(input.activeWorkflows, input.sessions)}
         {renderSessionRows(qaSessions)}
       </Stack>
     ),
     merge: (
       <Stack gap="xs">
+        {renderStepRecovery({
+          projectId: input.projectId,
+          title: "Recover merge readiness",
+          reason: recoveryReasonForMergeStep(input.activeWorkflows),
+          jobs: [],
+          sessions: [],
+          syncLabel: "Sync merge state"
+        })}
         {renderMergeIssueRows(input.projectId, input.activeWorkflows)}
       </Stack>
     ),
@@ -268,6 +302,85 @@ function buildWorkflowStepDetails(input: {
       </Stack>
     )
   };
+}
+
+function renderStepRecovery(input: {
+  projectId: string;
+  title: string;
+  reason: string | null;
+  jobs: JobRecord[];
+  sessions: AgentSessionRecord[];
+  syncLabel: string;
+}): ReactNode {
+  if (!input.reason) return null;
+  const failedJobs = input.jobs.filter((job) => job.status === "failed");
+  const blockedSessions = input.sessions.filter((session) => session.status === "blocked");
+
+  return (
+    <div className="workflow-recovery-panel">
+      <Group justify="space-between" gap="sm" align="flex-start">
+        <div>
+          <Group gap={6}>
+            <RefreshCw size={14} />
+            <Text size="sm" fw={780}>{input.title}</Text>
+          </Group>
+          <Text size="xs" c="dimmed" mt={3}>{input.reason}</Text>
+        </div>
+        <ProjectSyncForm projectId={input.projectId} label={input.syncLabel} compact />
+      </Group>
+      {failedJobs.length || blockedSessions.length ? (
+        <Group gap={6} mt="xs">
+          {failedJobs.map((job) => <ProjectRetryJobButton key={job.jobId} projectId={input.projectId} jobId={job.jobId} />)}
+          {blockedSessions.map((session) => (
+            <Button
+              key={session.sessionKey}
+              component="a"
+              href={`/projects/${input.projectId}?session=${encodeURIComponent(session.sessionKey)}`}
+              variant="light"
+              color="red"
+              size="compact-xs"
+              radius="xl"
+              leftSection={<RotateCcw size={14} />}
+            >
+              Open blocked session
+            </Button>
+          ))}
+        </Group>
+      ) : null}
+    </div>
+  );
+}
+
+function recoveryReasonForJobs(jobs: JobRecord[]): string | null {
+  if (jobs.some((job) => job.status === "failed")) return "A planning job failed. Retry the failed job, or sync GitHub if issues were created before the failure.";
+  if (jobs.some((job) => job.status === "running")) return "Planning is running. If the status does not change after several minutes, sync state or retry after it is marked failed.";
+  return null;
+}
+
+function recoveryReasonForDeveloperStep(workflows: WorkflowRecord[], jobs: JobRecord[], sessions: AgentSessionRecord[]): string | null {
+  if (jobs.some((job) => job.status === "failed")) return "A developer job failed. Retry the failed job; if a branch or PR was already created, recover it from GitHub first.";
+  if (sessions.some((session) => session.status === "blocked")) return "A developer session is blocked. Open the session for the blocker details, then retry or recover the PR from GitHub.";
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => issue.branch && !issue.prUrl)) return "Developer work has a branch but no recorded PR. Use GitHub sync to recover a PR that was created or finish PR creation manually.";
+  if (issues.some((issue) => hasAnyLabel(issue, ["taskix:dev-running"]) && !issue.prUrl)) return "Developer work is marked running without a PR. Sync GitHub to detect a partially completed PR, or retry the developer job.";
+  return null;
+}
+
+function recoveryReasonForQaStep(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): string | null {
+  if (sessions.some((session) => session.status === "blocked")) return "QA is blocked or failed. Open the QA session for findings, then retry the developer fix path after the issue is updated.";
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => issue.prUrl && hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running"]))) {
+    return "A PR is waiting on QA labels. After QA finishes, sync GitHub so Taskix can move the workflow to pass/fail or merge readiness.";
+  }
+  return null;
+}
+
+function recoveryReasonForMergeStep(workflows: WorkflowRecord[]): string | null {
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => hasAnyLabel(issue, ["qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"]) && issue.prState !== "MERGED")) {
+    return "QA has passed and the PR is ready. Merge from this step, then sync GitHub if the issue or PR state does not update.";
+  }
+  return null;
 }
 
 function renderStepRunAction(projectId: string, jobs: JobRecord[], jobType: JobRecord["type"], label: string): ReactNode {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -369,6 +369,9 @@ function recoveryReasonForDeveloperStep(workflows: WorkflowRecord[], jobs: JobRe
 function recoveryReasonForQaStep(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): string | null {
   if (sessions.some((session) => session.status === "blocked")) return "QA is blocked or failed. Open the QA session for findings, then retry the developer fix path after the issue is updated.";
   const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => (issue.prUrl || issue.prState?.toUpperCase() === "OPEN") && !hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running", "qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"]))) {
+    return "A PR is open but QA labels are missing. Sync GitHub to recover labels, or request QA before this workflow can move forward.";
+  }
   if (issues.some((issue) => issue.prUrl && hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running"]))) {
     return "A PR is waiting on QA labels. After QA finishes, sync GitHub so Taskix can move the workflow to pass/fail or merge readiness.";
   }

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -16,6 +16,13 @@ import { getIssueQaStatus } from "@/lib/qa-status";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows } from "@/lib/store";
 import type { AgentSessionRecord, IssueRecord, JobRecord, WorkflowRecord } from "@/lib/types";
 import { getWorkflowProgress, type WorkflowProgressStep } from "@/lib/workflow-progress";
+import {
+  hasAnyLabel,
+  recoveryReasonForDeveloperStep,
+  recoveryReasonForJobs,
+  recoveryReasonForMergeStep,
+  recoveryReasonForQaStep
+} from "@/lib/workflow-recovery";
 
 export default async function ProjectDetailPage({
   params,
@@ -351,41 +358,6 @@ function renderStepRecovery(input: {
   );
 }
 
-function recoveryReasonForJobs(jobs: JobRecord[]): string | null {
-  if (jobs.some((job) => job.status === "failed")) return "A planning job failed. Retry the failed job, or sync GitHub if issues were created before the failure.";
-  if (jobs.some((job) => job.status === "running")) return "Planning is running. If the status does not change after several minutes, sync state or retry after it is marked failed.";
-  return null;
-}
-
-function recoveryReasonForDeveloperStep(workflows: WorkflowRecord[], jobs: JobRecord[], sessions: AgentSessionRecord[]): string | null {
-  if (jobs.some((job) => job.status === "failed")) return "A developer job failed. Retry the failed job; if a branch or PR was already created, recover it from GitHub first.";
-  if (sessions.some((session) => session.status === "blocked")) return "A developer session is blocked. Open the session for the blocker details, then retry or recover the PR from GitHub.";
-  const issues = workflows.flatMap((workflow) => workflow.issues);
-  if (issues.some((issue) => issue.branch && !issue.prUrl)) return "Developer work has a branch but no recorded PR. Use GitHub sync to recover a PR that was created or finish PR creation manually.";
-  if (issues.some((issue) => hasAnyLabel(issue, ["taskix:dev-running"]) && !issue.prUrl)) return "Developer work is marked running without a PR. Sync GitHub to detect a partially completed PR, or retry the developer job.";
-  return null;
-}
-
-function recoveryReasonForQaStep(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): string | null {
-  if (sessions.some((session) => session.status === "blocked")) return "QA is blocked or failed. Open the QA session for findings, then retry the developer fix path after the issue is updated.";
-  const issues = workflows.flatMap((workflow) => workflow.issues);
-  if (issues.some((issue) => (issue.prUrl || issue.prState?.toUpperCase() === "OPEN") && !hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running", "qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"]))) {
-    return "A PR is open but QA labels are missing. Sync GitHub to recover labels, or request QA before this workflow can move forward.";
-  }
-  if (issues.some((issue) => issue.prUrl && hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running"]))) {
-    return "A PR is waiting on QA labels. After QA finishes, sync GitHub so Taskix can move the workflow to pass/fail or merge readiness.";
-  }
-  return null;
-}
-
-function recoveryReasonForMergeStep(workflows: WorkflowRecord[]): string | null {
-  const issues = workflows.flatMap((workflow) => workflow.issues);
-  if (issues.some((issue) => hasAnyLabel(issue, ["qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"]) && issue.prState !== "MERGED")) {
-    return "QA has passed and the PR is ready. Merge from this step, then sync GitHub if the issue or PR state does not update.";
-  }
-  return null;
-}
-
 function renderStepRunAction(projectId: string, jobs: JobRecord[], jobType: JobRecord["type"], label: string): ReactNode {
   const pendingCount = jobs.filter((job) => job.type === jobType && job.status === "pending").length;
   if (!pendingCount) return null;
@@ -558,11 +530,6 @@ function SessionLink({ session, archived = false }: { session: AgentSessionRecor
       {session.ownedPaths?.length ? <Text size="xs" c="dimmed" lineClamp={1}>Paths: {session.ownedPaths.join(", ")}</Text> : null}
     </a>
   );
-}
-
-function hasAnyLabel(issue: IssueRecord, expected: string[]): boolean {
-  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
-  return expected.some((label) => labels.has(label));
 }
 
 function WorkflowProgressList({

--- a/src/components/ProjectSyncForm.tsx
+++ b/src/components/ProjectSyncForm.tsx
@@ -9,7 +9,15 @@ type SyncResponse = {
   synced: number;
 };
 
-export function ProjectSyncForm({ projectId }: { projectId: string }) {
+export function ProjectSyncForm({
+  projectId,
+  label = "Sync GitHub",
+  compact = false
+}: {
+  projectId: string;
+  label?: string;
+  compact?: boolean;
+}) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [message, setMessage] = useState("");
@@ -42,7 +50,7 @@ export function ProjectSyncForm({ projectId }: { projectId: string }) {
   return (
     <Group gap={6} wrap="nowrap">
       <Button type="button" variant="light" size="xs" radius="xl" leftSection={<RefreshCw size={14} />} loading={pending} onClick={sync}>
-        Sync GitHub
+        {compact ? "Sync" : label}
       </Button>
       {message ? (
         <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>

--- a/src/lib/workflow-recovery.ts
+++ b/src/lib/workflow-recovery.ts
@@ -1,0 +1,51 @@
+import type { AgentSessionRecord, IssueRecord, JobRecord, WorkflowRecord } from "@/lib/types";
+
+type RecoveryIssue = Pick<IssueRecord, "branch" | "labels" | "prLabels" | "prState" | "prUrl">;
+type RecoveryWorkflow = Pick<WorkflowRecord, "issues">;
+type RecoveryJob = Pick<JobRecord, "status">;
+type RecoveryJobWithType = Pick<JobRecord, "status" | "type">;
+type RecoverySession = Pick<AgentSessionRecord, "status">;
+
+export function recoveryReasonForJobs(jobs: RecoveryJob[]): string | null {
+  if (jobs.some((job) => job.status === "failed")) return "A planning job failed. Retry the failed job, or sync GitHub if issues were created before the failure.";
+  if (jobs.some((job) => job.status === "running")) return "Planning is running. If the status does not change after several minutes, sync state or retry after it is marked failed.";
+  return null;
+}
+
+export function recoveryReasonForDeveloperStep(
+  workflows: RecoveryWorkflow[],
+  jobs: RecoveryJobWithType[],
+  sessions: RecoverySession[]
+): string | null {
+  if (jobs.some((job) => job.status === "failed")) return "A developer job failed. Retry the failed job; if a branch or PR was already created, recover it from GitHub first.";
+  if (sessions.some((session) => session.status === "blocked")) return "A developer session is blocked. Open the session for the blocker details, then retry or recover the PR from GitHub.";
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => issue.branch && !issue.prUrl)) return "Developer work has a branch but no recorded PR. Use GitHub sync to recover a PR that was created or finish PR creation manually.";
+  if (issues.some((issue) => hasAnyLabel(issue, ["taskix:dev-running"]) && !issue.prUrl)) return "Developer work is marked running without a PR. Sync GitHub to detect a partially completed PR, or retry the developer job.";
+  return null;
+}
+
+export function recoveryReasonForQaStep(workflows: RecoveryWorkflow[], sessions: RecoverySession[]): string | null {
+  if (sessions.some((session) => session.status === "blocked")) return "QA is blocked or failed. Open the QA session for findings, then retry the developer fix path after the issue is updated.";
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => (issue.prUrl || issue.prState?.toUpperCase() === "OPEN") && !hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running", "qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"]))) {
+    return "A PR is open but QA labels are missing. Sync GitHub to recover labels, or request QA before this workflow can move forward.";
+  }
+  if (issues.some((issue) => issue.prUrl && hasAnyLabel(issue, ["taskix:need-qa", "taskix:qa-running"]))) {
+    return "A PR is waiting on QA labels. After QA finishes, sync GitHub so Taskix can move the workflow to pass/fail or merge readiness.";
+  }
+  return null;
+}
+
+export function recoveryReasonForMergeStep(workflows: RecoveryWorkflow[]): string | null {
+  const issues = workflows.flatMap((workflow) => workflow.issues);
+  if (issues.some((issue) => hasAnyLabel(issue, ["qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"]) && issue.prState !== "MERGED")) {
+    return "QA has passed and the PR is ready. Merge from this step, then sync GitHub if the issue or PR state does not update.";
+  }
+  return null;
+}
+
+export function hasAnyLabel(issue: RecoveryIssue, expected: string[]): boolean {
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
+  return expected.some((label) => labels.has(label));
+}


### PR DESCRIPTION
Closes #110\n\n## Summary\n- Adds per-step recovery guidance in the project workflow panel for planning, developer PR, QA validation, and merge readiness.\n- Surfaces Sync GitHub, Retry failed job, and Open blocked session actions next to the relevant blocked step.\n- Reuses existing merge controls in the ready-to-merge step and keeps recovery UI lightweight inside step details.\n\n## Tests\n- npm test\n- npm run typecheck\n- npm run build