### PR TITLE
Update visible web header label

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <div className="mark">TB</div>
               <div>
                 <Text fw={800} size="md" c="white" lh={1.15}>
-                  Gitdex Console
+                  Gitdex Management
                 </Text>
                 <Text size="xs" c="blue.1">
                   Project routing, Codex sessions, GitHub orchestration


### PR DESCRIPTION
Closes #115

Scoped header label change only. Verification: npm run typecheck passed; npm test fails because scripts/header-label.test.mjs expects the old label and scripts is outside owned paths; npm run build fails during /_global-error prerender with useContext null after compiling successfully.