### PR TITLE
Stabilize build validation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,11 @@
+import path from "node:path";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  turbopack: {
+    root: path.resolve(".")
+  }
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev -H 127.0.0.1 -p 8000",
-    "build": "next build",
+    "build": "NODE_ENV=production next build",
     "start": "next start -H 127.0.0.1 -p 8000",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --test scripts/*.test.mjs",


### PR DESCRIPTION
## Summary
- Fixes #116.
- Pins Turbopack root to this isolated workspace so validation does not infer the parent checkout when multiple lockfiles exist.
- Makes `npm run build` force production mode so it passes even when the caller shell exports `NODE_ENV=development`.

## Scope notes
- Changed files are limited to owned paths: `package.json` and `next.config.mjs`.
- No deployment setup or unrelated application files were modified.
- The visible web header label scope is covered by the existing `scripts/header-label.test.mjs` test, which passed as part of `npm test`.

## Validation
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `npm test`: passed, 33 tests.
