### PR TITLE
Add shared return navigation primitives for non-chat console pages

### DIFF
--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  isNonChatConsoleHref,
+  isProjectChatHref,
+  resolveConsoleNavAction,
+  resolveConsoleReturnDestination,
+  shouldRecordPriorConsoleDestination
+} from "../src/lib/return-navigation.ts";
+
+test("return destination prefers known prior page state", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/settings",
+    priorDestination: "/projects/project-a?workflow=wf-1",
+    recentProjectChats: [{ projectId: "project-b", createdAt: "2026-05-01T10:00:00.000Z" }]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/project-a?workflow=wf-1",
+    source: "prior"
+  });
+});
+
+test("return destination skips the current page and falls back to most recent project chat", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/settings",
+    priorDestination: "/settings",
+    recentProjectChats: [
+      { projectId: "older", createdAt: "2026-05-01T10:00:00.000Z" },
+      { projectId: "newer", createdAt: "2026-05-03T10:00:00.000Z" }
+    ]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/newer",
+    source: "recent-project-chat"
+  });
+});
+
+test("return destination uses stable fallback when no prior page or project chat is known", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/tools",
+    recentProjectChats: []
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects",
+    source: "fallback"
+  });
+});
+
+test("non-chat views do not replace the prior chat return target", () => {
+  assert.equal(shouldRecordPriorConsoleDestination("/projects/project-a"), true);
+  assert.equal(shouldRecordPriorConsoleDestination("/projects/project-a?workflow=wf-1"), true);
+  assert.equal(shouldRecordPriorConsoleDestination("/settings"), false);
+  assert.equal(shouldRecordPriorConsoleDestination("/projects/project-a?panel=tools"), false);
+  assert.equal(shouldRecordPriorConsoleDestination("/api/projects"), false);
+});
+
+test("project chat and non-chat paths are classified independently", () => {
+  assert.equal(isProjectChatHref("/projects/project-a"), true);
+  assert.equal(isProjectChatHref("/projects/project-a?panel=settings"), false);
+  assert.equal(isNonChatConsoleHref("/projects/project-a?panel=settings"), true);
+  assert.equal(isNonChatConsoleHref("/tools"), true);
+});
+
+test("active left-bottom navigation re-click resolves to shared return action", () => {
+  const action = resolveConsoleNavAction({
+    currentHref: "/projects/project-a?panel=tools",
+    itemHref: "/projects/project-a?panel=tools",
+    returnDestination: { href: "/projects/project-a", source: "prior" }
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});
+
+test("inactive left-bottom navigation opens the selected destination", () => {
+  const action = resolveConsoleNavAction({
+    currentHref: "/projects/project-a?panel=settings",
+    itemHref: "/projects/project-a?panel=tools",
+    returnDestination: { href: "/projects/project-a", source: "prior" }
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a?panel=tools",
+    active: false,
+    action: "open"
+  });
+});

--- a/src/components/console/ConsoleReturnLink.tsx
+++ b/src/components/console/ConsoleReturnLink.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@mantine/core";
+import { ArrowLeft } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import type { ConsoleReturnDestination } from "@/lib/return-navigation";
+
+export function ConsoleReturnLink({
+  destination,
+  children = "Back",
+  ...props
+}: {
+  destination: ConsoleReturnDestination;
+  children?: ReactNode;
+} & Omit<ComponentProps<typeof Button>, "component" | "href" | "leftSection" | "children">) {
+  return (
+    <Button component="a" href={destination.href} variant="subtle" leftSection={<ArrowLeft size={16} />} {...props}>
+      {children}
+    </Button>
+  );
+}

--- a/src/components/navigation/ConsoleNavLink.tsx
+++ b/src/components/navigation/ConsoleNavLink.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps, ReactNode } from "react";
+import { resolveConsoleNavAction, type ConsoleReturnDestination } from "@/lib/return-navigation";
+
+export function ConsoleNavLink({
+  currentHref,
+  href,
+  returnDestination,
+  className,
+  activeClassName = "active",
+  children,
+  ...props
+}: {
+  currentHref?: string | null;
+  href: string;
+  returnDestination: ConsoleReturnDestination;
+  className?: string;
+  activeClassName?: string;
+  children: ReactNode;
+} & Omit<ComponentProps<typeof Link>, "href" | "children" | "className">) {
+  const action = resolveConsoleNavAction({ currentHref, itemHref: href, returnDestination });
+  const resolvedClassName = action.active ? [className, activeClassName].filter(Boolean).join(" ") : className;
+
+  return (
+    <Link
+      {...props}
+      href={action.href}
+      className={resolvedClassName}
+      data-nav-action={action.action}
+      aria-current={action.active ? "page" : undefined}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/navigation/useConsoleReturnNavigation.ts
+++ b/src/components/navigation/useConsoleReturnNavigation.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  resolveConsoleReturnDestination,
+  shouldRecordPriorConsoleDestination,
+  type ConsoleReturnDestination,
+  type RecentProjectChat
+} from "@/lib/return-navigation";
+
+const storageKey = "gitdex.console.priorDestination";
+
+export function useConsoleReturnNavigation({
+  recentProjectChats = [],
+  fallbackHref
+}: {
+  recentProjectChats?: RecentProjectChat[];
+  fallbackHref?: string;
+} = {}): {
+  currentHref: string;
+  returnDestination: ConsoleReturnDestination;
+} {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentHref = useMemo(() => {
+    const search = searchParams.toString();
+    return search ? `${pathname}?${search}` : pathname;
+  }, [pathname, searchParams]);
+  const [priorDestination, setPriorDestination] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPriorDestination(window.sessionStorage.getItem(storageKey));
+  }, []);
+
+  useEffect(() => {
+    if (!shouldRecordPriorConsoleDestination(currentHref)) return;
+    window.sessionStorage.setItem(storageKey, currentHref);
+    setPriorDestination(currentHref);
+  }, [currentHref]);
+
+  return {
+    currentHref,
+    returnDestination: resolveConsoleReturnDestination({
+      currentHref,
+      priorDestination,
+      recentProjectChats,
+      fallbackHref
+    })
+  };
+}

--- a/src/lib/return-navigation.ts
+++ b/src/lib/return-navigation.ts
@@ -1,0 +1,125 @@
+export type ConsoleDestination = {
+  href: string;
+  label?: string;
+};
+
+export type RecentProjectChat = {
+  projectId: string;
+  latestAt?: string | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+};
+
+export type ConsoleReturnDestination = {
+  href: string;
+  source: "prior" | "recent-project-chat" | "fallback";
+};
+
+export type ConsoleNavAction = {
+  href: string;
+  active: boolean;
+  action: "open" | "return";
+};
+
+export const defaultConsoleReturnHref = "/projects";
+
+const nonChatConsolePaths = new Set(["/projects", "/projects/new", "/settings", "/tools"]);
+
+export function resolveConsoleReturnDestination(input: {
+  currentHref?: string | null;
+  priorDestination?: ConsoleDestination | string | null;
+  recentProjectChats?: RecentProjectChat[];
+  fallbackHref?: string;
+}): ConsoleReturnDestination {
+  const currentHref = normalizeConsoleHref(input.currentHref);
+  const priorHref = normalizeConsoleHref(typeof input.priorDestination === "string" ? input.priorDestination : input.priorDestination?.href);
+
+  if (priorHref && priorHref !== currentHref) {
+    return { href: priorHref, source: "prior" };
+  }
+
+  const recentChatHref = mostRecentProjectChatHref(input.recentProjectChats ?? []);
+  if (recentChatHref && recentChatHref !== currentHref) {
+    return { href: recentChatHref, source: "recent-project-chat" };
+  }
+
+  return { href: normalizeConsoleHref(input.fallbackHref) ?? defaultConsoleReturnHref, source: "fallback" };
+}
+
+export function resolveConsoleNavAction(input: {
+  currentHref?: string | null;
+  itemHref: string;
+  returnDestination: ConsoleReturnDestination;
+}): ConsoleNavAction {
+  const currentHref = normalizeConsoleHref(input.currentHref);
+  const itemHref = normalizeConsoleHref(input.itemHref) ?? input.itemHref;
+  const active = currentHref === itemHref;
+
+  return {
+    href: active ? input.returnDestination.href : itemHref,
+    active,
+    action: active ? "return" : "open"
+  };
+}
+
+export function shouldRecordPriorConsoleDestination(href: string | null | undefined): boolean {
+  const normalized = normalizeConsoleHref(href);
+  return Boolean(normalized && !isNonChatConsoleHref(normalized));
+}
+
+export function isProjectChatHref(href: string | null | undefined): boolean {
+  const normalized = normalizeConsoleHref(href);
+  if (!normalized) return false;
+
+  const { pathname, searchParams } = splitConsoleHref(normalized);
+  if (searchParams.has("panel")) return false;
+
+  const segments = pathname.split("/").filter(Boolean);
+  return segments.length === 2 && segments[0] === "projects" && segments[1] !== "new";
+}
+
+export function isNonChatConsoleHref(href: string | null | undefined): boolean {
+  const normalized = normalizeConsoleHref(href);
+  if (!normalized) return false;
+
+  const { pathname, searchParams } = splitConsoleHref(normalized);
+  if (searchParams.has("panel")) return true;
+  return nonChatConsolePaths.has(pathname);
+}
+
+export function normalizeConsoleHref(href: string | null | undefined): string | null {
+  if (!href) return null;
+
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+
+  try {
+    const url = new URL(trimmed, "http://gitdex.local");
+    if (url.origin !== "http://gitdex.local" && !trimmed.startsWith("/")) return null;
+    if (!url.pathname.startsWith("/")) return null;
+    if (url.pathname.startsWith("/api/") || url.pathname === "/api") return null;
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function mostRecentProjectChatHref(projects: RecentProjectChat[]): string | null {
+  const mostRecent = projects
+    .filter((project) => project.projectId)
+    .slice()
+    .sort((left, right) => timestampForProject(right) - timestampForProject(left))[0];
+
+  return mostRecent ? `/projects/${encodeURIComponent(mostRecent.projectId)}` : null;
+}
+
+function timestampForProject(project: RecentProjectChat): number {
+  const value = project.latestAt ?? project.updatedAt ?? project.createdAt;
+  const timestamp = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function splitConsoleHref(href: string): { pathname: string; searchParams: URLSearchParams } {
+  const url = new URL(href, "http://gitdex.local");
+  return { pathname: url.pathname, searchParams: url.searchParams };
+}


### PR DESCRIPTION
Gitdex workflow: R1
Issue: #160
## Summary
Implemented issue #160 on gitdex/R1-issue-160 and pushed commit 02be5a3. Added shared return-navigation selection/recording primitives, reusable console return/nav components, and focused tests. Restored generated next-env.d.ts noise after builds.
## Changed Files
- src/lib/return-navigation.ts
- src/components/navigation/ConsoleNavLink.tsx
- src/components/navigation/useConsoleReturnNavigation.ts
- src/components/console/ConsoleReturnLink.tsx
- scripts/return-navigation.test.mjs
## Verification
- node --experimental-strip-types --test scripts/return-navigation.test.mjs
- npm run typecheck
- npm run build
Closes #160