### PR TITLE
Show package version in console header

### DIFF
--- a/scripts/header-version.test.mjs
+++ b/scripts/header-version.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import packageJson from "../package.json" with { type: "json" };
+
+const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+
+assert.match(
+  layoutSource,
+  /import packageJson from "\.\.\/\.\.\/package\.json";/,
+  "Root layout should source the header version from package.json"
+);
+
+assert.match(
+  layoutSource,
+  /aria-label=\{`Taskix version \$\{packageJson\.version\}`\}/,
+  "Root layout should expose the package version in the header affordance label"
+);
+
+assert.match(
+  layoutSource,
+  /v\{packageJson\.version\}/,
+  "Root layout should render the package version without duplicating the version literal"
+);
+
+assert.ok(packageJson.version, "package.json should define a version value");
+
+console.log(`header version verification passed for ${packageJson.version}`);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,6 +69,20 @@ pre,
   font-weight: var(--weight-heavy);
 }
 
+.topbar-version {
+  min-height: 28px;
+  padding: 0 10px;
+  color: #dbeafe;
+  background: rgba(37, 99, 235, 0.16);
+  border: 1px solid rgba(191, 219, 254, 0.34);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+  white-space: nowrap;
+}
+
 .shell {
   width: 100%;
   padding: 22px 28px 36px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { getSettings } from "@/lib/settings";
 import { listProjects, listWorkflows } from "@/lib/store";
 import { Providers } from "@/components/Providers";
 import { ShellLayout } from "@/components/ShellLayout";
+import packageJson from "../../package.json";
 import "@mantine/core/styles.css";
 import "./globals.css";
 
@@ -38,6 +39,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <Badge color="dark" variant="light">
                 Webhook <Code>{settings.appBaseUrl.replace(/\/$/, "")}/telegram/webhook</Code>
               </Badge>
+              <button className="topbar-version" type="button" aria-label={`Taskix version ${packageJson.version}`}>
+                v{packageJson.version}
+              </button>
             </Group>
           </header>
           <div className="shell">


### PR DESCRIPTION
Taskix workflow: WF-20260502-003
Issue: #130
## Summary
Implemented issue #130. The console header now displays `v{packageJson.version}` from the root `package.json` in a top-right non-executing header button, with responsive styling that keeps the label visible. Added a focused header version test that verifies the layout imports and renders the package version without duplicating the literal version string. Branch was committed and pushed; no PR was created per instructions.
## Changed Files
- src/app/layout.tsx
- src/app/globals.css
- scripts/header-version.test.mjs
## Verification
- node --experimental-strip-types --test scripts/header-version.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #130