### PR TITLE
Add first-run admin account and session authentication

### DIFF
--- a/scripts/admin-auth.test.mjs
+++ b/scripts/admin-auth.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import process from "node:process";
+import { describe, it } from "node:test";
+
+process.chdir(mkdtempSync(`${tmpdir()}/taskix-admin-auth-`));
+
+const { setupInitialAdminWithStore, authenticateAdminWithStore } = await import("../src/lib/admin-auth.ts");
+const { createAdminSessionWithStore, verifyAdminSessionTokenWithStore } = await import("../src/lib/session-auth.ts");
+
+describe("admin auth", () => {
+  it("allows one first-run setup for the fixed admin account and stores only a hash", async () => {
+    const store = createStore();
+    const setup = await setupInitialAdminWithStore("correct horse battery staple", store);
+
+    assert.deepEqual(setup, { ok: true, username: "admin" });
+    const account = await store.getAdminAccount();
+    assert.equal(account?.username, "admin");
+    assert.match(account?.passwordHash ?? "", /^scrypt:/);
+    assert.doesNotMatch(JSON.stringify(account), /correct horse battery staple/);
+  });
+
+  it("rejects setup after initialization without replacing the account hash", async () => {
+    const store = createStore();
+    await setupInitialAdminWithStore("correct horse battery staple", store);
+    const before = await store.getAdminAccount();
+    const setup = await setupInitialAdminWithStore("replacement-password", store);
+    const emptySetup = await setupInitialAdminWithStore("", store);
+    const after = await store.getAdminAccount();
+
+    assert.deepEqual(setup, { ok: false, reason: "already_initialized" });
+    assert.deepEqual(emptySetup, { ok: false, reason: "already_initialized" });
+    assert.equal(after?.passwordHash, before?.passwordHash);
+  });
+
+  it("authenticates initialized admin and rejects bad credentials", async () => {
+    const store = createStore();
+    await setupInitialAdminWithStore("correct horse battery staple", store);
+
+    assert.deepEqual(await authenticateAdminWithStore("admin", "correct horse battery staple", store), { ok: true, username: "admin" });
+    assert.deepEqual(await authenticateAdminWithStore("admin", "wrong", store), { ok: false, reason: "invalid_credentials" });
+    assert.deepEqual(await authenticateAdminWithStore("not-admin", "correct horse battery staple", store), { ok: false, reason: "invalid_credentials" });
+  });
+
+  it("creates a server-verifiable admin session and clears it from storage", async () => {
+    const store = createStore();
+    const token = await createAdminSessionWithStore(store);
+
+    assert.deepEqual(await verifyAdminSessionTokenWithStore(token, store), { authenticated: true, username: "admin" });
+    assert.deepEqual(await verifyAdminSessionTokenWithStore("invalid", store), { authenticated: false });
+
+    await store.deleteAdminSession();
+    assert.deepEqual(await verifyAdminSessionTokenWithStore(token, store), { authenticated: false });
+  });
+});
+
+function createStore() {
+  return {
+    account: null,
+    session: null,
+    async getAdminAccount() {
+      return this.account;
+    },
+    async saveInitialAdminAccount(account) {
+      if (this.account) return false;
+      this.account = account;
+      return true;
+    },
+    async getAdminSession() {
+      return this.session;
+    },
+    async saveAdminSession(session) {
+      this.session = session;
+    },
+    async deleteAdminSession() {
+      this.session = null;
+    }
+  };
+}

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { authenticateAdmin } from "@/lib/admin-auth";
+import { createAdminSession, setAdminSessionCookie } from "@/lib/session-auth";
+
+export async function POST(request: Request) {
+  const body = await readRequestBody(request);
+  const username = String(body.username ?? "").trim();
+  const password = String(body.password ?? "");
+  const result = await authenticateAdmin(username, password);
+
+  if (!result.ok && result.reason === "not_initialized") {
+    return NextResponse.json({ ok: false, error: "Admin setup has not been completed." }, { status: 409 });
+  }
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, error: "Invalid username or password." }, { status: 401 });
+  }
+
+  const token = await createAdminSession();
+  await setAdminSessionCookie(token);
+  return NextResponse.json({ ok: true, username: result.username });
+}
+
+async function readRequestBody(request: Request): Promise<Record<string, FormDataEntryValue | unknown>> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return await request.json() as Record<string, unknown>;
+  }
+  const form = await request.formData();
+  return Object.fromEntries(form.entries());
+}

--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { clearAdminSession } from "@/lib/session-auth";
+
+export async function POST() {
+  await clearAdminSession();
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/session/route.ts
+++ b/src/app/api/admin/session/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getAdminSessionFromCookies } from "@/lib/session-auth";
+
+export async function GET() {
+  const session = await getAdminSessionFromCookies();
+  if (!session.authenticated) {
+    return NextResponse.json({ authenticated: false }, { status: 401 });
+  }
+  return NextResponse.json({ authenticated: true, username: session.username });
+}

--- a/src/app/api/admin/setup/route.ts
+++ b/src/app/api/admin/setup/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { isAdminInitialized, setupInitialAdmin } from "@/lib/admin-auth";
+
+export async function GET() {
+  const initialized = await isAdminInitialized();
+  return NextResponse.json({ initialized, setupAvailable: !initialized });
+}
+
+export async function POST(request: Request) {
+  const body = await readRequestBody(request);
+  const username = String(body.username ?? "admin").trim();
+  const password = String(body.password ?? "");
+
+  if (username !== "admin") {
+    return NextResponse.json({ ok: false, error: "Setup only supports the fixed admin account." }, { status: 400 });
+  }
+
+  const result = await setupInitialAdmin(password);
+  if (!result.ok && result.reason === "already_initialized") {
+    return NextResponse.json({ ok: false, error: "Admin setup has already been completed." }, { status: 409 });
+  }
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, error: "Password is required." }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true, username: result.username }, { status: 201 });
+}
+
+async function readRequestBody(request: Request): Promise<Record<string, FormDataEntryValue | unknown>> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return await request.json() as Record<string, unknown>;
+  }
+  const form = await request.formData();
+  return Object.fromEntries(form.entries());
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,85 @@
+import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+import type { AdminAccountRecord } from "@/lib/store";
+
+const scrypt = promisify(scryptCallback);
+const adminUsername = "admin";
+const passwordSaltBytes = 16;
+const passwordKeyBytes = 64;
+
+export type AdminSetupResult =
+  | { ok: true; username: "admin" }
+  | { ok: false; reason: "already_initialized" | "invalid_password" };
+
+export type AdminLoginResult =
+  | { ok: true; username: "admin" }
+  | { ok: false; reason: "not_initialized" | "invalid_credentials" };
+
+export type AdminAccountStore = {
+  getAdminAccount(): Promise<AdminAccountRecord | null>;
+  saveInitialAdminAccount(account: AdminAccountRecord): Promise<boolean>;
+};
+
+export async function isAdminInitialized(): Promise<boolean> {
+  const store = await getAdminAccountStore();
+  return isAdminInitializedWithStore(store);
+}
+
+export async function setupInitialAdmin(password: string): Promise<AdminSetupResult> {
+  const store = await getAdminAccountStore();
+  return setupInitialAdminWithStore(password, store);
+}
+
+export async function authenticateAdmin(username: string, password: string): Promise<AdminLoginResult> {
+  const store = await getAdminAccountStore();
+  return authenticateAdminWithStore(username, password, store);
+}
+
+export async function isAdminInitializedWithStore(store: Pick<AdminAccountStore, "getAdminAccount">): Promise<boolean> {
+  return (await store.getAdminAccount()) !== null;
+}
+
+export async function setupInitialAdminWithStore(password: string, store: AdminAccountStore): Promise<AdminSetupResult> {
+  if (await store.getAdminAccount()) return { ok: false, reason: "already_initialized" };
+  if (!password.trim()) return { ok: false, reason: "invalid_password" };
+
+  const passwordHash = await hashPassword(password);
+  const saved = await store.saveInitialAdminAccount({
+    username: adminUsername,
+    passwordHash,
+    initializedAt: new Date().toISOString()
+  });
+
+  return saved ? { ok: true, username: adminUsername } : { ok: false, reason: "already_initialized" };
+}
+
+export async function authenticateAdminWithStore(username: string, password: string, store: Pick<AdminAccountStore, "getAdminAccount">): Promise<AdminLoginResult> {
+  const account = await store.getAdminAccount();
+  if (!account) return { ok: false, reason: "not_initialized" };
+  if (username !== adminUsername) return { ok: false, reason: "invalid_credentials" };
+  const passwordMatches = await verifyPassword(password, account.passwordHash);
+  return passwordMatches ? { ok: true, username: adminUsername } : { ok: false, reason: "invalid_credentials" };
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(passwordSaltBytes);
+  const derivedKey = await scrypt(password, salt, passwordKeyBytes) as Buffer;
+  return `scrypt:${salt.toString("base64")}:${derivedKey.toString("base64")}`;
+}
+
+export async function verifyPassword(password: string, passwordHash: string): Promise<boolean> {
+  const [algorithm, saltValue, hashValue] = passwordHash.split(":");
+  if (algorithm !== "scrypt" || !saltValue || !hashValue) return false;
+
+  const expectedKey = Buffer.from(hashValue, "base64");
+  const actualKey = await scrypt(password, Buffer.from(saltValue, "base64"), expectedKey.length) as Buffer;
+  return expectedKey.length === actualKey.length && timingSafeEqual(expectedKey, actualKey);
+}
+
+async function getAdminAccountStore(): Promise<AdminAccountStore> {
+  const store = await import("@/lib/store");
+  return {
+    getAdminAccount: store.getAdminAccount,
+    saveInitialAdminAccount: store.saveInitialAdminAccount
+  };
+}

--- a/src/lib/session-auth.ts
+++ b/src/lib/session-auth.ts
@@ -1,0 +1,104 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { AdminSessionRecord } from "@/lib/store";
+
+export const adminSessionCookieName = "taskix_admin_session";
+
+const sessionTokenBytes = 32;
+const sessionDurationMs = 7 * 24 * 60 * 60 * 1000;
+
+export type AdminSessionVerification =
+  | { authenticated: true; username: "admin" }
+  | { authenticated: false };
+
+export type AdminSessionStore = {
+  getAdminSession(): Promise<AdminSessionRecord | null>;
+  saveAdminSession(session: AdminSessionRecord): Promise<void>;
+  deleteAdminSession(): Promise<void>;
+};
+
+export async function createAdminSession(): Promise<string> {
+  const store = await getAdminSessionStore();
+  return createAdminSessionWithStore(store);
+}
+
+export async function createAdminSessionWithStore(store: Pick<AdminSessionStore, "saveAdminSession">): Promise<string> {
+  const token = randomBytes(sessionTokenBytes).toString("base64url");
+  const now = Date.now();
+  await store.saveAdminSession({
+    username: "admin",
+    tokenHash: hashSessionToken(token),
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + sessionDurationMs).toISOString()
+  });
+  return token;
+}
+
+export async function verifyAdminSessionToken(token: string | null | undefined): Promise<AdminSessionVerification> {
+  const store = await getAdminSessionStore();
+  return verifyAdminSessionTokenWithStore(token, store);
+}
+
+export async function verifyAdminSessionTokenWithStore(token: string | null | undefined, store: Pick<AdminSessionStore, "getAdminSession" | "deleteAdminSession">): Promise<AdminSessionVerification> {
+  if (!token) return { authenticated: false };
+
+  const session = await store.getAdminSession();
+  if (!session || new Date(session.expiresAt).getTime() <= Date.now()) {
+    if (session) await store.deleteAdminSession();
+    return { authenticated: false };
+  }
+
+  const expected = Buffer.from(session.tokenHash, "hex");
+  const actual = Buffer.from(hashSessionToken(token), "hex");
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    return { authenticated: false };
+  }
+
+  return { authenticated: true, username: session.username };
+}
+
+export async function getAdminSessionFromCookies(): Promise<AdminSessionVerification> {
+  const cookieStore = await getCookieStore();
+  return verifyAdminSessionToken(cookieStore.get(adminSessionCookieName)?.value);
+}
+
+export async function setAdminSessionCookie(token: string): Promise<void> {
+  const cookieStore = await getCookieStore();
+  cookieStore.set(adminSessionCookieName, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: Math.floor(sessionDurationMs / 1000)
+  });
+}
+
+export async function clearAdminSession(): Promise<void> {
+  const store = await getAdminSessionStore();
+  await store.deleteAdminSession();
+  const cookieStore = await getCookieStore();
+  cookieStore.set(adminSessionCookieName, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0
+  });
+}
+
+function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+async function getAdminSessionStore(): Promise<AdminSessionStore> {
+  const store = await import("@/lib/store");
+  return {
+    getAdminSession: store.getAdminSession,
+    saveAdminSession: store.saveAdminSession,
+    deleteAdminSession: store.deleteAdminSession
+  };
+}
+
+async function getCookieStore() {
+  const headers = await import("next/headers");
+  return headers.cookies();
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,6 +6,49 @@ import type { AgentSessionRecord, JobRecord, JobType, ProjectRecord, Role, Workf
 
 const RUNNING_JOB_TIMEOUT_MS = 15 * 60 * 1000;
 
+export type AdminAccountRecord = {
+  username: "admin";
+  passwordHash: string;
+  initializedAt: string;
+};
+
+export type AdminSessionRecord = {
+  username: "admin";
+  tokenHash: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
+const adminAccountKey = "admin_account";
+const adminSessionKey = "admin_session";
+
+export async function getAdminAccount(): Promise<AdminAccountRecord | null> {
+  const row = getDb().prepare("SELECT value FROM kv WHERE key = ?").get(adminAccountKey) as { value: string } | undefined;
+  return row ? (JSON.parse(row.value) as AdminAccountRecord) : null;
+}
+
+export async function saveInitialAdminAccount(account: AdminAccountRecord): Promise<boolean> {
+  const result = getDb()
+    .prepare("INSERT OR IGNORE INTO kv (key, value) VALUES (?, ?)")
+    .run(adminAccountKey, JSON.stringify(account)) as { changes: number };
+  return result.changes === 1;
+}
+
+export async function getAdminSession(): Promise<AdminSessionRecord | null> {
+  const row = getDb().prepare("SELECT value FROM kv WHERE key = ?").get(adminSessionKey) as { value: string } | undefined;
+  return row ? (JSON.parse(row.value) as AdminSessionRecord) : null;
+}
+
+export async function saveAdminSession(session: AdminSessionRecord): Promise<void> {
+  getDb()
+    .prepare("INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+    .run(adminSessionKey, JSON.stringify(session));
+}
+
+export async function deleteAdminSession(): Promise<void> {
+  getDb().prepare("DELETE FROM kv WHERE key = ?").run(adminSessionKey);
+}
+
 export async function listProjects(): Promise<ProjectRecord[]> {
   const rows = getDb().prepare("SELECT payload FROM projects ORDER BY created_at ASC").all() as { payload: string }[];
   return rows.map((row) => normalizeProject(JSON.parse(row.payload) as ProjectRecord));


### PR DESCRIPTION
Taskix workflow: WF-20260502-004
Issue: #136
## Summary
Implemented issue #136 on branch taskix/WF-20260502-004-issue-136 and pushed commit 4b7e76b5a24672f724010b0940a09effda7b850b. Added fixed first-run admin setup, scrypt password hashing, login/logout/session API routes, server-verifiable session storage, and focused auth/session tests. No PR was created because the instructions explicitly said not to run gh pr create; the branch is ready for the Taskix server to open the PR.
## Changed Files
- src/lib/admin-auth.ts
- src/lib/session-auth.ts
- src/lib/store.ts
- src/app/api/admin/setup/route.ts
- src/app/api/admin/login/route.ts
- src/app/api/admin/logout/route.ts
- src/app/api/admin/session/route.ts
- scripts/admin-auth.test.mjs
## Verification
- node --experimental-strip-types --test scripts/admin-auth.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #136