### PR TITLE
Replace sidebar shell with compact top navigation header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1312,23 +1312,31 @@ pre,
 
 @media (max-width: 720px) {
   .topbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     min-height: 48px;
     padding: 8px 12px;
     gap: 8px;
   }
 
+  .topbar-brand {
+    min-width: 0;
+  }
+
   .topbar-title {
     font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .mark {
+    flex: 0 0 auto;
     width: 28px;
     height: 28px;
   }
 
   .top-nav {
-    flex: 0 0 auto;
-    margin-left: auto;
+    justify-self: end;
   }
 
   .top-nav-links {
@@ -1337,6 +1345,11 @@ pre,
 
   .top-nav-menu-trigger {
     display: grid;
+  }
+
+  .topbar-actions {
+    justify-self: end;
+    overflow: visible;
   }
 
   .topbar-menu-trigger {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,6 +71,7 @@ pre,
 
 .topbar-actions {
   min-width: 0;
+  flex: 0 0 auto;
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -91,6 +92,83 @@ pre,
 
 .topbar-actions .topbar-version {
   flex: 0 0 auto;
+}
+
+.top-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.top-nav-links {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 4px;
+}
+
+.top-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  min-width: 0;
+  padding: 0 10px;
+  color: #d8e3f2;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  white-space: nowrap;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.top-nav-link:hover,
+.top-nav-link:focus-visible {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.top-nav-link:focus-visible,
+.top-nav-menu-trigger:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+.top-nav-link.active {
+  color: #ffffff;
+  background: rgba(37, 99, 235, 0.34);
+  border-color: rgba(147, 197, 253, 0.36);
+}
+
+.top-nav-link-main {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+}
+
+.top-nav-menu-trigger {
+  display: none;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: #e5edf8;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(226, 232, 240, 0.28);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.top-nav-menu-trigger:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.14);
 }
 
 .topbar-menu-trigger {
@@ -276,121 +354,7 @@ pre,
 }
 
 .layout {
-  display: grid;
-  grid-template-columns: 238px minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
-  transition: grid-template-columns 160ms ease;
-}
-
-.layout.layout-collapsed {
-  grid-template-columns: 72px minmax(0, 1fr);
-}
-
-.sidebar {
-  position: sticky;
-  top: 18px;
-  padding: 10px;
-  border-color: rgba(148, 163, 184, 0.36);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.96)),
-    #ffffff;
-}
-
-.sidebar.collapsed {
-  padding: 8px;
-}
-
-.nav-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 34px;
-  gap: 8px;
-}
-
-.sidebar.collapsed .nav-head {
-  justify-content: center;
-}
-
-.nav-kicker {
-  padding: 6px 10px 10px;
-  color: #667085;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-bold);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.side-link {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  min-height: 42px;
-  padding: 8px 9px;
-  color: #344054;
-  border: 1px solid transparent;
-  border-radius: 10px;
-  text-decoration: none;
-  font-size: var(--text-ui);
-  font-weight: var(--weight-semibold);
-  transition:
-    background 140ms ease,
-    border-color 140ms ease,
-    color 140ms ease,
-    box-shadow 140ms ease;
-}
-
-.sidebar.collapsed .side-link {
-  justify-content: center;
-  padding: 8px;
-}
-
-.side-link:hover {
-  color: #101828;
-  background: #f2f6fb;
-  border-color: #e4eaf2;
-}
-
-.side-link.active {
-  color: #0f3d99;
-  background: linear-gradient(180deg, #eef5ff, #e7f0ff);
-  border-color: #c9dcff;
-  box-shadow: 0 1px 2px rgba(37, 99, 235, 0.1);
-}
-
-.side-link-main {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-}
-
-.sidebar.collapsed .side-link-main {
-  gap: 0;
-}
-
-.side-link-icon {
-  display: grid;
-  place-items: center;
-  width: 28px;
-  height: 28px;
-  color: #667085;
-  background: #ffffff;
-  border: 1px solid #e5eaf0;
-  border-radius: 8px;
-}
-
-.sidebar.collapsed .side-link-icon {
-  width: 32px;
-  height: 32px;
-}
-
-.side-link.active .side-link-icon {
-  color: #1d4ed8;
-  border-color: #bdd3ff;
-  background: #ffffff;
+  width: 100%;
 }
 
 .content {
@@ -1329,20 +1293,12 @@ pre,
 }
 
 @media (max-width: 1180px) {
-  .layout {
-    grid-template-columns: 1fr;
-  }
-
   .project-chat-layout {
     grid-template-columns: 1fr;
   }
 
   .workflow-detail-layout {
     grid-template-columns: 1fr;
-  }
-
-  .sidebar {
-    position: static;
   }
 
   .project-context {
@@ -1358,6 +1314,39 @@ pre,
   .topbar {
     min-height: 48px;
     padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .topbar-title {
+    font-size: 16px;
+  }
+
+  .mark {
+    width: 28px;
+    height: 28px;
+  }
+
+  .top-nav {
+    flex: 0 0 auto;
+    margin-left: auto;
+  }
+
+  .top-nav-links {
+    display: none;
+  }
+
+  .top-nav-menu-trigger {
+    display: grid;
+  }
+
+  .topbar-menu-trigger {
+    width: 34px;
+    min-height: 34px;
+    padding: 0;
+  }
+
+  .topbar-menu-trigger span {
+    display: none;
   }
 
   .shell {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Group, Text } from "@mantine/core";
 import { getSettings } from "@/lib/settings";
 import { listProjects, listWorkflows } from "@/lib/store";
 import { HeaderSecondaryActions } from "@/components/HeaderSecondaryActions";
+import { Nav } from "@/components/Nav";
 import { Providers } from "@/components/Providers";
 import { ShellLayout } from "@/components/ShellLayout";
 import packageJson from "../../package.json";
@@ -29,12 +30,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 Gitdex
               </Text>
             </Group>
+            <Nav workflowCount={workflows.length} projectCount={projects.length} />
             <Group className="topbar-actions" gap={6} justify="flex-start" wrap="nowrap">
               <HeaderSecondaryActions codexModel={settings.codexModel} webhookUrl={webhookUrl} version={packageJson.version} />
             </Group>
           </header>
           <div className="shell">
-            <ShellLayout workflowCount={workflows.length} projectCount={projects.length}>{children}</ShellLayout>
+            <ShellLayout>{children}</ShellLayout>
           </div>
         </Providers>
       </body>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,19 +2,15 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ActionIcon, Badge, Paper, Stack, Text, Tooltip } from "@mantine/core";
-import { ChevronsLeft, ChevronsRight, FolderKanban, Gauge, Settings, Wrench } from "lucide-react";
+import { Badge, Menu } from "@mantine/core";
+import { FolderKanban, Gauge, Menu as MenuIcon, Settings, Wrench } from "lucide-react";
 
 export function Nav({
   workflowCount,
-  projectCount,
-  collapsed,
-  onToggleCollapsed
+  projectCount
 }: {
   workflowCount: number;
   projectCount: number;
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
 }) {
   const pathname = usePathname();
   const items = [
@@ -25,34 +21,48 @@ export function Nav({
   ];
 
   return (
-    <Paper className={`sidebar ${collapsed ? "collapsed" : ""}`} component="nav" aria-label="Primary" p="xs">
-      <div className="nav-head">
-        {!collapsed && <Text className="nav-kicker">Workspace</Text>}
-        <ActionIcon variant="subtle" size="sm" aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"} onClick={onToggleCollapsed}>
-          {collapsed ? <ChevronsRight size={16} /> : <ChevronsLeft size={16} />}
-        </ActionIcon>
-      </div>
-      <Stack gap={6}>
+    <nav className="top-nav" aria-label="Primary">
+      <div className="top-nav-links">
         {items.map((item) => {
           const Icon = item.icon;
-          const link = (
-            <Link key={item.href} href={item.href} className={`side-link ${item.active ? "active" : ""}`}>
-              <span className="side-link-main">
-                <span className="side-link-icon">
-                  <Icon size={17} strokeWidth={2.2} />
-                </span>
-                {!collapsed && <span>{item.label}</span>}
+          return (
+            <Link key={item.href} href={item.href} className={`top-nav-link ${item.active ? "active" : ""}`}>
+              <span className="top-nav-link-main">
+                <Icon size={16} strokeWidth={2.2} aria-hidden="true" />
+                <span>{item.label}</span>
               </span>
-              {!collapsed && typeof item.count === "number" && (
-                <Badge size="sm" variant={item.active ? "filled" : "light"} color={item.active ? "blue" : "gray"}>
+              {typeof item.count === "number" && (
+                <Badge size="xs" variant={item.active ? "filled" : "light"} color={item.active ? "blue" : "gray"}>
                   {item.count}
                 </Badge>
               )}
             </Link>
           );
-          return collapsed ? <Tooltip key={item.href} label={item.label} position="right">{link}</Tooltip> : link;
         })}
-      </Stack>
-    </Paper>
+      </div>
+      <Menu shadow="md" width={220} position="bottom-end" withArrow>
+        <Menu.Target>
+          <button className="top-nav-menu-trigger" type="button" aria-label="Open primary navigation">
+            <MenuIcon size={18} aria-hidden="true" />
+          </button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          {items.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Menu.Item
+                key={item.href}
+                component={Link}
+                href={item.href}
+                leftSection={<Icon size={16} aria-hidden="true" />}
+                rightSection={typeof item.count === "number" ? <Badge size="xs">{item.count}</Badge> : null}
+              >
+                {item.label}
+              </Menu.Item>
+            );
+          })}
+        </Menu.Dropdown>
+      </Menu>
+    </nav>
   );
 }

--- a/src/components/ShellLayout.tsx
+++ b/src/components/ShellLayout.tsx
@@ -1,34 +1,10 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { Nav } from "@/components/Nav";
-
 export function ShellLayout({
-  workflowCount,
-  projectCount,
   children
 }: {
-  workflowCount: number;
-  projectCount: number;
   children: React.ReactNode;
 }) {
-  const [collapsed, setCollapsed] = useState(false);
-
-  useEffect(() => {
-    setCollapsed(window.localStorage.getItem("taskix-sidebar-collapsed") === "true");
-  }, []);
-
-  function toggleCollapsed() {
-    setCollapsed((current) => {
-      const next = !current;
-      window.localStorage.setItem("taskix-sidebar-collapsed", String(next));
-      return next;
-    });
-  }
-
   return (
-    <div className={`layout ${collapsed ? "layout-collapsed" : ""}`}>
-      <Nav workflowCount={workflowCount} projectCount={projectCount} collapsed={collapsed} onToggleCollapsed={toggleCollapsed} />
+    <div className="layout">
       <main className="content">{children}</main>
     </div>
   );


### PR DESCRIPTION
Taskix workflow: WF-20260503-002
Issue: #152
## Summary
Implemented issue #152 on branch taskix/WF-20260503-002-issue-152 and pushed commit 839b36709d8fe02f6dbfca663d24f026c8ceee84. GitHub issue context had no comments, linked PRs, or QA feedback, so the issue body was the active source of truth. Replaced the left sidebar shell with top-header primary navigation preserving Gitdex branding, Dashboard/Projects/Tools/Settings entries, counts, active states, and a compact mobile menu. Worktree started clean on main, so I created and pushed the expected issue branch.
## Changed Files
- src/app/globals.css
- src/app/layout.tsx
- src/components/Nav.tsx
- src/components/ShellLayout.tsx
## Verification
- npm run typecheck
- npm run build
- npm test
Closes #152