### PR TITLE
Redesign console header layout for compact desktop and mobile heights

### DIFF
--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -5,8 +5,8 @@ const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta
 
 assert.match(
   layoutSource,
-  /<Text[^>]*>\s*Gitdex Management\s*<\/Text>/,
-  "Root layout header should visibly render Gitdex Management"
+  /<Text[^>]*className="topbar-title"[^>]*>\s*Gitdex\s*<\/Text>/,
+  "Root layout header should visibly render the Gitdex brand name"
 );
 
 console.log("header label verification passed");

--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -2,11 +2,36 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+const globalStyles = await readFile(new URL("../src/app/globals.css", import.meta.url), "utf8");
 
 assert.match(
   layoutSource,
   /<Text[^>]*className="topbar-title"[^>]*>\s*Gitdex\s*<\/Text>/,
   "Root layout header should visibly render the Gitdex brand name"
+);
+
+assert.match(
+  layoutSource,
+  /<Group[^>]*className="topbar-actions"[^>]*justify="flex-start"[^>]*wrap="nowrap"/,
+  "Header actions should start-align inside the horizontal scroll region so overflow remains reachable"
+);
+
+assert.match(
+  globalStyles,
+  /\.topbar-actions\s*\{[^}]*min-width:\s*0;[^}]*overflow-x:\s*auto;/s,
+  "Header actions should be allowed to shrink and scroll horizontally"
+);
+
+assert.match(
+  globalStyles,
+  /\.topbar-actions \.mantine-Badge-root\s*\{[^}]*flex:\s*0 0 auto;[^}]*max-width:\s*none;/s,
+  "Header badges should keep their full width in the scrollable action row"
+);
+
+assert.match(
+  globalStyles,
+  /\.topbar-actions \.mantine-Badge-label\s*\{[^}]*overflow:\s*visible;[^}]*text-overflow:\s*clip;/s,
+  "Header badge labels should not ellipsize important control text"
 );
 
 console.log("header label verification passed");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,29 +49,55 @@ pre,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 18px;
-  min-height: 64px;
-  padding: 0 28px;
+  gap: 14px;
+  min-height: 52px;
+  padding: 8px 28px;
   color: #ffffff;
   background: #111827;
   border-bottom: 1px solid #0b1220;
 }
 
+.topbar-brand {
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.topbar-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.topbar-actions {
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.topbar-actions::-webkit-scrollbar {
+  display: none;
+}
+
+.topbar-actions .mantine-Badge-root {
+  flex: 0 0 auto;
+}
+
 .mark {
   display: grid;
   place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
   background: linear-gradient(135deg, #2563eb, #0f766e);
   font-family: var(--font-display);
-  font-size: var(--text-md);
+  font-size: var(--text-sm);
   font-weight: var(--weight-heavy);
 }
 
 .topbar-version {
-  min-height: 28px;
-  padding: 0 10px;
+  min-height: 24px;
+  padding: 0 9px;
   color: #dbeafe;
   background: rgba(37, 99, 235, 0.16);
   border: 1px solid rgba(191, 219, 254, 0.34);
@@ -1245,9 +1271,8 @@ pre,
 
 @media (max-width: 720px) {
   .topbar {
-    align-items: flex-start;
-    flex-direction: column;
-    padding: 14px 16px;
+    min-height: 48px;
+    padding: 8px 12px;
   }
 
   .shell {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,16 @@ pre,
 
 .topbar-actions .mantine-Badge-root {
   flex: 0 0 auto;
+  max-width: none;
+}
+
+.topbar-actions .mantine-Badge-label {
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.topbar-actions .topbar-version {
+  flex: 0 0 auto;
 }
 
 .mark {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 Gitdex
               </Text>
             </Group>
-            <Group className="topbar-actions" gap={6} justify="flex-end" wrap="nowrap">
+            <Group className="topbar-actions" gap={6} justify="flex-start" wrap="nowrap">
               <Badge color="dark" variant="light">
                 Model <Code>{settings.codexModel}</Code>
               </Badge>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,18 +22,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body>
         <Providers>
           <header className="topbar">
-            <Group gap="sm" wrap="nowrap">
+            <Group className="topbar-brand" gap="xs" wrap="nowrap">
               <div className="mark">TB</div>
-              <div>
-                <Text fw={800} size="md" c="white" lh={1.15}>
-                  Gitdex Management
-                </Text>
-                <Text size="xs" c="blue.1">
-                  Project routing, Codex sessions, GitHub orchestration
-                </Text>
-              </div>
+              <Text className="topbar-title" fw={800} c="white">
+                Gitdex
+              </Text>
             </Group>
-            <Group gap="xs" justify="flex-end">
+            <Group className="topbar-actions" gap={6} justify="flex-end" wrap="nowrap">
               <Badge color="dark" variant="light">
                 Model <Code>{settings.codexModel}</Code>
               </Badge>


### PR DESCRIPTION
Taskix workflow: WF-20260503-001
Issue: #148
## Summary
Implemented issue #148 on `taskix/WF-20260503-001-issue-148` and pushed commit `b4df9f3`. The worktree started clean on `main`, so I created the expected issue branch from `origin/main`. Header now uses a compact single-row layout with the `TB` logo and visible `Gitdex` brand, keeps model/webhook/version actions reachable in a non-wrapping scrollable action group on narrow screens, and reduces desktop/mobile header sizing. Updated `scripts/header-label.test.mjs` as a directly related acceptance test because it asserted the previous `Gitdex Management` header text.
## Changed Files
- src/app/layout.tsx
- src/app/globals.css
- scripts/header-label.test.mjs
## Verification
- npm run typecheck
- npm run build
- npm test
Closes #148