### PR TITLE
Add project-aware header switcher

### DIFF
--- a/scripts/header-label.test.mjs
+++ b/scripts/header-label.test.mjs
@@ -31,6 +31,12 @@ assert.match(
 
 assert.match(
   headerActionsSource,
+  /<ProjectSwitcher projects=\{projects\} \/>/,
+  "Compact header actions should preserve the project switcher entry point"
+);
+
+assert.match(
+  headerActionsSource,
   /Self-update v\$\{version\}/,
   "Compact header action menu should keep the self-update action label clear"
 );

--- a/scripts/header-version.test.mjs
+++ b/scripts/header-version.test.mjs
@@ -12,7 +12,7 @@ assert.match(
 
 assert.match(
   layoutSource,
-  /<HeaderSecondaryActions[^>]*version=\{packageJson\.version\}[^>]*\/>/,
+  /<HeaderSecondaryActions[^>]*projects=\{headerProjects\}[^>]*version=\{packageJson\.version\}[^>]*\/>/,
   "Root layout should wire the package version into the compact header actions entry point"
 );
 

--- a/scripts/project-switcher.test.mjs
+++ b/scripts/project-switcher.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import {
+  currentProjectFromPathname,
+  projectContextLabel,
+  projectHref,
+  projectIdFromPathname
+} from "../src/components/project-switcher/routes.ts";
+
+const projects = [
+  {
+    projectId: "alpha-1",
+    name: "Dispatch",
+    slug: "dispatch",
+    githubAccount: "Taskix-AI",
+    githubRepo: "Dispatch"
+  },
+  {
+    projectId: "beta-2",
+    name: "Dispatch",
+    slug: "dispatch-beta",
+    githubAccount: "Taskix-AI",
+    githubRepo: "DispatchBeta"
+  }
+];
+
+assert.equal(projectIdFromPathname("/projects/alpha-1"), "alpha-1", "Project detail routes should expose the project id");
+assert.equal(projectIdFromPathname("/projects/alpha-1/requirements"), "alpha-1", "Nested project routes should expose the project id");
+assert.equal(projectIdFromPathname("/projects"), null, "The project index should not expose a current project id");
+assert.equal(projectIdFromPathname("/projects/new"), null, "The new-project route should not expose a current project id");
+assert.equal(projectIdFromPathname("/workflows"), null, "Non-project routes should not expose a current project id");
+
+assert.equal(currentProjectFromPathname(projects, "/projects/alpha-1/requirements")?.name, "Dispatch", "Known project routes should resolve the current project");
+assert.equal(currentProjectFromPathname(projects, "/projects/missing"), null, "Unknown project ids should not render a current project");
+assert.equal(projectHref("beta-2"), "/projects/beta-2", "Switch targets should use existing project detail routes");
+assert.equal(projectContextLabel(projects[1]), "Taskix-AI/DispatchBeta", "Project entries should include repository context for similar names");
+
+console.log("project switcher verification passed");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,15 +189,49 @@ pre,
   cursor: pointer;
 }
 
+.project-switcher-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  max-width: 230px;
+  gap: 7px;
+  padding: 0 10px;
+  color: #e5edf8;
+  background: rgba(20, 184, 166, 0.16);
+  border: 1px solid rgba(94, 234, 212, 0.32);
+  border-radius: 8px;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.project-switcher-trigger-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .topbar-menu-trigger:hover,
-.topbar-menu-trigger:focus-visible {
+.topbar-menu-trigger:focus-visible,
+.project-switcher-trigger:hover,
+.project-switcher-trigger:focus-visible {
   color: #ffffff;
   background: rgba(255, 255, 255, 0.14);
 }
 
-.topbar-menu-trigger:focus-visible {
+.topbar-menu-trigger:focus-visible,
+.project-switcher-trigger:focus-visible {
   outline: 2px solid #93c5fd;
   outline-offset: 2px;
+}
+
+.project-switcher-item {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
 }
 
 .topbar-menu-item {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,13 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const [settings, projects, workflows] = await Promise.all([getSettings(), listProjects(), listWorkflows()]);
   const webhookUrl = `${settings.appBaseUrl.replace(/\/$/, "")}/telegram/webhook`;
+  const headerProjects = projects.map(({ projectId, name, slug, githubAccount, githubRepo }) => ({
+    projectId,
+    name,
+    slug,
+    githubAccount,
+    githubRepo
+  }));
 
   return (
     <html lang="en">
@@ -32,7 +39,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             </Group>
             <Nav workflowCount={workflows.length} projectCount={projects.length} />
             <Group className="topbar-actions" gap={6} justify="flex-start" wrap="nowrap">
-              <HeaderSecondaryActions codexModel={settings.codexModel} webhookUrl={webhookUrl} version={packageJson.version} />
+              <HeaderSecondaryActions codexModel={settings.codexModel} projects={headerProjects} webhookUrl={webhookUrl} version={packageJson.version} />
             </Group>
           </header>
           <div className="shell">

--- a/src/components/HeaderSecondaryActions.tsx
+++ b/src/components/HeaderSecondaryActions.tsx
@@ -2,45 +2,52 @@
 
 import { Code, Menu, Text } from "@mantine/core";
 import { Info, MoreHorizontal, RefreshCw, Settings2 } from "lucide-react";
+import { ProjectSwitcher } from "@/components/ProjectSwitcher";
+import type { ProjectSwitcherProject } from "@/components/project-switcher/routes";
 import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
 
 export function HeaderSecondaryActions({
   codexModel,
+  projects,
   webhookUrl,
   version
 }: {
   codexModel: string;
+  projects: ProjectSwitcherProject[];
   webhookUrl: string;
   version: string;
 }) {
   return (
-    <Menu shadow="md" width={340} position="bottom-end" withArrow>
-      <Menu.Target>
-        <button className="topbar-menu-trigger" type="button" aria-label="Open console details and actions">
-          <MoreHorizontal size={18} aria-hidden="true" />
-          <span>Console</span>
-        </button>
-      </Menu.Target>
-      <Menu.Dropdown>
-        <Menu.Label>Runtime</Menu.Label>
-        <Menu.Item leftSection={<Settings2 size={16} aria-hidden="true" />} closeMenuOnClick={false}>
-          <span className="topbar-menu-item">
-            <Text component="span" size="sm" fw={700}>Model</Text>
-            <Code>{codexModel}</Code>
-          </span>
-        </Menu.Item>
-        <Menu.Item leftSection={<Info size={16} aria-hidden="true" />} closeMenuOnClick={false}>
-          <span className="topbar-menu-item">
-            <Text component="span" size="sm" fw={700}>Webhook</Text>
-            <Code>{webhookUrl}</Code>
-          </span>
-        </Menu.Item>
-        <Menu.Divider />
-        <div className="topbar-menu-action-row">
-          <RefreshCw size={16} aria-hidden="true" />
-          <SelfUpdateDialog version={version} triggerClassName="topbar-menu-action" triggerLabel={`Self-update v${version}`} />
-        </div>
-      </Menu.Dropdown>
-    </Menu>
+    <>
+      <ProjectSwitcher projects={projects} />
+      <Menu shadow="md" width={340} position="bottom-end" withArrow>
+        <Menu.Target>
+          <button className="topbar-menu-trigger" type="button" aria-label="Open console details and actions">
+            <MoreHorizontal size={18} aria-hidden="true" />
+            <span>Console</span>
+          </button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Label>Runtime</Menu.Label>
+          <Menu.Item leftSection={<Settings2 size={16} aria-hidden="true" />} closeMenuOnClick={false}>
+            <span className="topbar-menu-item">
+              <Text component="span" size="sm" fw={700}>Model</Text>
+              <Code>{codexModel}</Code>
+            </span>
+          </Menu.Item>
+          <Menu.Item leftSection={<Info size={16} aria-hidden="true" />} closeMenuOnClick={false}>
+            <span className="topbar-menu-item">
+              <Text component="span" size="sm" fw={700}>Webhook</Text>
+              <Code>{webhookUrl}</Code>
+            </span>
+          </Menu.Item>
+          <Menu.Divider />
+          <div className="topbar-menu-action-row">
+            <RefreshCw size={16} aria-hidden="true" />
+            <SelfUpdateDialog version={version} triggerClassName="topbar-menu-action" triggerLabel={`Self-update v${version}`} />
+          </div>
+        </Menu.Dropdown>
+      </Menu>
+    </>
   );
 }

--- a/src/components/ProjectSwitcher.tsx
+++ b/src/components/ProjectSwitcher.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Menu, Text } from "@mantine/core";
+import { Check, ChevronsUpDown, FolderKanban } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  currentProjectFromPathname,
+  projectContextLabel,
+  projectHref,
+  type ProjectSwitcherProject
+} from "@/components/project-switcher/routes";
+
+export function ProjectSwitcher({ projects }: { projects: ProjectSwitcherProject[] }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const currentProject = currentProjectFromPathname(projects, pathname);
+
+  if (!currentProject) {
+    return null;
+  }
+
+  return (
+    <Menu shadow="md" width={280} position="bottom-end" withArrow>
+      <Menu.Target>
+        <button className="project-switcher-trigger" type="button" aria-label={`Current project: ${currentProject.name}`}>
+          <FolderKanban size={16} aria-hidden="true" />
+          <span className="project-switcher-trigger-label">{currentProject.name}</span>
+          <ChevronsUpDown size={14} aria-hidden="true" />
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>Project</Menu.Label>
+        {projects.map((project) => {
+          const isCurrent = project.projectId === currentProject.projectId;
+
+          return (
+            <Menu.Item
+              key={project.projectId}
+              leftSection={isCurrent ? <Check size={16} aria-hidden="true" /> : <FolderKanban size={16} aria-hidden="true" />}
+              disabled={isCurrent}
+              onClick={() => {
+                router.push(projectHref(project.projectId));
+              }}
+            >
+              <span className="project-switcher-item">
+                <Text component="span" size="sm" fw={700}>
+                  {project.name}
+                </Text>
+                <Text component="span" size="xs" c="dimmed">
+                  {projectContextLabel(project)}
+                </Text>
+              </span>
+            </Menu.Item>
+          );
+        })}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/project-switcher/routes.ts
+++ b/src/components/project-switcher/routes.ts
@@ -1,0 +1,37 @@
+export type ProjectSwitcherProject = {
+  projectId: string;
+  name: string;
+  slug: string;
+  githubAccount: string;
+  githubRepo: string;
+};
+
+export function projectIdFromPathname(pathname: string): string | null {
+  const [pathOnly] = pathname.split(/[?#]/, 1);
+  const segments = pathOnly.split("/").filter(Boolean);
+
+  if (segments[0] !== "projects" || !segments[1] || segments[1] === "new") {
+    return null;
+  }
+
+  return decodeURIComponent(segments[1]);
+}
+
+export function projectHref(projectId: string): string {
+  return `/projects/${encodeURIComponent(projectId)}`;
+}
+
+export function currentProjectFromPathname(projects: ProjectSwitcherProject[], pathname: string): ProjectSwitcherProject | null {
+  const projectId = projectIdFromPathname(pathname);
+  if (!projectId) return null;
+
+  return projects.find((project) => project.projectId === projectId) ?? null;
+}
+
+export function projectContextLabel(project: ProjectSwitcherProject): string {
+  if (project.githubAccount && project.githubRepo) {
+    return `${project.githubAccount}/${project.githubRepo}`;
+  }
+
+  return project.slug;
+}


### PR DESCRIPTION
Taskix workflow: WF-20260503-002
Issue: #153
## Summary
Implemented issue #153 on the expected branch after confirming the worktree was clean on main and there was no active PR. Added a compact project switcher in the header, wired sanitized project metadata from the root layout, hid the control outside matched project detail/nested routes, disabled the current project entry, and kept existing console/version actions intact. Committed and pushed cf7fc4bd8ca4a0bfcf40095ff0e1876c33ac8687 to origin/taskix/WF-20260503-002-issue-153. No PR was created per instruction.
## Changed Files
- src/app/layout.tsx
- src/app/globals.css
- src/components/HeaderSecondaryActions.tsx
- src/components/ProjectSwitcher.tsx
- src/components/project-switcher/routes.ts
- scripts/project-switcher.test.mjs
- scripts/header-label.test.mjs
- scripts/header-version.test.mjs
## Verification
- node --experimental-strip-types --test scripts/project-switcher.test.mjs scripts/header-label.test.mjs scripts/header-version.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #153