### PR TITLE
Add controlled Next.js service restart endpoint

### DIFF
--- a/scripts/self-update-restart.test.mjs
+++ b/scripts/self-update-restart.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import process from "node:process";
+
+import {
+  resetSelfUpdateStateForTests,
+  runSelfUpdate,
+  selfUpdateGuard,
+  consumeRestartAvailability,
+  setSelfUpdateCommandRunnerForTests
+} from "../src/lib/self-update.ts";
+import {
+  getTaskixServiceRestartCommand,
+  requestTaskixServiceRestart,
+  resetTaskixServiceRestarterForTests,
+  setTaskixServiceRestarterForTests
+} from "../src/lib/taskix-service.ts";
+
+const originalFlag = process.env.TASKIX_ENABLE_SELF_UPDATE;
+const originalManager = process.env.TASKIX_NEXT_SERVICE_MANAGER;
+const originalServiceName = process.env.TASKIX_NEXT_SERVICE_NAME;
+
+afterEach(() => {
+  restoreEnv("TASKIX_ENABLE_SELF_UPDATE", originalFlag);
+  restoreEnv("TASKIX_NEXT_SERVICE_MANAGER", originalManager);
+  restoreEnv("TASKIX_NEXT_SERVICE_NAME", originalServiceName);
+  resetSelfUpdateStateForTests();
+  resetTaskixServiceRestarterForTests();
+});
+
+test("restart endpoint rejects requests when self-update is disabled", async () => {
+  delete process.env.TASKIX_ENABLE_SELF_UPDATE;
+
+  const response = await restartRequest(trustedRequest());
+
+  assert.equal(response.status, 403);
+  assert.match(response.error, /disabled/);
+});
+
+test("restart endpoint rejects callers without trusted localhost proof", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  const response = await restartRequest({ headers: new Headers(), remoteAddress: "203.0.113.10" });
+
+  assert.equal(response.status, 403);
+  assert.match(response.error, /localhost/);
+});
+
+test("restart endpoint blocks before a successful update build", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  const response = await restartRequest(trustedRequest());
+
+  assert.equal(response.status, 409);
+  assert.match(response.error, /self-update completes successfully/);
+});
+
+test("restart endpoint invokes the configured Taskix Next.js service after a successful update", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+  process.env.TASKIX_NEXT_SERVICE_MANAGER = "systemctl";
+  process.env.TASKIX_NEXT_SERVICE_NAME = "taskix-next.service";
+  const invoked = [];
+
+  setSelfUpdateCommandRunnerForTests(async (command) => ({
+    command: command.command,
+    exitCode: 0,
+    stdout: `${command.command} ok`,
+    stderr: ""
+  }));
+  setTaskixServiceRestarterForTests(async (command) => {
+    invoked.push(command);
+    return {
+      ok: true,
+      manager: command.manager,
+      serviceName: command.serviceName,
+      stdout: "restarted",
+      stderr: "",
+      error: null
+    };
+  });
+
+  await runSelfUpdate("/tmp/taskix-self-update-restart-test");
+  const response = await restartRequest(trustedRequest());
+
+  assert.equal(response.status, 200);
+  assert.equal(response.ok, true);
+  assert.equal(response.restartRequested, true);
+  assert.equal(response.manager, "systemctl");
+  assert.equal(response.serviceName, "taskix-next.service");
+  assert.equal(invoked.length, 1);
+  assert.deepEqual(invoked[0].args, ["restart", "taskix-next.service"]);
+});
+
+test("restart endpoint reports configured service failures", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+  process.env.TASKIX_NEXT_SERVICE_MANAGER = "pm2";
+  process.env.TASKIX_NEXT_SERVICE_NAME = "taskix-next";
+
+  setSelfUpdateCommandRunnerForTests(async (command) => ({
+    command: command.command,
+    exitCode: 0,
+    stdout: "",
+    stderr: ""
+  }));
+  setTaskixServiceRestarterForTests(async (command) => ({
+    ok: false,
+    manager: command.manager,
+    serviceName: command.serviceName,
+    stdout: "",
+    stderr: "pm2 failed",
+    error: "Taskix service restart failed."
+  }));
+
+  await runSelfUpdate("/tmp/taskix-self-update-restart-test");
+  const response = await restartRequest(trustedRequest());
+
+  assert.equal(response.status, 500);
+  assert.equal(response.restartRequested, false);
+  assert.equal(response.stderr, "pm2 failed");
+  assert.match(response.error, /restart failed/);
+});
+
+test("service restart config is limited to explicit Taskix service managers and names", () => {
+  assert.equal(getTaskixServiceRestartCommand({ TASKIX_NEXT_SERVICE_MANAGER: "sh", TASKIX_NEXT_SERVICE_NAME: "taskix" }).ok, false);
+  assert.equal(getTaskixServiceRestartCommand({ TASKIX_NEXT_SERVICE_MANAGER: "systemctl", TASKIX_NEXT_SERVICE_NAME: "other-app" }).ok, false);
+  assert.equal(getTaskixServiceRestartCommand({ TASKIX_NEXT_SERVICE_MANAGER: "systemctl", TASKIX_NEXT_SERVICE_NAME: "taskix/other" }).ok, false);
+  assert.equal(getTaskixServiceRestartCommand({ TASKIX_NEXT_SERVICE_MANAGER: "pm2", TASKIX_NEXT_SERVICE_NAME: "taskix-next" }).ok, true);
+});
+
+function trustedRequest() {
+  return { headers: new Headers(), remoteAddress: "127.0.0.1" };
+}
+
+function restartRequest(source) {
+  return requestTaskixServiceRestart({
+    source,
+    guard: selfUpdateGuard,
+    consumeRestartAvailability
+  });
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/src/app/api/self-update/restart/route.ts
+++ b/src/app/api/self-update/restart/route.ts
@@ -1,22 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
 import { consumeRestartAvailability, selfUpdateGuard } from "@/lib/self-update";
+import { requestTaskixServiceRestart } from "@/lib/taskix-service";
 
 export async function POST(request: NextRequest) {
-  const guard = selfUpdateGuard(request);
-  if (!guard.ok) {
-    return NextResponse.json({ error: guard.error }, { status: guard.status });
-  }
-
-  if (!consumeRestartAvailability()) {
+  const result = await requestTaskixServiceRestart({
+    source: request,
+    guard: selfUpdateGuard,
+    consumeRestartAvailability
+  });
+  if (!result.ok) {
     return NextResponse.json(
-      { error: "Restart is not available until self-update completes successfully." },
-      { status: 409 }
+      {
+        ok: false,
+        restartRequested: false,
+        error: result.error,
+        manager: result.manager,
+        serviceName: result.serviceName,
+        stdout: result.stdout,
+        stderr: result.stderr
+      },
+      { status: result.status }
     );
   }
 
   return NextResponse.json({
     ok: true,
     restartRequested: true,
-    message: "Restart requested. Restart supervision is handled outside Taskix."
-  });
+    manager: result.manager,
+    serviceName: result.serviceName,
+    stdout: result.stdout,
+    stderr: result.stderr
+  }, { status: result.status });
 }

--- a/src/lib/taskix-service.ts
+++ b/src/lib/taskix-service.ts
@@ -1,0 +1,181 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type TaskixServiceManager = "systemctl" | "launchctl" | "pm2";
+
+export type TaskixServiceRestartResult = {
+  ok: boolean;
+  manager: TaskixServiceManager | null;
+  serviceName: string | null;
+  stdout: string;
+  stderr: string;
+  error: string | null;
+};
+
+export type TaskixServiceRestartResponse = TaskixServiceRestartResult & {
+  status: number;
+  restartRequested: boolean;
+};
+
+type RestartCommand = {
+  manager: TaskixServiceManager;
+  bin: string;
+  args: string[];
+  serviceName: string;
+};
+
+type ServiceRestarter = (command: RestartCommand) => Promise<TaskixServiceRestartResult>;
+type RestartGuardResult = { ok: true } | { ok: false; status: number; error: string };
+
+let serviceRestarter: ServiceRestarter = runRestartCommand;
+
+export async function requestTaskixServiceRestart<TSource>(input: {
+  source: TSource;
+  guard: (source: TSource) => RestartGuardResult;
+  consumeRestartAvailability: () => boolean;
+}): Promise<TaskixServiceRestartResponse> {
+  const guard = input.guard(input.source);
+  if (!guard.ok) {
+    return {
+      ok: false,
+      status: guard.status,
+      restartRequested: false,
+      manager: null,
+      serviceName: null,
+      stdout: "",
+      stderr: "",
+      error: guard.error
+    };
+  }
+
+  if (!input.consumeRestartAvailability()) {
+    return {
+      ok: false,
+      status: 409,
+      restartRequested: false,
+      manager: null,
+      serviceName: null,
+      stdout: "",
+      stderr: "",
+      error: "Restart is not available until self-update completes successfully."
+    };
+  }
+
+  const result = await restartTaskixService();
+  return {
+    ...result,
+    status: result.ok ? 200 : result.manager ? 500 : 503,
+    restartRequested: result.ok
+  };
+}
+
+export async function restartTaskixService(env: NodeJS.ProcessEnv = process.env): Promise<TaskixServiceRestartResult> {
+  const config = getTaskixServiceRestartCommand(env);
+  if (!config.ok) {
+    return {
+      ok: false,
+      manager: null,
+      serviceName: null,
+      stdout: "",
+      stderr: "",
+      error: config.error
+    };
+  }
+
+  return serviceRestarter(config.command);
+}
+
+export function getTaskixServiceRestartCommand(env: NodeJS.ProcessEnv = process.env) {
+  const manager = env.TASKIX_NEXT_SERVICE_MANAGER;
+  const serviceName = env.TASKIX_NEXT_SERVICE_NAME?.trim() ?? "";
+
+  if (!isTaskixServiceManager(manager)) {
+    return {
+      ok: false as const,
+      error: "Taskix service restart is not configured. Set TASKIX_NEXT_SERVICE_MANAGER to systemctl, launchctl, or pm2."
+    };
+  }
+
+  if (!isTaskixServiceName(serviceName)) {
+    return {
+      ok: false as const,
+      error: "Taskix service restart requires TASKIX_NEXT_SERVICE_NAME to identify the Taskix Next.js service."
+    };
+  }
+
+  return {
+    ok: true as const,
+    command: buildRestartCommand(manager, serviceName)
+  };
+}
+
+export function setTaskixServiceRestarterForTests(restarter: ServiceRestarter) {
+  serviceRestarter = restarter;
+}
+
+export function resetTaskixServiceRestarterForTests() {
+  serviceRestarter = runRestartCommand;
+}
+
+function buildRestartCommand(manager: TaskixServiceManager, serviceName: string): RestartCommand {
+  if (manager === "systemctl") {
+    return { manager, bin: "systemctl", args: ["restart", serviceName], serviceName };
+  }
+
+  if (manager === "launchctl") {
+    return { manager, bin: "launchctl", args: ["kickstart", "-k", serviceName], serviceName };
+  }
+
+  return { manager, bin: "pm2", args: ["restart", serviceName], serviceName };
+}
+
+function isTaskixServiceManager(value: string | undefined): value is TaskixServiceManager {
+  return value === "systemctl" || value === "launchctl" || value === "pm2";
+}
+
+function isTaskixServiceName(value: string) {
+  // This endpoint is intentionally not a general service-control API.
+  return /^[a-zA-Z0-9._:@-]+$/.test(value) && value.toLowerCase().includes("taskix");
+}
+
+async function runRestartCommand(command: RestartCommand): Promise<TaskixServiceRestartResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command.bin, command.args, {
+      maxBuffer: 1024 * 1024 * 2
+    });
+
+    return {
+      ok: true,
+      manager: command.manager,
+      serviceName: command.serviceName,
+      stdout,
+      stderr,
+      error: null
+    };
+  } catch (error) {
+    const failure = error as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      message?: string;
+    };
+
+    return {
+      ok: false,
+      manager: command.manager,
+      serviceName: command.serviceName,
+      stdout: stringifyOutput(failure.stdout),
+      stderr: stringifyOutput(failure.stderr),
+      error: failure.message ?? "Taskix service restart failed."
+    };
+  }
+}
+
+function stringifyOutput(value: string | Buffer | undefined) {
+  if (!value) {
+    return "";
+  }
+
+  return Buffer.isBuffer(value) ? value.toString("utf8") : value;
+}


### PR DESCRIPTION
Taskix workflow: WF-20260502-003
Issue: #129
## Summary
Implemented issue #129 on branch taskix/WF-20260502-003-issue-129 and pushed it. Added a controlled Taskix Next.js service restart helper using explicit TASKIX_NEXT_SERVICE_MANAGER and TASKIX_NEXT_SERVICE_NAME configuration, kept restart gated by the existing self-update feature flag, trusted localhost guard, and successful-update restart token, and added focused restart coverage. No PR was created per instruction; gh shows no PR exists yet for the pushed branch.
## Changed Files
- scripts/self-update-restart.test.mjs
- src/app/api/self-update/restart/route.ts
- src/lib/taskix-service.ts
## Verification
- node --experimental-strip-types --test scripts/self-update-restart.test.mjs
- npm run typecheck
- npm test
- npm run build
- git diff --check
Closes #129