### PR TITLE
Run console header validation checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev -H 127.0.0.1 -p 8000",
-    "build": "next build",
+    "build": "NODE_ENV=production next build",
     "start": "next start -H 127.0.0.1 -p 8000",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --test scripts/*.test.mjs",


### PR DESCRIPTION
Taskix workflow: WF-20260502-002
Issue: #124
## Summary
Implemented issue #124 on branch taskix/WF-20260502-002-issue-124. The build script now forces NODE_ENV=production so npm run build passes in the validation environment. Validation notes: the header change from issue #123 is in src/app/layout.tsx, the direct acceptance check is scripts/header-label.test.mjs, and no unrelated copy or behavior changes were intentionally introduced. Branch was committed and pushed; no PR was created per instruction.
## Changed Files
- package.json
## Verification
- npm run typecheck: passed
- npm test: passed, 35 tests
- npm run build: passed
- rg -n "Gitdex Console|Gitdex Management|Gitdex" src/app src/components scripts/header-label.test.mjs package.json package-lock.json: only expected Gitdex Management references in src/app/layout.tsx and scripts/header-label.test.mjs
Closes #124