### PR TITLE
Remove redundant chat card header and preserve chat controls

### DIFF
--- a/scripts/chat-ui.test.mjs
+++ b/scripts/chat-ui.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const projectPageSource = await readFile(new URL("../src/app/projects/[projectId]/page.tsx", import.meta.url), "utf8");
+const chatAreaSource = await readFile(new URL("../src/components/ProjectChatArea.tsx", import.meta.url), "utf8");
+const globalStyles = await readFile(new URL("../src/app/globals.css", import.meta.url), "utf8");
+
+assert.doesNotMatch(
+  projectPageSource,
+  /className="chat-header"/,
+  "Project page should not render the duplicated chat-card header above the timeline"
+);
+
+assert.doesNotMatch(
+  globalStyles,
+  /\.chat-header\b/,
+  "Global styles should not reserve space for the removed chat header"
+);
+
+assert.match(
+  chatAreaSource,
+  /readOnly\s*\?\s*\([\s\S]*className="chat-session-status"[\s\S]*Read-only session/,
+  "Read-only session inspection should still render a visible status near the chat area"
+);
+
+assert.match(
+  chatAreaSource,
+  /!\s*readOnly\s*&&\s*\([\s\S]*className="chat-composer"/,
+  "Normal chat mode should keep the composer available"
+);
+
+assert.match(
+  chatAreaSource,
+  /Default target\s*<Code>PM<\/Code>/,
+  "Normal chat composer should keep the default PM target indicator"
+);
+
+console.log("chat UI source verification passed");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -469,19 +469,6 @@ pre,
   overflow: hidden;
 }
 
-.chat-header {
-  position: sticky;
-  top: 0;
-  z-index: 5;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--app-border);
-  background: rgba(255, 255, 255, 0.88);
-}
-
 .chat-scroll {
   flex: 1;
   min-height: 0;
@@ -493,6 +480,15 @@ pre,
     radial-gradient(circle at 10% 10%, rgba(37, 99, 235, 0.06), transparent 28%),
     #f8fbff;
   scrollbar-gutter: stable;
+}
+
+.chat-session-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 10px 20px 0;
+  background: #f8fbff;
 }
 
 .chat-composer {
@@ -1370,15 +1366,17 @@ pre,
     padding: 14px;
   }
 
-  .chat-header {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
   .chat-composer-actions {
     align-items: stretch;
     flex-direction: column;
     padding-left: 4px;
+  }
+
+  .chat-session-status {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 14px 0;
   }
 
   .workflow-session-grid {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from "@mantine/core";
-import { Bot, GitBranch, Info, ListTodo, RefreshCw, RotateCcw } from "lucide-react";
+import { GitBranch, Info, ListTodo, RefreshCw, RotateCcw } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunJob } from "@/components/ProjectAutoRunJob";
 import { ProjectAutoRunIssueAction } from "@/components/ProjectAutoRunIssueAction";
@@ -113,18 +113,6 @@ export default async function ProjectDetailPage({
       <ProjectAutoSync projectId={project.projectId} />
       <div className="project-chat-layout">
         <Paper className="chat-panel">
-          <div className="chat-header">
-            <div>
-              <Text fw={820}>{project.name}</Text>
-              <Text size="sm" c="dimmed">
-                {isInspectingIssueSession ? "Agent context" : "Agent chat"} · {project.githubRepo}
-              </Text>
-            </div>
-            <Group gap="xs">
-              <Badge variant="light" leftSection={<Bot size={12} />}>All agents</Badge>
-              {isInspectingIssueSession ? <Badge variant="outline">Read-only session</Badge> : null}
-            </Group>
-          </div>
           <ProjectChatArea projectId={project.projectId} sessions={sessions} jobs={jobs} workflows={workflows} inspectedSession={activeSession} readOnly={isInspectingIssueSession} />
         </Paper>
 

--- a/src/components/ProjectChatArea.tsx
+++ b/src/components/ProjectChatArea.tsx
@@ -155,6 +155,14 @@ export function ProjectChatArea({
 
   return (
     <>
+      {readOnly ? (
+        <div className="chat-session-status">
+          <Badge variant="outline">Read-only session</Badge>
+          <Text size="xs" c="dimmed">
+            Inspecting archived agent context
+          </Text>
+        </div>
+      ) : null}
       <div ref={scrollRef} className="chat-scroll">
         <MessageList projectId={projectId} sessions={visibleSessions} jobs={liveJobs} workflows={workflows} inspectedSession={readOnly ? inspectedSession : null} optimisticMessage={optimisticMessage} pending={pending} />
       </div>


### PR DESCRIPTION
Taskix workflow: WF-20260503-002
Issue: #155
## Summary
Implemented issue #155 on the expected branch and pushed commit 202e0cd. Removed the redundant project chat header from the project page, moved the read-only inspection status into ProjectChatArea for inspected sessions, removed obsolete .chat-header CSS, and added a focused chat UI source test covering the header removal, read-only status, composer, and PM default indicator. No PR existed and I did not create one per instructions; the branch is pushed for Taskix to create/update the PR.
## Changed Files
- src/app/projects/[projectId]/page.tsx
- src/components/ProjectChatArea.tsx
- src/app/globals.css
- scripts/chat-ui.test.mjs
## Verification
- npm test -- --test-name-pattern='chat UI source verification'
- npm run typecheck
- npm run build (failed: local SQLite database locked in default DATA_DIR)
- DATA_DIR=/private/tmp/taskix-issue-155-build-data npm run build
- npm test
Closes #155