### PR TITLE
Move project details into collapsed right panel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -443,34 +443,6 @@ pre,
   border-top: 1px solid #fee2e2;
 }
 
-.project-details-panel {
-  margin: 0;
-}
-
-.project-details-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  cursor: pointer;
-  list-style: none;
-}
-
-.project-details-summary::-webkit-details-marker {
-  display: none;
-}
-
-.project-details-summary::after {
-  color: #64748b;
-  content: "Show";
-  font-size: var(--text-xs);
-  font-weight: var(--weight-bold);
-}
-
-.project-details-panel[open] .project-details-summary::after {
-  content: "Hide";
-}
-
 .project-delete-form {
   margin-top: 8px;
 }
@@ -493,6 +465,56 @@ pre,
   grid-template-columns: minmax(480px, 1fr) minmax(520px, clamp(520px, 40vw, 680px));
   gap: 18px;
   align-items: start;
+}
+
+.project-detail-drawer-content {
+  max-width: 100vw;
+}
+
+.project-detail-drawer-header {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--app-border);
+  padding: 16px;
+}
+
+.project-detail-drawer-body {
+  padding: 16px;
+}
+
+.project-detail-title {
+  min-width: 0;
+}
+
+.project-detail-list {
+  display: grid;
+  gap: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.project-detail-row {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  padding: 10px 12px;
+  background: #fff;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.project-detail-row:last-child {
+  border-bottom: 0;
+}
+
+.project-detail-value {
+  width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.project-detail-danger-zone {
+  margin-top: 0;
 }
 
 .chat-panel {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -7,7 +7,7 @@ import { ProjectAutoRunIssueAction } from "@/components/ProjectAutoRunIssueActio
 import { ProjectAutoRunIssuesButton } from "@/components/ProjectAutoRunIssuesButton";
 import { ProjectAutoSync } from "@/components/ProjectAutoSync";
 import { ProjectChatArea } from "@/components/ProjectChatArea";
-import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
+import { ProjectDetailPanel } from "@/components/ProjectDetailPanel";
 import { ProjectArchitectReviewButton } from "@/components/ProjectArchitectReviewButton";
 import { ProjectEscalateSessionButton } from "@/components/ProjectEscalateSessionButton";
 import { ProjectHandoffForm } from "@/components/ProjectHandoffForm";
@@ -124,6 +124,18 @@ export default async function ProjectDetailPage({
                 <Text size="sm" c="dimmed">Current project delivery flow.</Text>
               </div>
               <Group gap="xs">
+                <ProjectDetailPanel
+                  project={{
+                    projectId: project.projectId,
+                    slug: project.slug,
+                    githubRepo: project.githubRepo,
+                    autoDeploy: project.autoDeploy,
+                    agentsFilePath: project.agentsFilePath,
+                    updateAgentsFile: project.updateAgentsFile,
+                    projectManagerSessionId: project.projectManagerSessionId,
+                    devopsSessionId: project.devopsSessionId
+                  }}
+                />
                 <Button
                   component="a"
                   href={`/projects/${project.projectId}/github-triage`}
@@ -196,29 +208,6 @@ export default async function ProjectDetailPage({
             </Stack>
           </Paper>
 
-          <Paper mt="md">
-            <details className="project-details-panel">
-              <summary className="section-header project-details-summary">
-                <div>
-                  <Text fw={760}>Project</Text>
-                  <Text size="sm" c="dimmed">{project.githubRepo}</Text>
-                </div>
-                <Badge variant="light">{project.autoDeploy ? "auto deploy" : "manual deploy"}</Badge>
-              </summary>
-              <Stack p="md" gap="xs">
-                <Text size="sm">Slug: <Code>{project.slug}</Code></Text>
-                <Text size="sm">PM: <Code>{project.projectManagerSessionId ?? "new"}</Code></Text>
-                <Text size="sm">DevOps: <Code>{project.devopsSessionId ?? "new"}</Code></Text>
-                <Text size="sm">Agents: <Code>{project.agentsFilePath}</Code></Text>
-                <Text size="sm">Agents update: <Code>{project.updateAgentsFile ? "enabled" : "skipped"}</Code></Text>
-                <div className="project-danger-zone">
-                  <Text size="xs" fw={780} c="red">Delete local project</Text>
-                  <Text size="xs" c="dimmed">Type <Code>{project.slug}</Code> to remove this local project and its local Taskix state. GitHub data is not deleted.</Text>
-                  <ProjectDeleteForm projectId={project.projectId} slug={project.slug} />
-                </div>
-              </Stack>
-            </details>
-          </Paper>
         </aside>
       </div>
     </>

--- a/src/components/ProjectDetailPanel.tsx
+++ b/src/components/ProjectDetailPanel.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Badge, Button, Code, Drawer, Group, Stack, Text } from "@mantine/core";
+import { Info, X } from "lucide-react";
+import { useState } from "react";
+import { ProjectDeleteForm } from "@/components/ProjectDeleteForm";
+
+export function ProjectDetailPanel({
+  project
+}: {
+  project: {
+    projectId: string;
+    slug: string;
+    githubRepo: string;
+    autoDeploy: boolean;
+    agentsFilePath: string;
+    updateAgentsFile: boolean;
+    projectManagerSessionId?: string | null;
+    devopsSessionId?: string | null;
+  };
+}) {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="light"
+        size="xs"
+        radius="xl"
+        leftSection={<Info size={14} />}
+        onClick={() => setOpened(true)}
+      >
+        Project details
+      </Button>
+      <Drawer
+        opened={opened}
+        onClose={() => setOpened(false)}
+        position="right"
+        size="min(460px, 100vw)"
+        title={<ProjectDetailPanelTitle repo={project.githubRepo} autoDeploy={project.autoDeploy} />}
+        closeButtonProps={{ icon: <X size={18} />, "aria-label": "Close project details" }}
+        overlayProps={{ backgroundOpacity: 0.24, blur: 1 }}
+        classNames={{
+          content: "project-detail-drawer-content",
+          header: "project-detail-drawer-header",
+          body: "project-detail-drawer-body"
+        }}
+      >
+        <Stack gap="md">
+          <div className="project-detail-list" aria-label="Project details">
+            <ProjectDetailRow label="GitHub repo" value={project.githubRepo} />
+            <ProjectDetailRow label="Deploy mode" value={project.autoDeploy ? "Automatic" : "Manual"} />
+            <ProjectDetailRow label="Slug" value={project.slug} />
+            <ProjectDetailRow label="PM session" value={project.projectManagerSessionId ?? "new"} />
+            <ProjectDetailRow label="DevOps session" value={project.devopsSessionId ?? "new"} />
+            <ProjectDetailRow label="Agents file path" value={project.agentsFilePath} />
+            <ProjectDetailRow label="Agents update setting" value={project.updateAgentsFile ? "enabled" : "skipped"} />
+          </div>
+
+          <div className="project-danger-zone project-detail-danger-zone">
+            <Text size="xs" fw={780} c="red">Delete local project</Text>
+            <Text size="xs" c="dimmed">
+              Type <Code>{project.slug}</Code> to remove this local project and its local Taskix state. GitHub data is not deleted.
+            </Text>
+            <ProjectDeleteForm projectId={project.projectId} slug={project.slug} />
+          </div>
+        </Stack>
+      </Drawer>
+    </>
+  );
+}
+
+function ProjectDetailPanelTitle({ repo, autoDeploy }: { repo: string; autoDeploy: boolean }) {
+  return (
+    <Group gap="xs" wrap="nowrap">
+      <div className="project-detail-title">
+        <Text fw={780}>Project</Text>
+        <Text size="xs" c="dimmed" lineClamp={1}>{repo}</Text>
+      </div>
+      <Badge variant="light">{autoDeploy ? "auto deploy" : "manual deploy"}</Badge>
+    </Group>
+  );
+}
+
+function ProjectDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="project-detail-row">
+      <Text size="xs" c="dimmed">{label}</Text>
+      <Code className="project-detail-value">{value}</Code>
+    </div>
+  );
+}


### PR DESCRIPTION
Taskix workflow: WF-20260503-002
Issue: #154
## Summary
Implemented issue #154 on the expected clean branch. Moved project metadata/delete controls out of the workflow context sidebar into a collapsed-by-default right-side Project details drawer opened from the project chat header, preserving local UI state and route/query params. Pushed commit 95010002e4d6c5a9d6671372232130c86c4610c8 to origin/taskix/WF-20260503-002-issue-154.
## Changed Files
- src/app/projects/[projectId]/page.tsx
- src/app/globals.css
- src/components/ProjectDetailPanel.tsx
## Verification
- npm run typecheck
- npm run build
- npm test
Closes #154