### PR TITLE
Implement self-update operator dialog and restart polling UX

### DIFF
--- a/scripts/header-version.test.mjs
+++ b/scripts/header-version.test.mjs
@@ -12,14 +12,14 @@ assert.match(
 
 assert.match(
   layoutSource,
-  /aria-label=\{`Taskix version \$\{packageJson\.version\}`\}/,
-  "Root layout should expose the package version in the header affordance label"
+  /<SelfUpdateDialog version=\{packageJson\.version\} \/>/,
+  "Root layout should wire the package version into the self-update dialog entry point"
 );
 
 assert.match(
   layoutSource,
-  /v\{packageJson\.version\}/,
-  "Root layout should render the package version without duplicating the version literal"
+  /version=\{packageJson\.version\}/,
+  "Root layout should pass the package version without duplicating the version literal"
 );
 
 assert.ok(packageJson.version, "package.json should define a version value");

--- a/scripts/self-update-api.test.mjs
+++ b/scripts/self-update-api.test.mjs
@@ -9,10 +9,13 @@ import {
   isSelfUpdateEnabled,
   isLocalhostRequest,
   hasTrustedCallerAddress,
+  mintSelfUpdateOperatorIntent,
   resetSelfUpdateStateForTests,
+  runOperatorSelfUpdate,
   runSelfUpdate,
   selfUpdateGuard,
-  setSelfUpdateCommandRunnerForTests
+  setSelfUpdateCommandRunnerForTests,
+  validateSelfUpdateOperatorIntent
 } from "../src/lib/self-update.ts";
 
 const originalFlag = process.env.TASKIX_ENABLE_SELF_UPDATE;
@@ -134,6 +137,67 @@ test("self-update state reports trusted caller validation availability", () => {
       trustedLocalhostCallerValidated: true
     }
   );
+});
+
+test("self-update state exposes operator submission and boot readiness markers", () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  const state = getSelfUpdateState(new NextRequest("http://127.0.0.1:8000/api/self-update"));
+
+  assert.equal(state.operatorSubmissionAvailable, true);
+  assert.equal(typeof state.operatorIntentToken, "string");
+  assert.equal(typeof state.bootId, "string");
+  assert.equal(typeof state.startedAt, "string");
+  assert.equal(state.restartStatus, "idle");
+});
+
+test("operator intent validation rejects missing stale and invalid tokens", () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  const firstIntent = mintSelfUpdateOperatorIntent();
+  const secondIntent = mintSelfUpdateOperatorIntent();
+
+  assert.ok(firstIntent);
+  assert.ok(secondIntent);
+  assert.equal(validateSelfUpdateOperatorIntent({ nonce: firstIntent.cookie.value, token: null }).ok, false);
+  assert.equal(validateSelfUpdateOperatorIntent({ nonce: firstIntent.cookie.value, token: "invalid" }).ok, false);
+  assert.equal(
+    validateSelfUpdateOperatorIntent({ nonce: secondIntent.cookie.value, token: firstIntent.token }).ok,
+    false
+  );
+  assert.equal(
+    validateSelfUpdateOperatorIntent({ nonce: firstIntent.cookie.value, token: firstIntent.token }).ok,
+    true
+  );
+});
+
+test("operator self-update flow requires a valid server-minted intent token", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+  const calls = [];
+  setSelfUpdateCommandRunnerForTests(async (command) => {
+    calls.push(command.command);
+    return { command: command.command, exitCode: 0, stdout: `${command.command} ok`, stderr: "" };
+  });
+
+  const missing = await runOperatorSelfUpdate({ nonce: null, token: null }, "/tmp/taskix-self-update-operator-test");
+  assert.equal(missing.status, 403);
+
+  const intent = mintSelfUpdateOperatorIntent();
+  assert.ok(intent);
+
+  const stale = await runOperatorSelfUpdate(
+    { nonce: "stale", token: intent.token },
+    "/tmp/taskix-self-update-operator-test"
+  );
+  assert.equal(stale.status, 403);
+
+  const accepted = await runOperatorSelfUpdate(
+    { nonce: intent.cookie.value, token: intent.token },
+    "/tmp/taskix-self-update-operator-test"
+  );
+
+  assert.equal(accepted.status, 200);
+  assert.deepEqual(calls, ["git pull", "npm install", "npm run build"]);
 });
 
 test("runtime loopback addresses prove localhost route callers", () => {

--- a/scripts/self-update-api.test.mjs
+++ b/scripts/self-update-api.test.mjs
@@ -11,6 +11,7 @@ import {
   hasTrustedCallerAddress,
   mintSelfUpdateOperatorIntent,
   resetSelfUpdateStateForTests,
+  runOperatorSelfUpdateAndRestart,
   runOperatorSelfUpdate,
   runSelfUpdate,
   selfUpdateGuard,
@@ -227,6 +228,82 @@ test("operator self-update flow requires a valid server-minted intent token", as
   );
   assert.equal(replay.status, 403);
   assert.deepEqual(calls, ["git pull", "npm install", "npm run build"]);
+});
+
+test("operator self-update flow requests restart through internal server integration", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  const calls = [];
+  let restartCalls = 0;
+  setSelfUpdateCommandRunnerForTests(async (command) => {
+    calls.push(command.command);
+    return { command: command.command, exitCode: 0, stdout: `${command.command} ok`, stderr: "" };
+  });
+  const restartTaskixService = async () => {
+    restartCalls += 1;
+    return {
+      ok: true,
+      manager: "systemctl",
+      serviceName: "taskix-next.service",
+      stdout: "restarted",
+      stderr: "",
+      error: null
+    };
+  };
+
+  const intent = mintSelfUpdateOperatorIntent();
+  assert.ok(intent);
+
+  const response = await runOperatorSelfUpdateAndRestart(
+    { nonce: intent.cookie.value, token: intent.token },
+    restartTaskixService,
+    "/tmp/taskix-self-update-operator-restart-test"
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.ok, true);
+  assert.equal(response.update?.ok, true);
+  assert.equal(response.restart?.restartRequested, true);
+  assert.deepEqual(calls, ["git pull", "npm install", "npm run build"]);
+  assert.equal(restartCalls, 1);
+  assert.equal(getSelfUpdateState().restartStatus, "requested");
+  assert.equal(getSelfUpdateState().restartAvailable, false);
+});
+
+test("operator self-update flow reports terminal restart failure distinctly", async () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+
+  setSelfUpdateCommandRunnerForTests(async (command) => {
+    return { command: command.command, exitCode: 0, stdout: `${command.command} ok`, stderr: "" };
+  });
+  const restartTaskixService = async () => {
+    return {
+      ok: false,
+      manager: "systemctl",
+      serviceName: "taskix-next.service",
+      stdout: "",
+      stderr: "restart failed",
+      error: "Taskix service restart failed."
+    };
+  };
+
+  const intent = mintSelfUpdateOperatorIntent();
+  assert.ok(intent);
+
+  const response = await runOperatorSelfUpdateAndRestart(
+    { nonce: intent.cookie.value, token: intent.token },
+    restartTaskixService,
+    "/tmp/taskix-self-update-operator-restart-failure-test"
+  );
+
+  assert.equal(response.status, 500);
+  assert.equal(response.ok, false);
+  assert.equal(response.update?.ok, true);
+  assert.equal(response.restart?.restartRequested, false);
+
+  const state = getSelfUpdateState();
+  assert.equal(state.restartStatus, "failed");
+  assert.match(state.restartError, /restart failed/i);
 });
 
 test("runtime loopback addresses prove localhost route callers", () => {

--- a/scripts/self-update-api.test.mjs
+++ b/scripts/self-update-api.test.mjs
@@ -15,6 +15,7 @@ import {
   runSelfUpdate,
   selfUpdateGuard,
   setSelfUpdateCommandRunnerForTests,
+  setSelfUpdateOperatorIntentClockForTests,
   validateSelfUpdateOperatorIntent
 } from "../src/lib/self-update.ts";
 
@@ -167,8 +168,29 @@ test("operator intent validation rejects missing stale and invalid tokens", () =
   );
   assert.equal(
     validateSelfUpdateOperatorIntent({ nonce: firstIntent.cookie.value, token: firstIntent.token }).ok,
+    false
+  );
+  assert.equal(
+    validateSelfUpdateOperatorIntent({ nonce: secondIntent.cookie.value, token: secondIntent.token }).ok,
     true
   );
+  assert.equal(
+    validateSelfUpdateOperatorIntent({ nonce: secondIntent.cookie.value, token: secondIntent.token }).ok,
+    false
+  );
+});
+
+test("operator intent validation rejects expired tokens", () => {
+  process.env.TASKIX_ENABLE_SELF_UPDATE = "true";
+  let now = 1_000;
+  setSelfUpdateOperatorIntentClockForTests(() => now);
+
+  const intent = mintSelfUpdateOperatorIntent();
+  assert.ok(intent);
+
+  now += intent.cookie.maxAge * 1000 + 1;
+
+  assert.equal(validateSelfUpdateOperatorIntent({ nonce: intent.cookie.value, token: intent.token }).ok, false);
 });
 
 test("operator self-update flow requires a valid server-minted intent token", async () => {
@@ -197,6 +219,13 @@ test("operator self-update flow requires a valid server-minted intent token", as
   );
 
   assert.equal(accepted.status, 200);
+  assert.deepEqual(calls, ["git pull", "npm install", "npm run build"]);
+
+  const replay = await runOperatorSelfUpdate(
+    { nonce: intent.cookie.value, token: intent.token },
+    "/tmp/taskix-self-update-operator-test"
+  );
+  assert.equal(replay.status, 403);
   assert.deepEqual(calls, ["git pull", "npm install", "npm run build"]);
 });
 

--- a/scripts/self-update-ui.test.mjs
+++ b/scripts/self-update-ui.test.mjs
@@ -18,15 +18,33 @@ test("self-update dialog disables duplicate submissions during running phases", 
   }
 });
 
-test("self-update dialog allows submission only when server integration is enabled", () => {
+test("self-update dialog allows submission only when server integration and operator submission are enabled", () => {
   assert.equal(deriveSelfUpdateDialogModel({ phase: "idle", status: enabledStatus() }).canSubmit, true);
   assert.equal(deriveSelfUpdateDialogModel({ phase: "idle", status: { ...enabledStatus(), enabled: false } }).canSubmit, false);
+  assert.equal(
+    deriveSelfUpdateDialogModel({ phase: "idle", status: { ...enabledStatus(), operatorSubmissionAvailable: false } }).canSubmit,
+    false
+  );
 });
 
-test("self-update polling stops on ready response", () => {
+test("self-update polling continues when status responds with the pre-restart boot marker", () => {
   const decision = deriveSelfUpdatePollDecision({
     responseOk: true,
     status: enabledStatus(),
+    initialBootId: "boot-before",
+    elapsedMs: 2_000,
+    timeoutMs: 60_000
+  });
+
+  assert.equal(decision.phase, "polling");
+  assert.equal(decision.shouldContinue, true);
+});
+
+test("self-update polling stops on a changed boot marker", () => {
+  const decision = deriveSelfUpdatePollDecision({
+    responseOk: true,
+    status: { ...enabledStatus(), bootId: "boot-after" },
+    initialBootId: "boot-before",
     elapsedMs: 2_000,
     timeoutMs: 60_000
   });
@@ -39,6 +57,7 @@ test("self-update polling continues through temporary unavailable responses", ()
   const decision = deriveSelfUpdatePollDecision({
     responseOk: false,
     status: null,
+    initialBootId: "boot-before",
     elapsedMs: 10_000,
     timeoutMs: 60_000
   });
@@ -51,6 +70,7 @@ test("self-update polling stops at bounded timeout", () => {
   const decision = deriveSelfUpdatePollDecision({
     responseOk: false,
     status: null,
+    initialBootId: "boot-before",
     elapsedMs: 60_000,
     timeoutMs: 60_000
   });
@@ -59,12 +79,32 @@ test("self-update polling stops at bounded timeout", () => {
   assert.equal(decision.shouldContinue, false);
 });
 
+test("self-update polling reports terminal restart failure distinctly", () => {
+  const decision = deriveSelfUpdatePollDecision({
+    responseOk: true,
+    status: { ...enabledStatus(), restartStatus: "failed", restartError: "restart failed" },
+    initialBootId: "boot-before",
+    elapsedMs: 2_000,
+    timeoutMs: 60_000
+  });
+
+  assert.equal(decision.phase, "failure");
+  assert.equal(decision.shouldContinue, false);
+  assert.match(decision.message, /restart failed/);
+});
+
 function enabledStatus() {
   return {
     enabled: true,
     restartAvailable: false,
     lastRun: null,
     trustedCallerAddressAvailable: true,
-    trustedLocalhostCallerValidated: true
+    trustedLocalhostCallerValidated: true,
+    operatorSubmissionAvailable: true,
+    operatorIntentToken: "intent-token",
+    bootId: "boot-before",
+    startedAt: "2026-05-02T00:00:00.000Z",
+    restartStatus: "idle",
+    restartError: null
   };
 }

--- a/scripts/self-update-ui.test.mjs
+++ b/scripts/self-update-ui.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  deriveSelfUpdateDialogModel,
+  deriveSelfUpdatePollDecision
+} from "../src/lib/self-update-ui.ts";
+
+test("self-update dialog disables duplicate submissions during running phases", () => {
+  for (const phase of ["loading", "updating", "restarting", "polling"]) {
+    const model = deriveSelfUpdateDialogModel({
+      phase,
+      status: enabledStatus()
+    });
+
+    assert.equal(model.actionDisabled, true);
+    assert.equal(model.canSubmit, false);
+  }
+});
+
+test("self-update dialog allows submission only when server integration is enabled", () => {
+  assert.equal(deriveSelfUpdateDialogModel({ phase: "idle", status: enabledStatus() }).canSubmit, true);
+  assert.equal(deriveSelfUpdateDialogModel({ phase: "idle", status: { ...enabledStatus(), enabled: false } }).canSubmit, false);
+});
+
+test("self-update polling stops on ready response", () => {
+  const decision = deriveSelfUpdatePollDecision({
+    responseOk: true,
+    status: enabledStatus(),
+    elapsedMs: 2_000,
+    timeoutMs: 60_000
+  });
+
+  assert.equal(decision.phase, "success");
+  assert.equal(decision.shouldContinue, false);
+});
+
+test("self-update polling continues through temporary unavailable responses", () => {
+  const decision = deriveSelfUpdatePollDecision({
+    responseOk: false,
+    status: null,
+    elapsedMs: 10_000,
+    timeoutMs: 60_000
+  });
+
+  assert.equal(decision.phase, "polling");
+  assert.equal(decision.shouldContinue, true);
+});
+
+test("self-update polling stops at bounded timeout", () => {
+  const decision = deriveSelfUpdatePollDecision({
+    responseOk: false,
+    status: null,
+    elapsedMs: 60_000,
+    timeoutMs: 60_000
+  });
+
+  assert.equal(decision.phase, "timeout");
+  assert.equal(decision.shouldContinue, false);
+});
+
+function enabledStatus() {
+  return {
+    enabled: true,
+    restartAvailable: false,
+    lastRun: null,
+    trustedCallerAddressAvailable: true,
+    trustedLocalhostCallerValidated: true
+  };
+}

--- a/src/app/api/operator/self-update/update/route.ts
+++ b/src/app/api/operator/self-update/update/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  runOperatorSelfUpdate,
+  selfUpdateOperatorNonceCookieName
+} from "@/lib/self-update";
+
+type OperatorUpdatePayload = {
+  operatorIntentToken?: string;
+};
+
+export async function POST(request: NextRequest) {
+  let payload: OperatorUpdatePayload = {};
+
+  try {
+    payload = (await request.json()) as OperatorUpdatePayload;
+  } catch {
+    payload = {};
+  }
+
+  const response = await runOperatorSelfUpdate({
+    nonce: request.cookies.get(selfUpdateOperatorNonceCookieName)?.value,
+    token: payload.operatorIntentToken
+  });
+
+  if (!response.ok || !response.result) {
+    return NextResponse.json({ error: response.error }, { status: response.status });
+  }
+
+  return NextResponse.json(response.result, { status: response.status });
+}

--- a/src/app/api/operator/self-update/update/route.ts
+++ b/src/app/api/operator/self-update/update/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
-  runOperatorSelfUpdate,
+  runOperatorSelfUpdateAndRestart,
   selfUpdateOperatorNonceCookieName
 } from "@/lib/self-update";
+import { restartTaskixService } from "@/lib/taskix-service";
 
 type OperatorUpdatePayload = {
   operatorIntentToken?: string;
@@ -17,14 +18,14 @@ export async function POST(request: NextRequest) {
     payload = {};
   }
 
-  const response = await runOperatorSelfUpdate({
+  const response = await runOperatorSelfUpdateAndRestart({
     nonce: request.cookies.get(selfUpdateOperatorNonceCookieName)?.value,
     token: payload.operatorIntentToken
-  });
+  }, restartTaskixService);
 
-  if (!response.ok || !response.result) {
-    return NextResponse.json({ error: response.error }, { status: response.status });
+  if (!response.ok || !response.update) {
+    return NextResponse.json({ error: response.error, restart: response.restart }, { status: response.status });
   }
 
-  return NextResponse.json(response.result, { status: response.status });
+  return NextResponse.json(response.update, { status: response.status });
 }

--- a/src/app/api/self-update/restart/route.ts
+++ b/src/app/api/self-update/restart/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { consumeRestartAvailability, selfUpdateGuard } from "@/lib/self-update";
+import {
+  consumeRestartAvailability,
+  markSelfUpdateRestartFailed,
+  markSelfUpdateRestartRequested,
+  selfUpdateGuard
+} from "@/lib/self-update";
 import { requestTaskixServiceRestart } from "@/lib/taskix-service";
 
 export async function POST(request: NextRequest) {
@@ -9,6 +14,7 @@ export async function POST(request: NextRequest) {
     consumeRestartAvailability
   });
   if (!result.ok) {
+    markSelfUpdateRestartFailed(result.error ?? "Taskix service restart failed.");
     return NextResponse.json(
       {
         ok: false,
@@ -23,6 +29,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  markSelfUpdateRestartRequested();
   return NextResponse.json({
     ok: true,
     restartRequested: true,

--- a/src/app/api/self-update/route.ts
+++ b/src/app/api/self-update/route.ts
@@ -1,6 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSelfUpdateState } from "@/lib/self-update";
+import { buildSelfUpdateState, mintSelfUpdateOperatorIntent } from "@/lib/self-update";
 
 export async function GET(request: NextRequest) {
-  return NextResponse.json(getSelfUpdateState(request));
+  const operatorIntent = mintSelfUpdateOperatorIntent();
+  const response = NextResponse.json(buildSelfUpdateState(request, operatorIntent));
+
+  if (operatorIntent) {
+    response.cookies.set(operatorIntent.cookie.name, operatorIntent.cookie.value, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: operatorIntent.cookie.maxAge
+    });
+  }
+
+  return response;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Badge, Code, Group, Text } from "@mantine/core";
 import { getSettings } from "@/lib/settings";
 import { listProjects, listWorkflows } from "@/lib/store";
 import { Providers } from "@/components/Providers";
+import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
 import { ShellLayout } from "@/components/ShellLayout";
 import packageJson from "../../package.json";
 import "@mantine/core/styles.css";
@@ -39,9 +40,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <Badge color="dark" variant="light">
                 Webhook <Code>{settings.appBaseUrl.replace(/\/$/, "")}/telegram/webhook</Code>
               </Badge>
-              <button className="topbar-version" type="button" aria-label={`Taskix version ${packageJson.version}`}>
-                v{packageJson.version}
-              </button>
+              <SelfUpdateDialog version={packageJson.version} />
             </Group>
           </header>
           <div className="shell">

--- a/src/components/SelfUpdateDialog.tsx
+++ b/src/components/SelfUpdateDialog.tsx
@@ -20,6 +20,7 @@ export function SelfUpdateDialog({ version }: { version: string }) {
   const [status, setStatus] = useState<SelfUpdateState | null>(null);
   const [error, setError] = useState("");
   const pollStartedAt = useRef(0);
+  const preRestartBootId = useRef<string | null>(null);
 
   const model = useMemo(() => deriveSelfUpdateDialogModel({ phase, status, error }), [phase, status, error]);
 
@@ -63,20 +64,22 @@ export function SelfUpdateDialog({ version }: { version: string }) {
         const decision = deriveSelfUpdatePollDecision({
           responseOk: true,
           status: nextStatus,
+          initialBootId: preRestartBootId.current,
           elapsedMs,
           timeoutMs: pollTimeoutMs
         });
-        setError(decision.phase === "timeout" ? decision.message : "");
+        setError(decision.phase === "timeout" || decision.phase === "failure" ? decision.message : "");
         setPhase(decision.phase);
       } catch {
         if (cancelled) return;
         const decision = deriveSelfUpdatePollDecision({
           responseOk: false,
           status: null,
+          initialBootId: preRestartBootId.current,
           elapsedMs,
           timeoutMs: pollTimeoutMs
         });
-        setError(decision.phase === "timeout" ? decision.message : "");
+        setError(decision.phase === "timeout" || decision.phase === "failure" ? decision.message : "");
         setPhase(decision.phase);
       }
     }
@@ -91,11 +94,17 @@ export function SelfUpdateDialog({ version }: { version: string }) {
     setError("");
     setPhase("updating");
     try {
-      const updateResult = await postJson<SelfUpdateRunResult>("/api/self-update/update");
+      const operatorIntentToken = status?.operatorIntentToken;
+      if (!operatorIntentToken) {
+        throw new Error("Operator self-update submission is not available for this UI session.");
+      }
+
+      const updateResult = await postJson<SelfUpdateRunResult>("/api/operator/self-update/update", { operatorIntentToken });
       setStatus((current) => current ? { ...current, lastRun: updateResult, restartAvailable: updateResult.restartAvailable } : current);
       if (!updateResult.ok) throw new Error(`Self-update failed at ${updateResult.failedCommand ?? "unknown command"}.`);
 
       setPhase("restarting");
+      preRestartBootId.current = status?.bootId ?? null;
       await postJson("/api/self-update/restart");
 
       pollStartedAt.current = Date.now();
@@ -138,7 +147,7 @@ export function SelfUpdateDialog({ version }: { version: string }) {
               Self-update API {status?.enabled ? "enabled" : "disabled"}; restart {status?.restartAvailable ? "available" : "not available"}.
             </Text>
             <Text size="sm" c="dimmed">
-              Trusted localhost validation {status?.trustedLocalhostCallerValidated ? "passed" : "not confirmed"}.
+              Operator submission {status?.operatorSubmissionAvailable ? "available" : "not available"}; boot marker {status?.bootId ?? "unknown"}.
             </Text>
           </Stack>
 
@@ -177,8 +186,12 @@ async function loadStatus() {
   return response.json() as Promise<SelfUpdateState>;
 }
 
-async function postJson<T = unknown>(url: string) {
-  const response = await fetch(url, { method: "POST" });
+async function postJson<T = unknown>(url: string, body?: unknown) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: body === undefined ? undefined : { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
   if (!response.ok) throw new Error(await readApiError(response));
   return response.json() as Promise<T>;
 }

--- a/src/components/SelfUpdateDialog.tsx
+++ b/src/components/SelfUpdateDialog.tsx
@@ -99,13 +99,10 @@ export function SelfUpdateDialog({ version }: { version: string }) {
         throw new Error("Operator self-update submission is not available for this UI session.");
       }
 
+      preRestartBootId.current = status?.bootId ?? null;
       const updateResult = await postJson<SelfUpdateRunResult>("/api/operator/self-update/update", { operatorIntentToken });
       setStatus((current) => current ? { ...current, lastRun: updateResult, restartAvailable: updateResult.restartAvailable } : current);
       if (!updateResult.ok) throw new Error(`Self-update failed at ${updateResult.failedCommand ?? "unknown command"}.`);
-
-      setPhase("restarting");
-      preRestartBootId.current = status?.bootId ?? null;
-      await postJson("/api/self-update/restart");
 
       pollStartedAt.current = Date.now();
       setPhase("polling");

--- a/src/components/SelfUpdateDialog.tsx
+++ b/src/components/SelfUpdateDialog.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { Alert, Badge, Button, Code, Group, Modal, Stack, Text } from "@mantine/core";
+import { RefreshCw, RotateCcw } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { SelfUpdateRunResult, SelfUpdateState } from "@/lib/self-update";
+import { deriveSelfUpdateDialogModel, deriveSelfUpdatePollDecision, type SelfUpdateDialogPhase } from "@/lib/self-update-ui";
+
+const pollIntervalMs = 2_000;
+const pollTimeoutMs = 60_000;
+
+type ApiFailure = {
+  error?: string;
+  stderr?: string;
+};
+
+export function SelfUpdateDialog({ version }: { version: string }) {
+  const [opened, setOpened] = useState(false);
+  const [phase, setPhase] = useState<SelfUpdateDialogPhase>("idle");
+  const [status, setStatus] = useState<SelfUpdateState | null>(null);
+  const [error, setError] = useState("");
+  const pollStartedAt = useRef(0);
+
+  const model = useMemo(() => deriveSelfUpdateDialogModel({ phase, status, error }), [phase, status, error]);
+
+  useEffect(() => {
+    if (!opened) return;
+
+    let cancelled = false;
+    setPhase("loading");
+    setError("");
+    void loadStatus().then((nextStatus) => {
+      if (cancelled) return;
+      setStatus(nextStatus);
+      setPhase("idle");
+    }).catch((caught: unknown) => {
+      if (cancelled) return;
+      setError(toErrorMessage(caught, "Unable to load self-update status."));
+      setPhase("failure");
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [opened]);
+
+  useEffect(() => {
+    if (phase !== "polling") return;
+
+    let cancelled = false;
+    const timer = window.setInterval(() => {
+      void pollStatus();
+    }, pollIntervalMs);
+
+    void pollStatus();
+
+    async function pollStatus() {
+      const elapsedMs = Date.now() - pollStartedAt.current;
+      try {
+        const nextStatus = await loadStatus();
+        if (cancelled) return;
+        setStatus(nextStatus);
+        const decision = deriveSelfUpdatePollDecision({
+          responseOk: true,
+          status: nextStatus,
+          elapsedMs,
+          timeoutMs: pollTimeoutMs
+        });
+        setError(decision.phase === "timeout" ? decision.message : "");
+        setPhase(decision.phase);
+      } catch {
+        if (cancelled) return;
+        const decision = deriveSelfUpdatePollDecision({
+          responseOk: false,
+          status: null,
+          elapsedMs,
+          timeoutMs: pollTimeoutMs
+        });
+        setError(decision.phase === "timeout" ? decision.message : "");
+        setPhase(decision.phase);
+      }
+    }
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [phase]);
+
+  async function startUpdate() {
+    setError("");
+    setPhase("updating");
+    try {
+      const updateResult = await postJson<SelfUpdateRunResult>("/api/self-update/update");
+      setStatus((current) => current ? { ...current, lastRun: updateResult, restartAvailable: updateResult.restartAvailable } : current);
+      if (!updateResult.ok) throw new Error(`Self-update failed at ${updateResult.failedCommand ?? "unknown command"}.`);
+
+      setPhase("restarting");
+      await postJson("/api/self-update/restart");
+
+      pollStartedAt.current = Date.now();
+      setPhase("polling");
+    } catch (caught) {
+      setError(toErrorMessage(caught, "Self-update failed."));
+      setPhase("failure");
+      try {
+        setStatus(await loadStatus());
+      } catch {
+        // Keep the original failure visible if status refresh also fails.
+      }
+    }
+  }
+
+  return (
+    <>
+      <button className="topbar-version" type="button" aria-label={`Taskix version ${version}. Open self-update dialog`} onClick={() => setOpened(true)}>
+        v{version}
+      </button>
+      <Modal opened={opened} onClose={() => setOpened(false)} title="Taskix self-update" centered size="lg">
+        <Stack gap="md">
+          <Group justify="space-between" align="flex-start" gap="sm">
+            <Stack gap={2}>
+              <Text fw={700}>Current version</Text>
+              <Code>v{version}</Code>
+            </Stack>
+            <Badge color={badgeColor(model.phase)} variant="light">
+              {model.phase}
+            </Badge>
+          </Group>
+
+          <Alert color={alertColor(model.phase)} title="Update status">
+            <Text size="sm">{model.message}</Text>
+          </Alert>
+
+          <Stack gap={4}>
+            <Text size="sm" fw={700}>Server integration</Text>
+            <Text size="sm" c="dimmed">
+              Self-update API {status?.enabled ? "enabled" : "disabled"}; restart {status?.restartAvailable ? "available" : "not available"}.
+            </Text>
+            <Text size="sm" c="dimmed">
+              Trusted localhost validation {status?.trustedLocalhostCallerValidated ? "passed" : "not confirmed"}.
+            </Text>
+          </Stack>
+
+          {status?.lastRun ? (
+            <Stack gap={4}>
+              <Text size="sm" fw={700}>Last run</Text>
+              <Text size="sm" c={status.lastRun.ok ? "green" : "red"}>
+                {status.lastRun.ok ? "Completed successfully" : `Failed at ${status.lastRun.failedCommand ?? "unknown command"}`}
+              </Text>
+            </Stack>
+          ) : null}
+
+          <Group justify="flex-end">
+            <Button type="button" variant="default" onClick={() => setOpened(false)}>
+              Close
+            </Button>
+            <Button
+              type="button"
+              leftSection={model.shouldPoll ? <RotateCcw size={16} /> : <RefreshCw size={16} />}
+              loading={model.actionDisabled}
+              disabled={!model.canSubmit}
+              onClick={startUpdate}
+            >
+              Update and restart
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  );
+}
+
+async function loadStatus() {
+  const response = await fetch("/api/self-update", { cache: "no-store" });
+  if (!response.ok) throw new Error(await readApiError(response));
+  return response.json() as Promise<SelfUpdateState>;
+}
+
+async function postJson<T = unknown>(url: string) {
+  const response = await fetch(url, { method: "POST" });
+  if (!response.ok) throw new Error(await readApiError(response));
+  return response.json() as Promise<T>;
+}
+
+async function readApiError(response: Response) {
+  try {
+    const body = (await response.json()) as ApiFailure;
+    return body.error || body.stderr || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}
+
+function toErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function badgeColor(phase: SelfUpdateDialogPhase) {
+  if (phase === "success") return "green";
+  if (phase === "failure" || phase === "timeout") return "red";
+  if (phase === "polling" || phase === "restarting" || phase === "updating") return "blue";
+  return "gray";
+}
+
+function alertColor(phase: SelfUpdateDialogPhase) {
+  if (phase === "success") return "green";
+  if (phase === "failure" || phase === "timeout") return "red";
+  return "blue";
+}

--- a/src/lib/self-update-ui.ts
+++ b/src/lib/self-update-ui.ts
@@ -1,0 +1,104 @@
+import type { SelfUpdateState } from "@/lib/self-update";
+
+export type SelfUpdateDialogPhase = "idle" | "loading" | "updating" | "restarting" | "polling" | "success" | "failure" | "timeout";
+
+export type SelfUpdateDialogModel = {
+  phase: SelfUpdateDialogPhase;
+  status: SelfUpdateState | null;
+  message: string;
+  actionDisabled: boolean;
+  canSubmit: boolean;
+  shouldPoll: boolean;
+};
+
+export type SelfUpdatePollInput = {
+  responseOk: boolean;
+  status: SelfUpdateState | null;
+  elapsedMs: number;
+  timeoutMs: number;
+};
+
+export type SelfUpdatePollDecision =
+  | {
+      phase: "polling";
+      shouldContinue: true;
+      message: string;
+    }
+  | {
+      phase: "success" | "timeout";
+      shouldContinue: false;
+      message: string;
+    };
+
+const runningPhases = new Set<SelfUpdateDialogPhase>(["loading", "updating", "restarting", "polling"]);
+
+export function deriveSelfUpdateDialogModel(input: {
+  phase: SelfUpdateDialogPhase;
+  status: SelfUpdateState | null;
+  error?: string;
+}): SelfUpdateDialogModel {
+  const actionDisabled = runningPhases.has(input.phase);
+  const enabled = input.status?.enabled ?? false;
+  const canSubmit = enabled && !actionDisabled;
+  const unavailableReason = enabled
+    ? ""
+    : "Self-update is disabled. Set TASKIX_ENABLE_SELF_UPDATE=true on the Taskix server to enable it.";
+
+  const message = input.error || phaseMessage(input.phase, input.status) || unavailableReason;
+
+  return {
+    phase: input.phase,
+    status: input.status,
+    message,
+    actionDisabled,
+    canSubmit,
+    shouldPoll: input.phase === "polling"
+  };
+}
+
+export function deriveSelfUpdatePollDecision(input: SelfUpdatePollInput): SelfUpdatePollDecision {
+  if (input.elapsedMs >= input.timeoutMs) {
+    return {
+      phase: "timeout",
+      shouldContinue: false,
+      message: "Restart polling timed out before Taskix reported ready."
+    };
+  }
+
+  if (input.responseOk && input.status) {
+    return {
+      phase: "success",
+      shouldContinue: false,
+      message: "Taskix is responding after the restart request."
+    };
+  }
+
+  return {
+    phase: "polling",
+    shouldContinue: true,
+    message: "Waiting for Taskix to respond after restart."
+  };
+}
+
+function phaseMessage(phase: SelfUpdateDialogPhase, status: SelfUpdateState | null) {
+  switch (phase) {
+    case "loading":
+      return "Checking self-update status.";
+    case "updating":
+      return "Running git pull, npm install, and production build.";
+    case "restarting":
+      return "Requesting Taskix service restart.";
+    case "polling":
+      return "Waiting for Taskix to respond after restart.";
+    case "success":
+      return "Taskix is responding after the restart request.";
+    case "failure":
+      return "Self-update failed.";
+    case "timeout":
+      return "Restart polling timed out before Taskix reported ready.";
+    case "idle":
+      if (status?.lastRun?.ok) return "Last self-update completed successfully. Restart is available until it is requested.";
+      if (status?.lastRun && !status.lastRun.ok) return `Last self-update failed at ${status.lastRun.failedCommand}.`;
+      return "Ready to check for updates and restart Taskix.";
+  }
+}

--- a/src/lib/self-update-ui.ts
+++ b/src/lib/self-update-ui.ts
@@ -14,6 +14,7 @@ export type SelfUpdateDialogModel = {
 export type SelfUpdatePollInput = {
   responseOk: boolean;
   status: SelfUpdateState | null;
+  initialBootId: string | null;
   elapsedMs: number;
   timeoutMs: number;
 };
@@ -25,7 +26,7 @@ export type SelfUpdatePollDecision =
       message: string;
     }
   | {
-      phase: "success" | "timeout";
+      phase: "success" | "failure" | "timeout";
       shouldContinue: false;
       message: string;
     };
@@ -39,12 +40,15 @@ export function deriveSelfUpdateDialogModel(input: {
 }): SelfUpdateDialogModel {
   const actionDisabled = runningPhases.has(input.phase);
   const enabled = input.status?.enabled ?? false;
-  const canSubmit = enabled && !actionDisabled;
-  const unavailableReason = enabled
-    ? ""
-    : "Self-update is disabled. Set TASKIX_ENABLE_SELF_UPDATE=true on the Taskix server to enable it.";
+  const operatorSubmissionAvailable = input.status?.operatorSubmissionAvailable ?? false;
+  const canSubmit = enabled && operatorSubmissionAvailable && !actionDisabled;
+  const unavailableReason = !enabled
+    ? "Self-update is disabled. Set TASKIX_ENABLE_SELF_UPDATE=true on the Taskix server to enable it."
+    : !operatorSubmissionAvailable
+      ? "Operator self-update submission is not available for this UI session."
+      : "";
 
-  const message = input.error || phaseMessage(input.phase, input.status) || unavailableReason;
+  const message = input.error || unavailableReason || phaseMessage(input.phase, input.status);
 
   return {
     phase: input.phase,
@@ -57,6 +61,14 @@ export function deriveSelfUpdateDialogModel(input: {
 }
 
 export function deriveSelfUpdatePollDecision(input: SelfUpdatePollInput): SelfUpdatePollDecision {
+  if (input.responseOk && input.status?.restartStatus === "failed") {
+    return {
+      phase: "failure",
+      shouldContinue: false,
+      message: input.status.restartError || "Taskix service restart failed."
+    };
+  }
+
   if (input.elapsedMs >= input.timeoutMs) {
     return {
       phase: "timeout",
@@ -65,18 +77,20 @@ export function deriveSelfUpdatePollDecision(input: SelfUpdatePollInput): SelfUp
     };
   }
 
-  if (input.responseOk && input.status) {
+  if (input.responseOk && input.status && input.initialBootId && input.status.bootId !== input.initialBootId) {
     return {
       phase: "success",
       shouldContinue: false,
-      message: "Taskix is responding after the restart request."
+      message: "Taskix reported a new boot marker after the restart request."
     };
   }
 
   return {
     phase: "polling",
     shouldContinue: true,
-    message: "Waiting for Taskix to respond after restart."
+    message: input.responseOk
+      ? "Waiting for Taskix to finish restarting."
+      : "Waiting for Taskix to respond after restart."
   };
 }
 
@@ -89,11 +103,11 @@ function phaseMessage(phase: SelfUpdateDialogPhase, status: SelfUpdateState | nu
     case "restarting":
       return "Requesting Taskix service restart.";
     case "polling":
-      return "Waiting for Taskix to respond after restart.";
+      return "Waiting for Taskix to finish restarting.";
     case "success":
-      return "Taskix is responding after the restart request.";
+      return "Taskix reported a new boot marker after the restart request.";
     case "failure":
-      return "Self-update failed.";
+      return status?.restartError || "Self-update failed.";
     case "timeout":
       return "Restart polling timed out before Taskix reported ready.";
     case "idle":

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -38,6 +38,20 @@ export type SelfUpdateState = {
   restartError: string | null;
 };
 
+export type SelfUpdateServiceRestartResult = {
+  ok: boolean;
+  manager: string | null;
+  serviceName: string | null;
+  stdout: string;
+  stderr: string;
+  error: string | null;
+};
+
+export type SelfUpdateServiceRestartResponse = SelfUpdateServiceRestartResult & {
+  status: number;
+  restartRequested: boolean;
+};
+
 type CommandRunner = (command: SelfUpdateCommand, cwd: string) => Promise<SelfUpdateCommandResult>;
 type RequestSource =
   | Headers
@@ -199,6 +213,62 @@ export async function runOperatorSelfUpdate(input: { nonce?: string | null; toke
     status: result.ok ? 200 : 500,
     error: result.ok ? null : `Self-update failed at ${result.failedCommand ?? "unknown command"}.`,
     result
+  };
+}
+
+export async function runOperatorSelfUpdateAndRestart(
+  input: { nonce?: string | null; token?: string | null },
+  restartTaskixService: () => Promise<SelfUpdateServiceRestartResult>,
+  cwd = process.cwd()
+) {
+  const update = await runOperatorSelfUpdate(input, cwd);
+  if (!update.ok || !update.result) {
+    return {
+      ok: false as const,
+      status: update.status,
+      error: update.error,
+      update: update.result,
+      restart: null
+    };
+  }
+
+  if (!consumeRestartAvailability()) {
+    const error = "Restart is not available until self-update completes successfully.";
+    markSelfUpdateRestartFailed(error);
+    return {
+      ok: false as const,
+      status: 409,
+      error,
+      update: update.result,
+      restart: null
+    };
+  }
+
+  const restartResult = await restartTaskixService();
+  const restart: SelfUpdateServiceRestartResponse = {
+    ...restartResult,
+    status: restartResult.ok ? 200 : restartResult.manager ? 500 : 503,
+    restartRequested: restartResult.ok
+  };
+
+  if (!restart.ok) {
+    markSelfUpdateRestartFailed(restart.error ?? "Taskix service restart failed.");
+    return {
+      ok: false as const,
+      status: restart.status,
+      error: restart.error ?? "Taskix service restart failed.",
+      update: update.result,
+      restart
+    };
+  }
+
+  markSelfUpdateRestartRequested();
+  return {
+    ok: true as const,
+    status: 200,
+    error: null,
+    update: update.result,
+    restart
   };
 }
 

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -29,6 +30,12 @@ export type SelfUpdateState = {
   lastRun: SelfUpdateRunResult | null;
   trustedCallerAddressAvailable: boolean;
   trustedLocalhostCallerValidated: boolean;
+  operatorSubmissionAvailable: boolean;
+  operatorIntentToken: string | null;
+  bootId: string;
+  startedAt: string;
+  restartStatus: "idle" | "requested" | "failed";
+  restartError: string | null;
 };
 
 type CommandRunner = (command: SelfUpdateCommand, cwd: string) => Promise<SelfUpdateCommandResult>;
@@ -50,9 +57,17 @@ const updateCommands: SelfUpdateCommand[] = [
   { command: "npm run build", bin: "npm", args: ["run", "build"] }
 ];
 
+export const selfUpdateOperatorNonceCookieName = "taskix_self_update_operator_nonce";
+
 let restartAvailable = false;
 let lastRun: SelfUpdateRunResult | null = null;
 let commandRunner: CommandRunner = runCommand;
+let restartStatus: SelfUpdateState["restartStatus"] = "idle";
+let restartError: string | null = null;
+
+const bootId = randomUUID();
+const startedAt = new Date().toISOString();
+const operatorIntentSecret = randomBytes(32).toString("hex");
 
 export function isSelfUpdateEnabled(env: NodeJS.ProcessEnv = process.env) {
   return env.TASKIX_ENABLE_SELF_UPDATE === "true";
@@ -82,12 +97,25 @@ export function hasTrustedCallerAddress(source: RequestSource) {
 }
 
 export function getSelfUpdateState(source?: RequestSource): SelfUpdateState {
+  return buildSelfUpdateState(source, mintSelfUpdateOperatorIntent());
+}
+
+export function buildSelfUpdateState(
+  source: RequestSource | undefined,
+  operatorIntent: ReturnType<typeof mintSelfUpdateOperatorIntent>
+): SelfUpdateState {
   return {
     enabled: isSelfUpdateEnabled(),
     restartAvailable,
     lastRun,
     trustedCallerAddressAvailable: source ? hasTrustedCallerAddress(source) : false,
-    trustedLocalhostCallerValidated: source ? isLocalhostRequest(source) : false
+    trustedLocalhostCallerValidated: source ? isLocalhostRequest(source) : false,
+    operatorSubmissionAvailable: operatorIntent !== null,
+    operatorIntentToken: operatorIntent?.token ?? null,
+    bootId,
+    startedAt,
+    restartStatus,
+    restartError
   };
 }
 
@@ -123,6 +151,8 @@ function getTrustedCallerAddress(source: RequestSource) {
 export async function runSelfUpdate(cwd = process.cwd()): Promise<SelfUpdateRunResult> {
   const results: SelfUpdateCommandResult[] = [];
   restartAvailable = false;
+  restartStatus = "idle";
+  restartError = null;
 
   for (const command of updateCommands) {
     const result = await commandRunner(command, cwd);
@@ -149,6 +179,26 @@ export async function runSelfUpdate(cwd = process.cwd()): Promise<SelfUpdateRunR
   return lastRun;
 }
 
+export async function runOperatorSelfUpdate(input: { nonce?: string | null; token?: string | null }, cwd = process.cwd()) {
+  const guard = validateSelfUpdateOperatorIntent(input);
+  if (!guard.ok) {
+    return {
+      ok: false as const,
+      status: guard.status,
+      error: guard.error,
+      result: null
+    };
+  }
+
+  const result = await runSelfUpdate(cwd);
+  return {
+    ok: result.ok,
+    status: result.ok ? 200 : 500,
+    error: result.ok ? null : `Self-update failed at ${result.failedCommand ?? "unknown command"}.`,
+    result
+  };
+}
+
 export function getSelfUpdateCommands() {
   return updateCommands.map(({ command }) => command);
 }
@@ -162,6 +212,60 @@ export function consumeRestartAvailability() {
   return true;
 }
 
+export function mintSelfUpdateOperatorIntent() {
+  if (!isSelfUpdateEnabled()) {
+    return null;
+  }
+
+  const nonce = randomBytes(32).toString("base64url");
+  return {
+    token: signOperatorIntentNonce(nonce),
+    cookie: {
+      name: selfUpdateOperatorNonceCookieName,
+      value: nonce,
+      maxAge: 5 * 60
+    }
+  };
+}
+
+export function validateSelfUpdateOperatorIntent(input: { nonce?: string | null; token?: string | null }) {
+  if (!isSelfUpdateEnabled()) {
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update is disabled. Set TASKIX_ENABLE_SELF_UPDATE=true to enable it."
+    };
+  }
+
+  if (!input.nonce || !input.token) {
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update operator intent token is required."
+    };
+  }
+
+  if (!constantTimeEqual(input.token, signOperatorIntentNonce(input.nonce))) {
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update operator intent token is invalid or expired."
+    };
+  }
+
+  return { ok: true as const };
+}
+
+export function markSelfUpdateRestartRequested() {
+  restartStatus = "requested";
+  restartError = null;
+}
+
+export function markSelfUpdateRestartFailed(error: string) {
+  restartStatus = "failed";
+  restartError = error;
+}
+
 export function setSelfUpdateCommandRunnerForTests(runner: CommandRunner) {
   commandRunner = runner;
 }
@@ -170,6 +274,8 @@ export function resetSelfUpdateStateForTests() {
   restartAvailable = false;
   lastRun = null;
   commandRunner = runCommand;
+  restartStatus = "idle";
+  restartError = null;
 }
 
 async function runCommand(command: SelfUpdateCommand, cwd: string): Promise<SelfUpdateCommandResult> {
@@ -208,4 +314,14 @@ function stringifyOutput(value: string | Buffer | undefined) {
   }
 
   return Buffer.isBuffer(value) ? value.toString("utf8") : value;
+}
+
+function signOperatorIntentNonce(nonce: string) {
+  return createHmac("sha256", operatorIntentSecret).update(nonce).digest("base64url");
+}
+
+function constantTimeEqual(actual: string, expected: string) {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
 }

--- a/src/lib/self-update.ts
+++ b/src/lib/self-update.ts
@@ -64,10 +64,13 @@ let lastRun: SelfUpdateRunResult | null = null;
 let commandRunner: CommandRunner = runCommand;
 let restartStatus: SelfUpdateState["restartStatus"] = "idle";
 let restartError: string | null = null;
+let activeOperatorIntent: { nonce: string; expiresAt: number } | null = null;
+let operatorIntentNow = () => Date.now();
 
 const bootId = randomUUID();
 const startedAt = new Date().toISOString();
 const operatorIntentSecret = randomBytes(32).toString("hex");
+const operatorIntentMaxAgeSeconds = 5 * 60;
 
 export function isSelfUpdateEnabled(env: NodeJS.ProcessEnv = process.env) {
   return env.TASKIX_ENABLE_SELF_UPDATE === "true";
@@ -214,16 +217,22 @@ export function consumeRestartAvailability() {
 
 export function mintSelfUpdateOperatorIntent() {
   if (!isSelfUpdateEnabled()) {
+    activeOperatorIntent = null;
     return null;
   }
 
   const nonce = randomBytes(32).toString("base64url");
+  activeOperatorIntent = {
+    nonce,
+    expiresAt: operatorIntentNow() + operatorIntentMaxAgeSeconds * 1000
+  };
+
   return {
     token: signOperatorIntentNonce(nonce),
     cookie: {
       name: selfUpdateOperatorNonceCookieName,
       value: nonce,
-      maxAge: 5 * 60
+      maxAge: operatorIntentMaxAgeSeconds
     }
   };
 }
@@ -245,6 +254,31 @@ export function validateSelfUpdateOperatorIntent(input: { nonce?: string | null;
     };
   }
 
+  if (!activeOperatorIntent) {
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update operator intent token is invalid or expired."
+    };
+  }
+
+  if (operatorIntentNow() > activeOperatorIntent.expiresAt) {
+    activeOperatorIntent = null;
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update operator intent token is invalid or expired."
+    };
+  }
+
+  if (input.nonce !== activeOperatorIntent.nonce) {
+    return {
+      ok: false as const,
+      status: 403,
+      error: "Self-update operator intent token is invalid or expired."
+    };
+  }
+
   if (!constantTimeEqual(input.token, signOperatorIntentNonce(input.nonce))) {
     return {
       ok: false as const,
@@ -253,6 +287,7 @@ export function validateSelfUpdateOperatorIntent(input: { nonce?: string | null;
     };
   }
 
+  activeOperatorIntent = null;
   return { ok: true as const };
 }
 
@@ -270,12 +305,18 @@ export function setSelfUpdateCommandRunnerForTests(runner: CommandRunner) {
   commandRunner = runner;
 }
 
+export function setSelfUpdateOperatorIntentClockForTests(now: () => number) {
+  operatorIntentNow = now;
+}
+
 export function resetSelfUpdateStateForTests() {
   restartAvailable = false;
   lastRun = null;
   commandRunner = runCommand;
   restartStatus = "idle";
   restartError = null;
+  activeOperatorIntent = null;
+  operatorIntentNow = () => Date.now();
 }
 
 async function runCommand(command: SelfUpdateCommand, cwd: string): Promise<SelfUpdateCommandResult> {


### PR DESCRIPTION
Taskix workflow: WF-20260502-003
Issue: #131

## Summary
Implements the operator-facing self-update dialog from the existing top-right version label, wiring update/restart actions to the self-update APIs with deterministic UI state handling and focused tests.

## Verification
- npm run typecheck
- npm test
- npm run build

Closes #131