### PR TITLE
Add focused verification for header label

### DIFF
--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+
+assert.match(
+  layoutSource,
+  /<Text[^>]*>\s*Gitdex Console\s*<\/Text>/,
+  "Root layout header should visibly render Gitdex Console"
+);
+
+console.log("header label verification passed");


### PR DESCRIPTION
## Summary
- Adds a focused Node test that verifies the root layout visibly renders `Gitdex Console` in the top header.
- Keeps the change scoped to the existing lightweight `scripts/*.test.mjs` test pattern.

Closes #105

## Verification
- `node --experimental-strip-types --test scripts/header-label.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run build`

## Scope Notes
- Changed files: `scripts/header-label.test.mjs`
- Recovery/ready-to-merge behavior was not in scope for this header-label verification issue.
- No generated PR merge was performed.
