### PR TITLE
Move secondary header actions into compact navigation affordance

### DIFF
--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+const headerActionsSource = await readFile(new URL("../src/components/HeaderSecondaryActions.tsx", import.meta.url), "utf8");
 const globalStyles = await readFile(new URL("../src/app/globals.css", import.meta.url), "utf8");
 
 assert.match(
@@ -23,15 +24,21 @@ assert.match(
 );
 
 assert.match(
-  globalStyles,
-  /\.topbar-actions \.mantine-Badge-root\s*\{[^}]*flex:\s*0 0 auto;[^}]*max-width:\s*none;/s,
-  "Header badges should keep their full width in the scrollable action row"
+  headerActionsSource,
+  /aria-label="Open console details and actions"/,
+  "Compact header action menu should expose a clear accessible label"
+);
+
+assert.match(
+  headerActionsSource,
+  /Self-update v\$\{version\}/,
+  "Compact header action menu should keep the self-update action label clear"
 );
 
 assert.match(
   globalStyles,
-  /\.topbar-actions \.mantine-Badge-label\s*\{[^}]*overflow:\s*visible;[^}]*text-overflow:\s*clip;/s,
-  "Header badge labels should not ellipsize important control text"
+  /\.topbar-menu-trigger\s*\{[^}]*white-space:\s*nowrap;/s,
+  "Compact header menu trigger should keep its action label readable"
 );
 
 console.log("header label verification passed");

--- a/scripts/header-version.test.mjs
+++ b/scripts/header-version.test.mjs
@@ -12,8 +12,8 @@ assert.match(
 
 assert.match(
   layoutSource,
-  /<SelfUpdateDialog version=\{packageJson\.version\} \/>/,
-  "Root layout should wire the package version into the self-update dialog entry point"
+  /<HeaderSecondaryActions[^>]*version=\{packageJson\.version\}[^>]*\/>/,
+  "Root layout should wire the package version into the compact header actions entry point"
 );
 
 assert.match(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -93,6 +93,81 @@ pre,
   flex: 0 0 auto;
 }
 
+.topbar-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  gap: 7px;
+  padding: 0 11px;
+  color: #e5edf8;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(226, 232, 240, 0.28);
+  border-radius: 8px;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.topbar-menu-trigger:hover,
+.topbar-menu-trigger:focus-visible {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.topbar-menu-trigger:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+.topbar-menu-item {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.topbar-menu-item .mantine-Code-root {
+  max-width: 248px;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.topbar-menu-action-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px 8px;
+  color: #475467;
+}
+
+.topbar-menu-action {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  min-width: 0;
+  padding: 0;
+  color: #1d4ed8;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  cursor: pointer;
+}
+
+.topbar-menu-action:hover,
+.topbar-menu-action:focus-visible {
+  color: #0f3d99;
+  text-decoration: underline;
+}
+
+.topbar-menu-action:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 .mark {
   display: grid;
   place-items: center;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { Badge, Code, Group, Text } from "@mantine/core";
+import { Group, Text } from "@mantine/core";
 import { getSettings } from "@/lib/settings";
 import { listProjects, listWorkflows } from "@/lib/store";
+import { HeaderSecondaryActions } from "@/components/HeaderSecondaryActions";
 import { Providers } from "@/components/Providers";
-import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
 import { ShellLayout } from "@/components/ShellLayout";
 import packageJson from "../../package.json";
 import "@mantine/core/styles.css";
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const [settings, projects, workflows] = await Promise.all([getSettings(), listProjects(), listWorkflows()]);
+  const webhookUrl = `${settings.appBaseUrl.replace(/\/$/, "")}/telegram/webhook`;
 
   return (
     <html lang="en">
@@ -29,13 +30,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               </Text>
             </Group>
             <Group className="topbar-actions" gap={6} justify="flex-start" wrap="nowrap">
-              <Badge color="dark" variant="light">
-                Model <Code>{settings.codexModel}</Code>
-              </Badge>
-              <Badge color="dark" variant="light">
-                Webhook <Code>{settings.appBaseUrl.replace(/\/$/, "")}/telegram/webhook</Code>
-              </Badge>
-              <SelfUpdateDialog version={packageJson.version} />
+              <HeaderSecondaryActions codexModel={settings.codexModel} webhookUrl={webhookUrl} version={packageJson.version} />
             </Group>
           </header>
           <div className="shell">

--- a/src/components/HeaderSecondaryActions.tsx
+++ b/src/components/HeaderSecondaryActions.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Code, Menu, Text } from "@mantine/core";
+import { Info, MoreHorizontal, RefreshCw, Settings2 } from "lucide-react";
+import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
+
+export function HeaderSecondaryActions({
+  codexModel,
+  webhookUrl,
+  version
+}: {
+  codexModel: string;
+  webhookUrl: string;
+  version: string;
+}) {
+  return (
+    <Menu shadow="md" width={340} position="bottom-end" withArrow>
+      <Menu.Target>
+        <button className="topbar-menu-trigger" type="button" aria-label="Open console details and actions">
+          <MoreHorizontal size={18} aria-hidden="true" />
+          <span>Console</span>
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>Runtime</Menu.Label>
+        <Menu.Item leftSection={<Settings2 size={16} aria-hidden="true" />} closeMenuOnClick={false}>
+          <span className="topbar-menu-item">
+            <Text component="span" size="sm" fw={700}>Model</Text>
+            <Code>{codexModel}</Code>
+          </span>
+        </Menu.Item>
+        <Menu.Item leftSection={<Info size={16} aria-hidden="true" />} closeMenuOnClick={false}>
+          <span className="topbar-menu-item">
+            <Text component="span" size="sm" fw={700}>Webhook</Text>
+            <Code>{webhookUrl}</Code>
+          </span>
+        </Menu.Item>
+        <Menu.Divider />
+        <div className="topbar-menu-action-row">
+          <RefreshCw size={16} aria-hidden="true" />
+          <SelfUpdateDialog version={version} triggerClassName="topbar-menu-action" triggerLabel={`Self-update v${version}`} />
+        </div>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/SelfUpdateDialog.tsx
+++ b/src/components/SelfUpdateDialog.tsx
@@ -14,7 +14,15 @@ type ApiFailure = {
   stderr?: string;
 };
 
-export function SelfUpdateDialog({ version }: { version: string }) {
+export function SelfUpdateDialog({
+  version,
+  triggerClassName = "topbar-version",
+  triggerLabel
+}: {
+  version: string;
+  triggerClassName?: string;
+  triggerLabel?: string;
+}) {
   const [opened, setOpened] = useState(false);
   const [phase, setPhase] = useState<SelfUpdateDialogPhase>("idle");
   const [status, setStatus] = useState<SelfUpdateState | null>(null);
@@ -151,8 +159,8 @@ export function SelfUpdateDialog({ version }: { version: string }) {
 
   return (
     <>
-      <button className="topbar-version" type="button" aria-label={`Taskix version ${version}. Open self-update dialog`} onClick={() => setOpened(true)}>
-        v{version}
+      <button className={triggerClassName} type="button" aria-label={`Taskix version ${version}. Open self-update dialog`} onClick={() => setOpened(true)}>
+        {triggerLabel ?? `v${version}`}
       </button>
       <Modal
         opened={opened}


### PR DESCRIPTION
Taskix workflow: WF-20260503-001
Issue: #149
## Summary
Implemented issue #149 on the expected branch and pushed commit ad09aab. The topbar now moves model, webhook, and self-update into a compact `Console` menu while preserving the existing self-update modal behavior. Updated the two focused header tests because they directly verify this issue’s header acceptance criteria. Build emitted the existing Next workspace-root warning, but completed successfully.
## Changed Files
- src/app/layout.tsx
- src/app/globals.css
- src/components/HeaderSecondaryActions.tsx
- src/components/SelfUpdateDialog.tsx
- scripts/header-label.test.mjs
- scripts/header-version.test.mjs
## Verification
- npm test
- npm run build
- npm run typecheck
Closes #149