### PR TITLE
Refactor web workflow handoffs for QA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ QA should test from user-visible behavior and leave a GitHub issue comment with:
 - Findings with severity, reproduction steps, expected result, and actual result.
 - Any untested areas or environment limits.
 
-When QA passes, add the `qa-passed` label. When QA fails, add `qa-failed` and comment with the failure details. Developers should address failed QA findings in a follow-up commit and request another QA pass on the same issue. Merge the PR into `main` only after QA has passed.
+When QA passes, add the `qa-passed` label. When QA fails, add `qa-failed` and comment with the failure details. Developers should address failed QA findings in a follow-up commit and request another QA pass on the same issue. When requesting QA recheck after a developer fix, remove `qa-failed` / `taskix:qa-failed` and add `taskix:need-qa` on both the source issue and PR so the workflow is back in QA-required state. Merge the PR into `main` only after QA has passed.
 
 ## Commit & Pull Request Guidelines
 

--- a/scripts/workflow-next-action.test.mjs
+++ b/scripts/workflow-next-action.test.mjs
@@ -47,6 +47,14 @@ describe("getWorkflowNextAction", () => {
     assert.equal(action.icon, "git-branch");
   });
 
+  it("shows the QA action for pending QA runs", () => {
+    const action = getWorkflowNextAction([job("qa_run", "pending")]);
+
+    assert.equal(action.title, "Start next QA validation");
+    assert.equal(action.buttonLabel, "Start Next QA Validation");
+    assert.equal(action.phase, "QA validation");
+  });
+
   it("marks failed jobs as blocked", () => {
     const action = getWorkflowNextAction([job("issue_run", "failed")]);
 

--- a/scripts/workflow-progress.test.mjs
+++ b/scripts/workflow-progress.test.mjs
@@ -3,8 +3,9 @@ import { describe, it } from "node:test";
 import { getWorkflowProgress } from "../src/lib/workflow-progress.ts";
 
 const workflow = (status, issues = []) => ({ status, issues });
-const job = (type, status) => ({ type, status });
+const job = (type, status, issueId = null) => ({ type, status, payload: { issueId } });
 const issue = (overrides = {}) => ({
+  issueId: "issue-1",
   labels: [],
   prLabels: [],
   prUrl: null,
@@ -72,6 +73,15 @@ describe("getWorkflowProgress", () => {
     assert.equal(currentStep(steps).id, "qa");
   });
 
+  it("marks pending QA jobs on the QA step", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("in_progress", [issue({ prUrl: "https://example.test/pr/1", prState: "OPEN" })])],
+      jobs: [job("qa_run", "pending", "issue-1")]
+    });
+
+    assert.equal(currentStep(steps).id, "qa");
+  });
+
   it("moves QA-passed issues to ready to merge", () => {
     const steps = getWorkflowProgress({
       workflows: [workflow("in_progress", [issue({ labels: ["qa-passed"], prState: "OPEN" })])],
@@ -95,10 +105,24 @@ describe("getWorkflowProgress", () => {
   it("shows failed developer jobs as blocked", () => {
     const steps = getWorkflowProgress({
       workflows: [workflow("in_progress", [issue()])],
-      jobs: [job("issue_run", "failed")]
+      jobs: [job("issue_run", "failed", "issue-1")]
     });
 
     assert.equal(currentStep(steps).id, "developer");
     assert.equal(currentStep(steps).status, "blocked");
+  });
+
+  it("ignores stale failed developer jobs after a retry reaches merge readiness", () => {
+    const steps = getWorkflowProgress({
+      workflows: [workflow("in_progress", [issue({ labels: ["taskix:qa-passed"], prUrl: "https://example.test/pr/1", prState: "OPEN" })])],
+      jobs: [
+        job("issue_run", "failed", "issue-1"),
+        job("issue_run", "done", "issue-1")
+      ]
+    });
+
+    assert.equal(currentStep(steps).id, "merge");
+    assert.equal(currentStep(steps).status, "current");
+    assert.equal(step(steps, "developer").status, "complete");
   });
 });

--- a/src/app/api/projects/[projectId]/issues/[issueId]/handoff-to-qa/route.ts
+++ b/src/app/api/projects/[projectId]/issues/[issueId]/handoff-to-qa/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { addLabelsWithGh, removeLabelsWithGh } from "@/lib/github-local";
+import { createJob, getProject, listJobs, listProjectWorkflows, saveWorkflow } from "@/lib/store";
+
+const removeQaTerminalLabels = ["qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"];
+const addQaLabels = ["taskix:need-qa", "taskix:qa-running"];
+
+export async function POST(_request: Request, { params }: { params: Promise<{ projectId: string; issueId: string }> }) {
+  const { projectId, issueId } = await params;
+  const project = await getProject(projectId);
+  if (!project) return NextResponse.json({ error: "Project not found." }, { status: 404 });
+  if (!project.githubRepo) return NextResponse.json({ error: "Project has no GitHub repo configured." }, { status: 400 });
+
+  const workflows = await listProjectWorkflows(project.projectId);
+  const workflow = workflows.find((item) => item.issues.some((issue) => issue.issueId === issueId));
+  const issue = workflow?.issues.find((item) => item.issueId === issueId);
+  if (!workflow || !issue) return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+  if (!issue.prUrl) return NextResponse.json({ error: "Issue has no pull request for QA." }, { status: 400 });
+  if (issue.prState === "MERGED") return NextResponse.json({ error: "Merged issues cannot be sent to QA." }, { status: 409 });
+
+  const issueLabelsToRemove = labelsToRemove(issue.labels ?? []);
+  const prLabelsToRemove = labelsToRemove(issue.prLabels ?? []);
+  try {
+    if (issue.githubIssueNumber) {
+      if (issueLabelsToRemove.length) await removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, issueLabelsToRemove);
+      await addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addQaLabels);
+    }
+    if (prLabelsToRemove.length) await removeLabelsWithGh(project.githubRepo, issue.prUrl, prLabelsToRemove);
+    await addLabelsWithGh(project.githubRepo, issue.prUrl, addQaLabels);
+  } catch (error) {
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : "Failed to hand off issue to QA.",
+      action: "Check GitHub connectivity and retry Handoff to QA. Local workflow state was not changed."
+    }, { status: 502 });
+  }
+
+  issue.labels = [
+    ...new Set([
+      ...(issue.labels ?? []).filter((label) => !removeQaTerminalLabels.includes(label.toLowerCase())),
+      ...addQaLabels
+    ])
+  ];
+  issue.prLabels = [
+    ...new Set([
+      ...(issue.prLabels ?? []).filter((label) => !removeQaTerminalLabels.includes(label.toLowerCase())),
+      ...addQaLabels
+    ])
+  ];
+  workflow.status = "in_progress";
+  workflow.timeline.push(`Handed ${issue.issueId} to QA.`);
+  await saveWorkflow(workflow);
+
+  const existingJob = (await listJobs(project.projectId)).find((job) => (
+    job.type === "qa_run"
+    && (job.status === "pending" || job.status === "running")
+    && job.payload.workflowId === workflow.workflowId
+    && job.payload.issueId === issue.issueId
+  ));
+  const job = existingJob ?? await createJob({
+    projectId: project.projectId,
+    type: "qa_run",
+    payload: { workflowId: workflow.workflowId, issueId: issue.issueId }
+  });
+
+  return NextResponse.json({ ok: true, jobId: job.jobId, redirectTo: `/projects/${project.projectId}/workflows/${workflow.workflowId}?autorun=1` });
+}
+
+function labelsToRemove(labels: string[]): string[] {
+  const lowerLabels = new Set(labels.map((label) => label.toLowerCase()));
+  return removeQaTerminalLabels.filter((label) => lowerLabels.has(label));
+}

--- a/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
+++ b/src/app/api/projects/[projectId]/issues/[issueId]/merge/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
-import { closeIssueWithGh, mergePullRequestWithGh } from "@/lib/github-local";
-import { getProject, listProjectWorkflows, saveWorkflow } from "@/lib/store";
+import { CodexClient } from "@/lib/codex";
+import { getSettings } from "@/lib/settings";
+import { appendAgentMessages, getAgentSession, getProject, listProjectWorkflows, saveProject, saveWorkflow } from "@/lib/store";
+import type { IssueRecord, ProjectRecord, WorkflowRecord } from "@/lib/types";
 
 export async function POST(_request: Request, { params }: { params: Promise<{ projectId: string; issueId: string }> }) {
   const { projectId, issueId } = await params;
@@ -18,39 +20,76 @@ export async function POST(_request: Request, { params }: { params: Promise<{ pr
   const isReady = labels.has("qa-passed") || labels.has("taskix:qa-passed") || labels.has("taskix:ready-to-merge");
   if (!isReady) return NextResponse.json({ error: "Issue is not QA-passed or ready to merge." }, { status: 409 });
 
-  const mergedLabels = ["taskix:merged"];
-  let closeIssueWarning: string | null = null;
+  const architectResult = await runArchitectMergeRequest(project, workflow, issue);
 
-  try {
-    await mergePullRequestWithGh(project.githubRepo, issue.prUrl);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "PR merge failed.";
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
+  return NextResponse.json({
+    ok: true,
+    delegated: true,
+    issueId,
+    prUrl: issue.prUrl,
+    architectUrl: `/projects/${project.projectId}?session=${encodeURIComponent(`${project.projectId}:architect`)}`,
+    architectReply: architectResult.text
+  });
+}
 
-  issue.prState = "MERGED";
-  issue.labels = [...new Set([...(issue.labels ?? []), ...mergedLabels])];
-  issue.prLabels = [...new Set([...(issue.prLabels ?? []), ...mergedLabels])];
-  workflow.timeline.push(`Merged PR ${issue.prUrl} for issue ${issue.issueId}.`);
+async function runArchitectMergeRequest(project: ProjectRecord, workflow: WorkflowRecord, issue: IssueRecord): Promise<{ text: string }> {
+  const now = new Date().toISOString();
+  const content = [
+    `Merge requested for ${issue.issueId}: ${issue.title}`,
+    "",
+    `Workflow: ${workflow.trackingCode ?? workflow.workflowId}`,
+    `GitHub issue: ${issue.githubIssueNumber ? `#${issue.githubIssueNumber}` : "none"}`,
+    `PR: ${issue.prUrl ?? "none"}`,
+    `Issue labels: ${(issue.labels ?? []).join(", ") || "none"}`,
+    `PR labels: ${(issue.prLabels ?? []).join(", ") || "none"}`,
+    `Recorded PR state: ${issue.prState ?? "unknown"}`,
+    "",
+    "Handle this as architect now. Inspect the PR and current branch state. If it can be merged under the repository workflow, merge it and report the result. If it has conflicts or needs rework, explain the blocker and next action for developer or user follow-up."
+  ].join("\n");
 
-  if (issue.githubIssueNumber) {
-    try {
-      await closeIssueWithGh(project.githubRepo, issue.githubIssueNumber, `Closed after PR ${issue.prUrl} was merged by Taskix.`);
-      issue.githubState = "CLOSED";
-      workflow.timeline.push(`Closed GitHub issue #${issue.githubIssueNumber} after merge.`);
-    } catch (error) {
-      closeIssueWarning = error instanceof Error ? error.message : "GitHub issue close failed.";
-      workflow.timeline.push(`GitHub issue #${issue.githubIssueNumber} close failed after merge: ${closeIssueWarning}`);
-    }
-  } else {
-    issue.githubState = "CLOSED";
-  }
-
-  if (workflow.issues.every((item) => item.prState === "MERGED" || item.githubState === "CLOSED")) {
-    workflow.status = "done";
-    workflow.timeline.push("Workflow completed after all issue PRs merged.");
-  }
+  workflow.timeline.push(`Requested architect merge handling for ${issue.issueId}.`);
   await saveWorkflow(workflow);
 
-  return NextResponse.json({ ok: true, merged: true, issueClosed: !closeIssueWarning, warning: closeIssueWarning, issueId, prUrl: issue.prUrl });
+  const sessionKey = `${project.projectId}:architect`;
+  const [settings, existingArchitectSession] = await Promise.all([
+    getSettings(),
+    getAgentSession(sessionKey)
+  ]);
+  const codex = new CodexClient(settings);
+  const result = await codex.architectChat({
+    projectName: project.name,
+    githubRepo: project.githubRepo,
+    message: content,
+    sessionId: project.architectSessionId ?? existingArchitectSession?.sessionId ?? null
+  });
+
+  if (result.sessionId && result.sessionId !== project.architectSessionId) {
+    project.architectSessionId = result.sessionId;
+    await saveProject(project);
+  }
+
+  await appendAgentMessages({
+    sessionKey,
+    projectId: project.projectId,
+    role: "architect",
+    title: "Architect",
+    sessionId: result.sessionId ?? project.architectSessionId ?? existingArchitectSession?.sessionId ?? null,
+    workflowId: workflow.workflowId,
+    issueId: issue.issueId,
+    prUrl: issue.prUrl ?? null,
+    labels: issue.labels ?? [],
+    currentStep: "merge requested",
+    executionLogs: result.executionLog ? [{
+      title: "Architect merge handling",
+      content: result.executionLog,
+      createdAt: new Date().toISOString(),
+      status: "ok"
+    }] : [],
+    messages: [
+      { role: "user", content, createdAt: now },
+      { role: "assistant", content: result.text, createdAt: new Date().toISOString() }
+    ]
+  });
+
+  return { text: result.text };
 }

--- a/src/app/api/projects/[projectId]/issues/[issueId]/return-to-developer/route.ts
+++ b/src/app/api/projects/[projectId]/issues/[issueId]/return-to-developer/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { addLabelsWithGh, commentIssueWithGh, removeLabelsWithGh } from "@/lib/github-local";
+import { createJob, getProject, listJobs, listProjectWorkflows, saveWorkflow } from "@/lib/store";
+
+const removeReadyLabels = ["qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge", "taskix:need-qa", "taskix:qa-running"];
+const addDeveloperLabels = ["taskix:dev-running"];
+
+export async function POST(_request: Request, { params }: { params: Promise<{ projectId: string; issueId: string }> }) {
+  const { projectId, issueId } = await params;
+  const project = await getProject(projectId);
+  if (!project) return NextResponse.json({ error: "Project not found." }, { status: 404 });
+  if (!project.githubRepo) return NextResponse.json({ error: "Project has no GitHub repo configured." }, { status: 400 });
+
+  const workflows = await listProjectWorkflows(project.projectId);
+  const workflow = workflows.find((item) => item.issues.some((issue) => issue.issueId === issueId));
+  const issue = workflow?.issues.find((item) => item.issueId === issueId);
+  if (!workflow || !issue) return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+  if (!issue.prUrl) return NextResponse.json({ error: "Issue has no pull request to return to developer." }, { status: 400 });
+  if (issue.prState === "MERGED") return NextResponse.json({ error: "Merged issues cannot be returned to developer." }, { status: 409 });
+
+  const labels = new Set([...(issue.labels ?? []), ...(issue.prLabels ?? [])].map((label) => label.toLowerCase()));
+  const canReturnToDeveloper = labels.has("qa-passed")
+    || labels.has("taskix:qa-passed")
+    || labels.has("taskix:ready-to-merge")
+    || labels.has("qa-failed")
+    || labels.has("taskix:qa-failed");
+  if (!canReturnToDeveloper) return NextResponse.json({ error: "Issue is not ready to return to developer." }, { status: 409 });
+
+  const issueLabelsToRemove = labelsToRemove(issue.labels ?? []);
+  const prLabelsToRemove = labelsToRemove(issue.prLabels ?? []);
+  const comment = [
+    "This PR was returned to developer.",
+    "",
+    "Reason: QA or architect merge handling found this PR needs developer rework before it can continue.",
+    "",
+    "Developer action:",
+    "- Rebase or merge latest `main` into the PR branch if merge handling reported conflicts.",
+    "- Address QA findings or merge blockers called out in the workflow session.",
+    "- Push the branch and report verification commands.",
+    "- Request QA recheck because the branch changed after the previous QA pass."
+  ].join("\n");
+
+  try {
+    if (issue.githubIssueNumber) {
+      if (issueLabelsToRemove.length) await removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, issueLabelsToRemove);
+      await addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, addDeveloperLabels);
+      await commentIssueWithGh(project.githubRepo, issue.githubIssueNumber, comment);
+    }
+    if (prLabelsToRemove.length) await removeLabelsWithGh(project.githubRepo, issue.prUrl, prLabelsToRemove);
+    await addLabelsWithGh(project.githubRepo, issue.prUrl, addDeveloperLabels);
+  } catch (error) {
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : "Failed to return issue to developer.",
+      action: "Check GitHub connectivity and retry Return to developer. Local workflow state was not changed."
+    }, { status: 502 });
+  }
+
+  issue.labels = [
+    ...new Set([
+      ...(issue.labels ?? []).filter((label) => !removeReadyLabels.includes(label.toLowerCase())),
+      ...addDeveloperLabels
+    ])
+  ];
+  issue.prLabels = [
+    ...new Set([
+      ...(issue.prLabels ?? []).filter((label) => !removeReadyLabels.includes(label.toLowerCase())),
+      ...addDeveloperLabels
+    ])
+  ];
+  workflow.status = "in_progress";
+  workflow.timeline.push(`Returned ${issue.issueId} to developer for branch update/rebase before merge.`);
+  await saveWorkflow(workflow);
+
+  const existingJob = (await listJobs(project.projectId)).find((job) => (
+    job.type === "issue_run"
+    && (job.status === "pending" || job.status === "running")
+    && job.payload.workflowId === workflow.workflowId
+    && job.payload.issueId === issue.issueId
+  ));
+  const job = existingJob ?? await createJob({
+    projectId: project.projectId,
+    type: "issue_run",
+    payload: { workflowId: workflow.workflowId, issueId: issue.issueId }
+  });
+
+  return NextResponse.json({ ok: true, jobId: job.jobId, redirectTo: `/projects/${project.projectId}/workflows/${workflow.workflowId}?autorun=1` });
+}
+
+function labelsToRemove(labels: string[]): string[] {
+  const lowerLabels = new Set(labels.map((label) => label.toLowerCase()));
+  return removeReadyLabels.filter((label) => lowerLabels.has(label));
+}

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -6,8 +6,10 @@ import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
 import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
+import { ProjectHandoffToQaButton } from "@/components/ProjectHandoffToQaButton";
 import { ProjectMergePrButton } from "@/components/ProjectMergePrButton";
 import { ProjectRetryJobButton } from "@/components/ProjectRetryJobButton";
+import { ProjectReturnToDeveloperButton } from "@/components/ProjectReturnToDeveloperButton";
 import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
@@ -227,6 +229,7 @@ function buildWorkflowStepDetails(input: {
   const qaSessions = input.dynamicSessions.filter((session) => session.role === "qa");
   const planningJobs = input.jobs.filter((job) => job.type === "workflow_run");
   const developerJobs = input.jobs.filter((job) => job.type === "issue_run");
+  const qaJobs = input.jobs.filter((job) => job.type === "qa_run");
 
   return {
     requirement: (
@@ -272,7 +275,7 @@ function buildWorkflowStepDetails(input: {
         })}
         {renderStepRunAction(input.projectId, input.jobs, "issue_run", "Run Developer Jobs")}
         {renderJobRows(input.projectId, developerJobs, input.queuedJobId)}
-        {renderDeveloperIssueRows(input.visibleActiveWorkflows, input.sessions)}
+        {renderDeveloperIssueRows(input.projectId, input.visibleActiveWorkflows, input.sessions)}
         {renderSessionRows(developerSessions)}
       </Stack>
     ),
@@ -286,7 +289,9 @@ function buildWorkflowStepDetails(input: {
           sessions: qaSessions,
           syncLabel: "Sync QA labels"
         })}
-        {renderQaIssueRows(input.activeWorkflows, input.sessions)}
+        {renderStepRunAction(input.projectId, input.jobs, "qa_run", "Run QA Jobs")}
+        {renderJobRows(input.projectId, qaJobs, input.queuedJobId)}
+        {renderQaIssueRows(input.projectId, input.activeWorkflows, input.sessions)}
         {renderSessionRows(qaSessions)}
       </Stack>
     ),
@@ -367,7 +372,7 @@ function renderStepRunAction(projectId: string, jobs: JobRecord[], jobType: JobR
         <div>
           <Text size="sm" fw={760}>{label}</Text>
           <Text size="xs" c="dimmed">
-            {pendingCount} pending {jobType === "workflow_run" ? "planning" : "developer"} job{pendingCount === 1 ? "" : "s"} for this step.
+            {pendingCount} pending {jobType === "workflow_run" ? "planning" : jobType === "qa_run" ? "QA" : "developer"} job{pendingCount === 1 ? "" : "s"} for this step.
           </Text>
         </div>
         <ProjectRunJobsForm projectId={projectId} label={label} />
@@ -440,22 +445,31 @@ function renderJobRows(projectId: string, jobs: JobRecord[], queuedJobId: string
   ));
 }
 
-function renderDeveloperIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
+function renderDeveloperIssueRows(projectId: string, workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
   const issues = workflows.flatMap((workflow) => workflow.issues);
   if (!issues.length) return <Text size="xs" c="dimmed">No developer issues planned yet.</Text>;
   return issues.map((issue) => {
     const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
     const qaStatus = getIssueQaStatus(issue, qaSession);
-    return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={qaStatus} />;
+    const canHandoffToQa = Boolean(issue.prUrl) && qaStatus.id === "not_requested";
+    return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={qaStatus} action={canHandoffToQa ? <ProjectHandoffToQaButton projectId={projectId} issueId={issue.issueId} /> : null} />;
   });
 }
 
-function renderQaIssueRows(workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
+function renderQaIssueRows(projectId: string, workflows: WorkflowRecord[], sessions: AgentSessionRecord[]): ReactNode {
   const issues = workflows.flatMap((workflow) => workflow.issues).filter((issue) => issue.prUrl || issue.prState || issue.qaSessionId);
   if (!issues.length) return <Text size="xs" c="dimmed">No QA-ready issues yet.</Text>;
   return issues.map((issue) => {
     const qaSession = sessions.find((session) => session.sessionKey === issue.qaSessionId);
-    return <IssueStatusRow key={issue.issueId} issue={issue} qaStatus={getIssueQaStatus(issue, qaSession)} />;
+    const qaStatus = getIssueQaStatus(issue, qaSession);
+    return (
+      <IssueStatusRow
+        key={issue.issueId}
+        issue={issue}
+        qaStatus={qaStatus}
+        action={qaStatus.id === "failed" ? <ProjectReturnToDeveloperButton projectId={projectId} issueId={issue.issueId} /> : null}
+      />
+    );
   });
 }
 
@@ -474,7 +488,8 @@ function renderMergeIssueRows(projectId: string, workflows: WorkflowRecord[]): R
         </div>
         <Group gap={6} wrap="nowrap">
           <Badge size="xs" color="green" variant="light">ready</Badge>
-          {issue.prUrl && issue.prState !== "MERGED" ? <ProjectMergePrButton projectId={projectId} issueId={issue.issueId} /> : null}
+          {issue.prUrl && issue.prState !== "MERGED" ? <ProjectReturnToDeveloperButton projectId={projectId} issueId={issue.issueId} /> : null}
+          {issue.prUrl && issue.prState !== "MERGED" ? <ProjectMergePrButton projectId={projectId} issueId={issue.issueId} prUrl={issue.prUrl} /> : null}
         </Group>
       </Group>
     </div>
@@ -499,7 +514,7 @@ function renderSessionRows(sessions: AgentSessionRecord[], archived = false): Re
   return sessions.map((session) => <SessionLink key={session.sessionKey} session={session} archived={archived || Boolean(session.archivedAt)} />);
 }
 
-function IssueStatusRow({ issue, qaStatus }: { issue: IssueRecord; qaStatus: ReturnType<typeof getIssueQaStatus> }) {
+function IssueStatusRow({ issue, qaStatus, action = null }: { issue: IssueRecord; qaStatus: ReturnType<typeof getIssueQaStatus>; action?: ReactNode }) {
   return (
     <Group gap={6} wrap="nowrap">
       <Text size="xs" c="dimmed" lineClamp={1}>
@@ -507,6 +522,7 @@ function IssueStatusRow({ issue, qaStatus }: { issue: IssueRecord; qaStatus: Ret
         {issue.prState ? ` · PR ${issue.prState}` : ""}
       </Text>
       <Badge color={qaStatus.color} size="xs" variant="light">{qaStatus.label}</Badge>
+      {action}
     </Group>
   );
 }

--- a/src/components/ProjectHandoffToQaButton.tsx
+++ b/src/components/ProjectHandoffToQaButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button, Text } from "@mantine/core";
+import { ClipboardCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function ProjectHandoffToQaButton({
+  projectId,
+  issueId
+}: {
+  projectId: string;
+  issueId: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handoffToQa() {
+    setPending(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/projects/${projectId}/issues/${issueId}/handoff-to-qa`, { method: "POST" });
+      const payload = await response.json() as { error?: string; redirectTo?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "QA handoff failed");
+        return;
+      }
+      if (payload.redirectTo) router.push(payload.redirectTo);
+      router.refresh();
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "QA handoff failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Button type="button" variant="light" color="blue" size="compact-xs" radius="xl" leftSection={<ClipboardCheck size={14} />} loading={pending} onClick={handoffToQa}>
+        Handoff to QA
+      </Button>
+      {error ? <Text size="xs" c="red" maw={220}>{error}</Text> : null}
+    </>
+  );
+}

--- a/src/components/ProjectMergePrButton.tsx
+++ b/src/components/ProjectMergePrButton.tsx
@@ -1,59 +1,118 @@
 "use client";
 
-import { Button, Group, Text } from "@mantine/core";
-import { GitMerge } from "lucide-react";
+import { Alert, Anchor, Button, Group, Stack, Text } from "@mantine/core";
+import { AlertTriangle, ExternalLink, GitPullRequestArrow } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 export function ProjectMergePrButton({
   projectId,
-  issueId
+  issueId,
+  prUrl
 }: {
   projectId: string;
   issueId: string;
+  prUrl?: string | null;
 }) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
-  const [message, setMessage] = useState("");
-  const [messageColor, setMessageColor] = useState<"dimmed" | "red" | "green">("dimmed");
+  const [result, setResult] = useState<MergeResult | null>(null);
 
   async function mergePr() {
     setPending(true);
-    setMessage("");
+    setResult(null);
     try {
       const response = await fetch(`/api/projects/${projectId}/issues/${issueId}/merge`, { method: "POST" });
-      const result = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(result.error ?? "Merge request failed");
-      setMessage("Merged");
-      setMessageColor("green");
+      const payload = await response.json() as MergeResponse;
+      if (!response.ok) {
+        setResult({
+          ok: false,
+          message: payload.error ?? "Architect handoff failed",
+          action: payload.action,
+          architectUrl: payload.architectUrl,
+          prUrl: payload.prUrl ?? prUrl,
+          mergeable: payload.mergeable
+        });
+        return;
+      }
+      setResult({
+        ok: true,
+        message: "Architect started",
+        architectUrl: payload.architectUrl,
+        prUrl: payload.prUrl ?? prUrl
+      });
       router.refresh();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Merge request failed");
-      setMessageColor("red");
+      setResult({ ok: false, message: error instanceof Error ? error.message : "Architect handoff failed", prUrl });
     } finally {
       setPending(false);
     }
   }
 
   return (
-    <Group gap={6} wrap="nowrap">
-      <Button
-        type="button"
-        color="green"
-        variant="filled"
-        size="sm"
-        radius="md"
-        leftSection={<GitMerge size={14} />}
-        loading={pending}
-        onClick={mergePr}
-      >
-        Merge PR
-      </Button>
-      {message ? (
-        <Text size="xs" c={messageColor} lineClamp={1} maw={180} title={message}>
-          {message}
-        </Text>
+    <Stack gap={6} className="merge-pr-control">
+      <Group gap={6} wrap="nowrap">
+        <Button
+          type="button"
+          color="green"
+          variant="filled"
+          size="sm"
+          radius="md"
+          leftSection={<GitPullRequestArrow size={14} />}
+          loading={pending}
+          onClick={mergePr}
+        >
+          Ask architect
+        </Button>
+        {result?.ok ? <Text size="xs" c="green">{result.message}</Text> : null}
+      </Group>
+      {result?.ok && result.architectUrl ? (
+        <Button component="a" href={result.architectUrl} size="compact-xs" variant="light" color="green" radius="xl">
+          Open architect session
+        </Button>
       ) : null}
-    </Group>
+      {result && !result.ok ? (
+        <Alert className="merge-pr-error" color="red" variant="light" icon={<AlertTriangle size={16} />}>
+          <Stack gap={4}>
+            <Text size="xs" fw={760}>Architect handoff failed</Text>
+            <Text size="xs">{result.message}</Text>
+            {result.mergeable ? <Text size="xs" c="dimmed">GitHub mergeable state: {result.mergeable}</Text> : null}
+            {result.action ? <Text size="xs" c="dimmed">{result.action}</Text> : null}
+            <Group gap="xs">
+              {result.architectUrl ? (
+                <Button component="a" href={result.architectUrl} size="compact-xs" variant="light" color="red" radius="xl">
+                  Open architect session
+                </Button>
+              ) : null}
+              {result.prUrl ? (
+                <Anchor size="xs" href={result.prUrl} target="_blank" rel="noreferrer">
+                  <Group gap={4} component="span">
+                    <ExternalLink size={12} />
+                    Open pull request
+                  </Group>
+                </Anchor>
+              ) : null}
+            </Group>
+          </Stack>
+        </Alert>
+      ) : null}
+    </Stack>
   );
 }
+
+type MergeResponse = {
+  error?: string;
+  action?: string;
+  architectUrl?: string;
+  prUrl?: string | null;
+  mergeable?: string | null;
+};
+
+type MergeResult = {
+  ok: boolean;
+  message: string;
+  action?: string;
+  architectUrl?: string;
+  prUrl?: string | null;
+  mergeable?: string | null;
+};

--- a/src/components/ProjectReturnToDeveloperButton.tsx
+++ b/src/components/ProjectReturnToDeveloperButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button, Text } from "@mantine/core";
+import { RotateCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function ProjectReturnToDeveloperButton({
+  projectId,
+  issueId
+}: {
+  projectId: string;
+  issueId: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function returnToDeveloper() {
+    setPending(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/projects/${projectId}/issues/${issueId}/return-to-developer`, { method: "POST" });
+      const payload = await response.json() as { error?: string; redirectTo?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Return to developer failed");
+        return;
+      }
+      if (payload.redirectTo) router.push(payload.redirectTo);
+      router.refresh();
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Return to developer failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Button type="button" variant="light" color="orange" size="compact-xs" radius="xl" leftSection={<RotateCcw size={14} />} loading={pending} onClick={returnToDeveloper}>
+        Return to developer
+      </Button>
+      {error ? <Text size="xs" c="red" maw={220}>{error}</Text> : null}
+    </>
+  );
+}

--- a/src/lib/github-local.ts
+++ b/src/lib/github-local.ts
@@ -195,16 +195,6 @@ export async function removeLabelsWithGh(repo: string, target: number | string, 
   await execFileAsync("gh", ["issue", "edit", String(target), "--repo", repo, "--remove-label", labels.join(",")]);
 }
 
-export async function mergePullRequestWithGh(repo: string, prUrl: string): Promise<void> {
-  await execFileAsync("gh", ["pr", "merge", prUrl, "--repo", repo, "--merge"]);
-}
-
-export async function closeIssueWithGh(repo: string, issueNumber: number, comment?: string): Promise<void> {
-  const args = ["issue", "close", String(issueNumber), "--repo", repo];
-  if (comment) args.push("--comment", comment);
-  await execFileAsync("gh", args);
-}
-
 export async function getIssueSnapshotWithGh(repo: string, issueNumber: number): Promise<GhIssueSnapshot> {
   const { stdout: issueStdout } = await execFileAsync("gh", ["issue", "view", String(issueNumber), "--repo", repo, "--json", "number,url,state,labels"]);
   const issue = JSON.parse(issueStdout) as { number: number; url: string; state: string; labels: Array<{ name: string }> };

--- a/src/lib/job-runner.ts
+++ b/src/lib/job-runner.ts
@@ -1,4 +1,4 @@
-import { runWorkflow, runWorkflowIssue, syncWorkflowFromGitHub } from "@/lib/orchestrator";
+import { runWorkflow, runWorkflowIssue, runWorkflowQa, syncWorkflowFromGitHub } from "@/lib/orchestrator";
 import { runWithJobRuntime } from "@/lib/job-runtime";
 import { claimNextPendingJob, getJob, getProject, getWorkflow, saveJob } from "@/lib/store";
 import type { JobRecord } from "@/lib/types";
@@ -10,7 +10,7 @@ export async function runNextJob(projectId?: string): Promise<{ job: JobRecord |
 
   try {
     await runWithJobRuntime(job.jobId, async () => {
-      if (job.type !== "workflow_run" && job.type !== "issue_run") return;
+      if (job.type !== "workflow_run" && job.type !== "issue_run" && job.type !== "qa_run") return;
       const project = job.projectId ? await getProject(job.projectId) : null;
       const workflow = await getWorkflow(job.payload.workflowId);
       if (workflow?.paused) {
@@ -23,6 +23,8 @@ export async function runNextJob(projectId?: string): Promise<{ job: JobRecord |
       }
       if (job.type === "issue_run" && job.payload.issueId) {
         await runWorkflowIssue(job.payload.workflowId, job.payload.issueId, project);
+      } else if (job.type === "qa_run" && job.payload.issueId) {
+        await runWorkflowQa(job.payload.workflowId, job.payload.issueId, project);
       } else {
         await runWorkflow(job.payload.workflowId, project);
       }

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -3,8 +3,8 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { CodexClient } from "@/lib/codex";
 import { GitHubClient } from "@/lib/github";
-import { addLabelsWithGh, createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh, removeLabelsWithGh } from "@/lib/github-local";
-import { expectedDeveloperBaseBranch, expectedDeveloperBranch, isRecoverablePrBase, manualDeployArchitectPolicyDecision, manualDeployFinalLabelPlan, prRecoveryBranches } from "@/lib/issue-run-policy";
+import { createIssueWithGh, findPullRequestByHeadWithGh, getIssueSnapshotWithGh } from "@/lib/github-local";
+import { expectedDeveloperBaseBranch, expectedDeveloperBranch, isRecoverablePrBase, prRecoveryBranches } from "@/lib/issue-run-policy";
 import { getSettings } from "@/lib/settings";
 import { appendAgentMessages, createJob, listWorkflows, saveProject, saveWorkflow, getWorkflow } from "@/lib/store";
 import type { IssueRecord, IssueSpec, ProjectRecord, WorkflowRecord } from "@/lib/types";
@@ -131,6 +131,95 @@ export async function runWorkflowIssue(workflowId: string, issueId: string, proj
   workflow.timeline.push(...result.timeline);
   workflow.status = deriveWorkflowStatus(workflow);
   if (result.blocked) workflow.status = "blocked";
+  await saveWorkflow(workflow);
+  if (project) await saveProject(project);
+  return workflow;
+}
+
+export async function runWorkflowQa(workflowId: string, issueId: string, project?: ProjectRecord | null): Promise<WorkflowRecord> {
+  const settings = await getSettings();
+  const codex = new CodexClient(settings);
+  const workflow = await getWorkflow(workflowId);
+  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  const issue = workflow.issues.find((item) => item.issueId === issueId);
+  if (!issue) throw new Error(`Issue ${issueId} not found in workflow ${displayWorkflowCode(workflow)}`);
+  if (!project?.githubRepo || !issue.githubIssueNumber || !issue.prUrl) throw new Error(`Issue ${issueId} is missing GitHub PR context for QA`);
+
+  workflow.status = "in_progress";
+  workflow.timeline.push(`QA started for issue ${issue.issueId}.`);
+  await saveWorkflow(workflow);
+
+  const issueOwnedPaths = issue.ownedPaths ?? [];
+  const qaStartedAt = new Date().toISOString();
+  if (workflow.projectId) {
+    await appendAgentMessages({
+      sessionKey: issue.qaSessionId ?? `${issue.issueId}:qa`,
+      projectId: workflow.projectId,
+      role: "qa",
+      title: `QA: ${issue.title}`,
+      workflowId: workflow.workflowId,
+      issueId: issue.issueId,
+      ownedPaths: issueOwnedPaths,
+      status: "active",
+      currentStep: "QA validating PR",
+      startedAt: qaStartedAt,
+      githubIssueNumber: issue.githubIssueNumber,
+      githubIssueUrl: issue.githubIssueUrl ?? null,
+      prUrl: issue.prUrl,
+      labels: ["taskix:need-qa", "taskix:qa-running"],
+      messages: [
+        { role: "user", content: `Validate PR ${issue.prUrl} for issue #${issue.githubIssueNumber}: ${issue.title}`, createdAt: qaStartedAt }
+      ]
+    });
+  }
+
+  const qaResult = await codex.qaReviewPr({
+    repo: project.githubRepo,
+    issueNumber: issue.githubIssueNumber,
+    prUrl: issue.prUrl
+  });
+  const qaFinishedAt = new Date().toISOString();
+  const qaCloseAt = qaResult.passed ? qaFinishedAt : null;
+  const appliedLabels = qaResult.passed ? ["taskix:qa-passed"] : ["taskix:qa-failed"];
+  const qaStateLabels = ["qa-passed", "taskix:need-qa", "taskix:qa-running", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"];
+  issue.labels = [...new Set([...(issue.labels ?? []).filter((label) => !qaStateLabels.includes(label.toLowerCase())), ...appliedLabels])];
+  issue.prLabels = [...new Set([...(issue.prLabels ?? []).filter((label) => !qaStateLabels.includes(label.toLowerCase())), ...appliedLabels])];
+
+  if (workflow.projectId) {
+    await appendAgentMessages({
+      sessionKey: issue.qaSessionId ?? `${issue.issueId}:qa`,
+      projectId: workflow.projectId,
+      role: "qa",
+      title: `QA: ${issue.title}`,
+      workflowId: workflow.workflowId,
+      issueId: issue.issueId,
+      ownedPaths: issueOwnedPaths,
+      status: qaResult.passed ? "done" : "blocked",
+      currentStep: qaResult.passed ? "QA passed" : "QA failed",
+      startedAt: qaStartedAt,
+      finishedAt: qaFinishedAt,
+      durationMs: Math.max(0, new Date(qaFinishedAt).getTime() - new Date(qaStartedAt).getTime()),
+      githubIssueNumber: issue.githubIssueNumber,
+      githubIssueUrl: issue.githubIssueUrl ?? null,
+      prUrl: issue.prUrl,
+      labels: appliedLabels,
+      closedAt: qaCloseAt,
+      archivedAt: qaCloseAt,
+      executionLogs: qaResult.executionLog ? [{
+        title: `QA Codex execution for ${issue.title}`,
+        content: qaResult.executionLog,
+        createdAt: qaFinishedAt,
+        status: qaResult.passed ? "ok" : "failed"
+      }] : [],
+      messages: [
+        { role: "assistant", content: `Passed: ${qaResult.passed}\n${qaResult.summary}\nFindings:\n${qaResult.findings.map((finding) => `- ${finding}`).join("\n") || "- none"}\nLabels: ${appliedLabels.join(", ")}`, createdAt: new Date().toISOString() }
+      ]
+    });
+  }
+
+  workflow.timeline.push(qaResult.passed ? `QA passed PR for issue ${issue.issueId}. Awaiting architect merge handoff.` : `QA failed PR for issue ${issue.issueId}: ${qaResult.summary}`);
+  workflow.status = deriveWorkflowStatus(workflow);
+  if (!qaResult.passed) workflow.status = "blocked";
   await saveWorkflow(workflow);
   if (project) await saveProject(project);
   return workflow;
@@ -319,7 +408,7 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
       githubIssueNumber: issue.githubIssueNumber,
       githubIssueUrl: issue.githubIssueUrl ?? null,
       prUrl: developerResult.prUrl || null,
-      labels: developerResult.prUrl ? ["taskix:pr-opened", "taskix:architect-review"] : ["taskix:blocked"],
+      labels: developerResult.prUrl ? ["taskix:pr-opened"] : ["taskix:blocked"],
       closedAt: closeAt,
       archivedAt: closeAt,
       executionLogs: developerResult.executionLog ? [{
@@ -351,125 +440,10 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
     };
   }
 
-  let architectReview = await requestInitialPrReview(project, issue, developerResult.prUrl, codex);
-  if (workflow.projectId) {
-    await appendAgentMessages({
-      sessionKey: `${workflow.projectId}:architect`,
-      projectId: workflow.projectId,
-      role: "architect",
-      title: "Architect",
-      workflowId: workflow.workflowId,
-      issueId: issue.issueId,
-      executionLogs: architectReview.executionLog ? [{
-        title: `Architect Codex review for ${issue.title}`,
-        content: architectReview.executionLog,
-        createdAt: new Date().toISOString(),
-        status: architectReview.decision === "blocked" || architectReview.decision === "changes_requested" ? "failed" : "ok"
-      }] : [],
-      messages: [
-        { role: "user", content: `Review PR for issue ${issue.issueId}: ${developerResult.prUrl}`, createdAt: new Date().toISOString() },
-        { role: "assistant", content: `Decision: ${architectReview.decision}\n${architectReview.summary}\nLabels: ${architectReview.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }
-      ]
-    });
-  }
-  timeline.push(`Architect reviewed PR for issue ${issue.issueId}: ${architectReview.decision}.`);
-
-  let qaPassed = false;
-  let qaSummary = "QA not requested.";
-  if (architectReview.decision === "need_qa") {
-    const qaStartedAt = new Date().toISOString();
-    if (workflow.projectId) {
-      await appendAgentMessages({
-        sessionKey: issue.qaSessionId ?? `${issue.issueId}:qa`,
-        projectId: workflow.projectId,
-        role: "qa",
-        title: `QA: ${issue.title}`,
-        workflowId: workflow.workflowId,
-        issueId: issue.issueId,
-        ownedPaths: issueOwnedPaths,
-        status: "active",
-        currentStep: "QA validating PR",
-        startedAt: qaStartedAt,
-        githubIssueNumber: issue.githubIssueNumber,
-        githubIssueUrl: issue.githubIssueUrl ?? null,
-        prUrl: developerResult.prUrl,
-        labels: ["taskix:need-qa", "taskix:qa-running"],
-        messages: [
-          { role: "user", content: `Validate PR ${developerResult.prUrl} for issue #${issue.githubIssueNumber}: ${issue.title}`, createdAt: qaStartedAt }
-        ]
-      });
-    }
-    const qaResult = await codex.qaReviewPr({
-      repo: project.githubRepo,
-      issueNumber: issue.githubIssueNumber,
-      prUrl: developerResult.prUrl
-    });
-    qaPassed = qaResult.passed;
-    qaSummary = qaResult.summary;
-    const qaFinishedAt = new Date().toISOString();
-    const qaCloseAt = qaResult.passed ? qaFinishedAt : null;
-  if (workflow.projectId) {
-    await appendAgentMessages({
-      sessionKey: issue.qaSessionId ?? `${issue.issueId}:qa`,
-      projectId: workflow.projectId,
-      role: "qa",
-      title: `QA: ${issue.title}`,
-      workflowId: workflow.workflowId,
-      issueId: issue.issueId,
-      ownedPaths: issueOwnedPaths,
-      status: qaResult.passed ? "done" : "blocked",
-      currentStep: qaResult.passed ? "QA passed" : "QA failed",
-      startedAt: qaStartedAt,
-      finishedAt: qaFinishedAt,
-      durationMs: Math.max(0, new Date(qaFinishedAt).getTime() - new Date(qaStartedAt).getTime()),
-      githubIssueNumber: issue.githubIssueNumber,
-      githubIssueUrl: issue.githubIssueUrl ?? null,
-      prUrl: developerResult.prUrl,
-      labels: qaResult.labelsApplied,
-      closedAt: qaCloseAt,
-      archivedAt: qaCloseAt,
-      executionLogs: qaResult.executionLog ? [{
-        title: `QA Codex execution for ${issue.title}`,
-        content: qaResult.executionLog,
-        createdAt: qaFinishedAt,
-        status: qaResult.passed ? "ok" : "failed"
-      }] : [],
-      messages: [
-          { role: "assistant", content: `Passed: ${qaResult.passed}\n${qaResult.summary}\nFindings:\n${qaResult.findings.map((finding) => `- ${finding}`).join("\n") || "- none"}\nLabels: ${qaResult.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }
-      ]
-    });
-  }
-    if (qaResult.passed) {
-      timeline.push(`QA passed PR for issue ${issue.issueId}.`);
-      architectReview = await requestFinalPrReview(project, issue, developerResult.prUrl, codex);
-      if (workflow.projectId) {
-        await appendAgentMessages({
-          sessionKey: `${workflow.projectId}:architect`,
-          projectId: workflow.projectId,
-          role: "architect",
-          title: "Architect",
-          workflowId: workflow.workflowId,
-          issueId: issue.issueId,
-          executionLogs: architectReview.executionLog ? [{
-            title: `Architect final Codex review for ${issue.title}`,
-            content: architectReview.executionLog,
-            createdAt: new Date().toISOString(),
-            status: architectReview.decision === "blocked" || architectReview.decision === "changes_requested" ? "failed" : "ok"
-          }] : [],
-          messages: [
-            { role: "user", content: `QA passed PR ${developerResult.prUrl}. Perform final review/merge for issue ${issue.issueId}.`, createdAt: new Date().toISOString() },
-            { role: "assistant", content: `Decision: ${architectReview.decision}\n${architectReview.summary}\nLabels: ${architectReview.labelsApplied.join(", ") || "none"}`, createdAt: new Date().toISOString() }
-          ]
-        });
-      }
-      timeline.push(`Architect final review after QA for issue ${issue.issueId}: ${architectReview.decision}.`);
-    } else {
-      timeline.push(`QA failed PR for issue ${issue.issueId}: ${qaResult.summary}`);
-    }
-  }
-
-  const blocked = architectReview.decision === "blocked" || architectReview.decision === "changes_requested" || (architectReview.decision === "need_qa" && !qaPassed);
-
+  const developerCompletionCleanupLabels = ["taskix:dev-running", "qa-passed", "taskix:qa-passed", "qa-failed", "taskix:qa-failed", "taskix:ready-to-merge"];
+  issue.labels = [...new Set([...(issue.labels ?? []).filter((label) => !developerCompletionCleanupLabels.includes(label.toLowerCase())), "taskix:pr-opened"])];
+  issue.prLabels = [...new Set([...(issue.prLabels ?? []).filter((label) => !developerCompletionCleanupLabels.includes(label.toLowerCase())), "taskix:pr-opened"])];
+  timeline.push(`Developer completed PR for issue ${issue.issueId}. Awaiting QA handoff.`);
   return {
     timeline,
     releaseNote: {
@@ -479,13 +453,14 @@ async function runIssue(issue: IssueRecord, workflow: WorkflowRecord, codex: Cod
       ownedPaths,
       developerSummary: developerResult.summary,
       prUrl: developerResult.prUrl,
-      qaPassed,
-      qaSummary,
-      architectDecision: architectReview.decision,
-      architectSummary: architectReview.summary
+      qaPassed: false,
+      qaSummary: "QA handoff pending.",
+      architectDecision: "need_qa",
+      architectSummary: "Developer completed PR; waiting for explicit QA handoff."
     },
-    blocked
+    blocked: false
   };
+
 }
 
 function createIssueCreator(project: ProjectRecord | null | undefined, settings: Awaited<ReturnType<typeof getSettings>>) {
@@ -502,9 +477,10 @@ function choosePrimaryPr(prs: Array<{ url: string; state: string; labels: string
 }
 
 function deriveQaSessionStatus(labels: string[]): "active" | "blocked" | "done" | null {
-  if (labels.includes("taskix:qa-passed")) return "done";
-  if (labels.includes("taskix:qa-failed")) return "blocked";
-  if (labels.includes("taskix:need-qa") || labels.includes("taskix:qa-running")) return "active";
+  const normalizedLabels = labels.map((label) => label.toLowerCase());
+  if (normalizedLabels.includes("taskix:qa-passed")) return "done";
+  if (normalizedLabels.includes("taskix:qa-failed")) return "blocked";
+  if (normalizedLabels.includes("taskix:need-qa") || normalizedLabels.includes("taskix:qa-running")) return "active";
   return null;
 }
 
@@ -564,92 +540,6 @@ async function readPullRequestRefs(repo: string, pr: string): Promise<{ head: st
   } catch {
     return { head: null, base: null, state: null, merged: false };
   }
-}
-
-async function requestInitialPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
-  if (!project.autoDeploy && issue.githubIssueNumber) {
-    const labels = ["taskix:need-qa"];
-    await Promise.all([
-      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
-      addLabelsWithGh(project.githubRepo, prUrl, labels)
-    ]);
-    return {
-      decision: "need_qa" as const,
-      summary: `Manual-deploy project: Taskix requested QA for ${prUrl} and stopped before merge review.`,
-      labelsApplied: labels,
-      comments: []
-    };
-  }
-
-  const review = await codex.architectReviewPr({
-    repo: project.githubRepo,
-    issueNumber: issue.githubIssueNumber ?? 0,
-    prUrl,
-    autoDeploy: project.autoDeploy
-  });
-  if (review.decision === "blocked" && !review.labelsApplied.length && review.summary.includes("Architect runner did not complete PR review") && issue.githubIssueNumber) {
-    const labels = ["taskix:need-qa"];
-    await Promise.all([
-      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labels),
-      addLabelsWithGh(project.githubRepo, prUrl, labels)
-    ]);
-    return {
-      decision: "need_qa" as const,
-      summary: `Architect runner did not complete structured PR review. Taskix conservatively requested QA for ${prUrl}.`,
-      labelsApplied: labels,
-      comments: []
-    };
-  }
-  return review;
-}
-
-async function requestFinalPrReview(project: ProjectRecord, issue: IssueRecord, prUrl: string, codex: CodexClient) {
-  if (!project.autoDeploy && issue.githubIssueNumber) {
-    const prRefs = await readPullRequestRefs(project.githubRepo, prUrl);
-    const architectDecision = manualDeployArchitectPolicyDecision({
-      prUrl,
-      qaPassed: true,
-      prState: prRefs.state,
-      prMerged: prRefs.merged
-    });
-    const labelPlan = manualDeployFinalLabelPlan({ prUrl, architectDecision });
-    if (labelPlan.decision !== "ready_to_merge") {
-      await Promise.all([
-        addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsApplied),
-        addLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsApplied),
-        removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsRemoved),
-        removeLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsRemoved)
-      ]);
-      return {
-        ...architectDecision,
-        decision: labelPlan.decision,
-        summary: labelPlan.summary,
-        labelsApplied: labelPlan.labelsApplied,
-        comments: labelPlan.comments
-      };
-    }
-
-    await Promise.all([
-      addLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsApplied),
-      addLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsApplied),
-      removeLabelsWithGh(project.githubRepo, issue.githubIssueNumber, labelPlan.labelsRemoved),
-      removeLabelsWithGh(project.githubRepo, prUrl, labelPlan.labelsRemoved)
-    ]);
-    return {
-      decision: "ready_to_merge" as const,
-      summary: labelPlan.summary,
-      labelsApplied: labelPlan.labelsApplied,
-      comments: labelPlan.comments
-    };
-  }
-
-  return codex.architectReviewPr({
-    repo: project.githubRepo,
-    issueNumber: issue.githubIssueNumber ?? 0,
-    prUrl,
-    autoDeploy: project.autoDeploy,
-    qaPassed: true
-  });
 }
 
 function deriveWorkflowStatus(workflow: WorkflowRecord): WorkflowRecord["status"] {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -168,8 +168,8 @@ export async function claimNextPendingJob(projectId?: string): Promise<JobRecord
   await recoverStaleRunningJobs(projectId);
 
   const row = projectId
-    ? getDb().prepare("SELECT payload FROM jobs WHERE status = 'pending' AND project_id = ? ORDER BY CASE type WHEN 'issue_run' THEN 0 ELSE 1 END, created_at ASC LIMIT 1").get(projectId) as { payload: string } | undefined
-    : getDb().prepare("SELECT payload FROM jobs WHERE status = 'pending' ORDER BY CASE type WHEN 'issue_run' THEN 0 ELSE 1 END, created_at ASC LIMIT 1").get() as { payload: string } | undefined;
+    ? getDb().prepare("SELECT payload FROM jobs WHERE status = 'pending' AND project_id = ? ORDER BY CASE type WHEN 'issue_run' THEN 0 WHEN 'qa_run' THEN 1 ELSE 2 END, created_at ASC LIMIT 1").get(projectId) as { payload: string } | undefined
+    : getDb().prepare("SELECT payload FROM jobs WHERE status = 'pending' ORDER BY CASE type WHEN 'issue_run' THEN 0 WHEN 'qa_run' THEN 1 ELSE 2 END, created_at ASC LIMIT 1").get() as { payload: string } | undefined;
   if (!row) return null;
 
   const job = JSON.parse(row.payload) as JobRecord;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export type WorkflowStatus = "created" | "planned" | "in_progress" | "blocked" |
 export type AgentSessionStatus = "active" | "blocked" | "done";
 export type AgentMessageRole = "user" | "assistant" | "system";
 export type JobStatus = "pending" | "running" | "done" | "failed";
-export type JobType = "workflow_run" | "issue_run";
+export type JobType = "workflow_run" | "issue_run" | "qa_run";
 
 export type Settings = {
   appBaseUrl: string;

--- a/src/lib/workflow-next-action.ts
+++ b/src/lib/workflow-next-action.ts
@@ -13,6 +13,7 @@ export type WorkflowNextAction = {
   icon: WorkflowNextActionIcon;
   planningPending: number;
   developerPending: number;
+  qaPending: number;
   runningCount: number;
   failedCount: number;
 };
@@ -20,6 +21,7 @@ export type WorkflowNextAction = {
 export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]): WorkflowNextAction {
   const planningPending = jobs.filter((job) => job.status === "pending" && job.type === "workflow_run").length;
   const developerPending = jobs.filter((job) => job.status === "pending" && job.type === "issue_run").length;
+  const qaPending = jobs.filter((job) => job.status === "pending" && job.type === "qa_run").length;
   const runningCount = jobs.filter((job) => job.status === "running").length;
   const failedCount = jobs.filter((job) => job.status === "failed").length;
 
@@ -34,6 +36,7 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
       icon: "clock",
       planningPending,
       developerPending,
+      qaPending,
       runningCount,
       failedCount
     };
@@ -50,6 +53,24 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
       icon: "play",
       planningPending,
       developerPending,
+      qaPending,
+      runningCount,
+      failedCount
+    };
+  }
+
+  if (qaPending) {
+    return {
+      title: "Start next QA validation",
+      phase: "QA validation",
+      description: "Runs one QA validation job for a developer PR and records pass/fail before architect merge handling.",
+      buttonLabel: "Start Next QA Validation",
+      disabledLabel: "Start Next QA Validation",
+      tone: "ready",
+      icon: "play",
+      planningPending,
+      developerPending,
+      qaPending,
       runningCount,
       failedCount
     };
@@ -66,6 +87,7 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
       icon: "git-branch",
       planningPending,
       developerPending,
+      qaPending,
       runningCount,
       failedCount
     };
@@ -82,6 +104,7 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
       icon: "alert",
       planningPending,
       developerPending,
+      qaPending,
       runningCount,
       failedCount
     };
@@ -97,6 +120,7 @@ export function getWorkflowNextAction(jobs: Pick<JobRecord, "status" | "type">[]
     icon: "check",
     planningPending,
     developerPending,
+    qaPending,
     runningCount,
     failedCount
   };

--- a/src/lib/workflow-progress.ts
+++ b/src/lib/workflow-progress.ts
@@ -41,11 +41,11 @@ const stepCopy: Record<WorkflowProgressStepId, { label: string; detail: string }
 
 export function getWorkflowProgress(input: {
   workflows: Pick<WorkflowRecord, "status" | "issues">[];
-  jobs: Pick<JobRecord, "status" | "type">[];
+  jobs: WorkflowProgressJob[];
 }): WorkflowProgressStep[] {
   const workflows = input.workflows;
-  const jobs = input.jobs;
   const issues = workflows.flatMap((workflow) => workflow.issues);
+  const jobs = input.jobs.filter((job) => isJobStillRelevant(job, issues));
   const hasAnyWorkflow = workflows.length > 0;
   const hasActiveWorkflow = workflows.some((workflow) => workflow.status !== "done");
   const hasDoneWorkflow = workflows.some((workflow) => workflow.status === "done");
@@ -81,21 +81,23 @@ function getStepStatus(input: {
 
 function getBlockedStep(
   workflows: Pick<WorkflowRecord, "status">[],
-  jobs: Pick<JobRecord, "status" | "type">[],
+  jobs: WorkflowProgressJob[],
   issues: Pick<IssueRecord, "labels" | "prLabels" | "prUrl" | "prState">[]
 ): WorkflowProgressStepId | null {
   if (jobs.some((job) => job.status === "failed" && job.type === "workflow_run")) return "planning";
   if (jobs.some((job) => job.status === "failed" && job.type === "issue_run")) return "developer";
-  if (workflows.some((workflow) => workflow.status === "blocked")) return "developer";
   if (issues.some((issue) => hasAnyIssueLabel(issue, ["qa-failed", "taskix:qa-failed"]))) return "qa";
+  if (jobs.some((job) => job.status === "failed" && job.type === "qa_run")) return "qa";
   const blockedIssue = issues.find((issue) => hasAnyIssueLabel(issue, ["taskix:blocked"]));
   if (blockedIssue) return blockedIssue.prUrl || blockedIssue.prState ? "qa" : "developer";
+  if (workflows.some((workflow) => workflow.status === "blocked")) return "developer";
   return null;
 }
 
-function getRunningStep(jobs: Pick<JobRecord, "status" | "type">[]): WorkflowProgressStepId | null {
+function getRunningStep(jobs: WorkflowProgressJob[]): WorkflowProgressStepId | null {
   if (jobs.some((job) => job.status === "running" && job.type === "workflow_run")) return "planning";
   if (jobs.some((job) => job.status === "running" && job.type === "issue_run")) return "developer";
+  if (jobs.some((job) => job.status === "running" && job.type === "qa_run")) return "qa";
   return null;
 }
 
@@ -110,6 +112,7 @@ function getCurrentStep(input: {
   if (!input.hasActiveWorkflow && input.hasDoneWorkflow) return "done";
   if (input.jobs.some((job) => job.status !== "done" && job.type === "workflow_run")) return "planning";
   if (input.jobs.some((job) => job.status !== "done" && job.type === "issue_run")) return "developer";
+  if (input.jobs.some((job) => job.status !== "done" && job.type === "qa_run")) return "qa";
   if (input.issues.some((issue) => hasAnyIssueLabel(issue, ["taskix:ready-to-merge"]))) return "merge";
   if (input.issues.some((issue) => hasAnyIssueLabel(issue, ["qa-passed", "taskix:qa-passed"]))) return "merge";
   if (input.issues.some((issue) => issue.prUrl || issue.prState)) return "qa";
@@ -120,6 +123,28 @@ function getCurrentStep(input: {
 
 function isDoneComplete(id: WorkflowProgressStepId, hasDoneWorkflow: boolean, hasActiveWorkflow: boolean): boolean {
   return id === "done" && hasDoneWorkflow && !hasActiveWorkflow;
+}
+
+type WorkflowProgressJob = Pick<JobRecord, "status" | "type"> & {
+  payload?: Pick<JobRecord["payload"], "issueId">;
+};
+
+function isJobStillRelevant(
+  job: WorkflowProgressJob,
+  issues: Pick<IssueRecord, "issueId" | "labels" | "prLabels" | "prUrl" | "prState">[]
+): boolean {
+  if (job.type !== "issue_run" || job.status !== "failed" || !job.payload?.issueId) return true;
+  const issue = issues.find((item) => item.issueId === job.payload?.issueId);
+  if (!issue) return true;
+  return !isIssuePastDeveloperStep(issue);
+}
+
+function isIssuePastDeveloperStep(issue: Pick<IssueRecord, "labels" | "prLabels" | "prUrl" | "prState">): boolean {
+  return Boolean(
+    issue.prUrl ||
+    issue.prState ||
+    hasAnyIssueLabel(issue, ["taskix:need-qa", "taskix:qa-running", "qa-passed", "taskix:qa-passed", "taskix:ready-to-merge"])
+  );
 }
 
 function hasAnyIssueLabel(issue: Pick<IssueRecord, "labels" | "prLabels">, expected: string[]): boolean {


### PR DESCRIPTION
## Summary
- Split the web workflow into explicit PM, architect planning, developer PR, QA validation, and architect merge stages.
- Added explicit Handoff to QA and Return to developer controls with dedicated API routes and qa_run jobs.
- Changed merge handling so the backend delegates to the architect Codex session instead of directly running gh merge.
- Updated workflow progress and next-action logic so QA jobs and stale developer failures are represented correctly.

Closes #113

## Verification
- npm run typecheck
- npm test
- npm run build

## QA Status
Status: need-qa

## QA Instructions
1. Run npm run dev and open http://127.0.0.1:8000.
2. Use a project workflow that has planned developer issues or create a fresh workflow for the refactored path.
3. Confirm developer completion stops after PR creation and exposes Handoff to QA, without auto-running QA or architect merge review.
4. Click Handoff to QA and confirm taskix:need-qa/taskix:qa-running labels are applied and a qa_run job appears in step 4.
5. Validate QA pass moves the issue to merge readiness and QA failure exposes Return to developer.
6. In merge readiness, click Ask architect and confirm it opens/appends the architect session instead of directly merging through the backend.
7. Click Return to developer from QA failure or merge readiness and confirm QA/ready labels are removed, taskix:dev-running is added, and an issue_run job is queued.
8. Confirm stale failed developer jobs do not keep the workflow stuck on step 3 after a retry has progressed.