### PR TITLE
Wire project list return behavior

### DIFF
--- a/scripts/project-list-return-navigation.test.mjs
+++ b/scripts/project-list-return-navigation.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  resolveConsoleNavAction,
+  resolveConsoleReturnDestination
+} from "../src/lib/return-navigation.ts";
+
+test("project list return prefers known prior page state", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/projects",
+    priorDestination: "/projects/project-a",
+    recentProjectChats: [{ projectId: "project-b", latestAt: "2026-05-03T10:00:00.000Z" }]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/project-a",
+    source: "prior"
+  });
+});
+
+test("project list return falls back to the most recent project chat", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/projects",
+    recentProjectChats: [
+      { projectId: "older", latestAt: "2026-05-01T10:00:00.000Z" },
+      { projectId: "newer", latestAt: "2026-05-03T10:00:00.000Z" }
+    ]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/newer",
+    source: "recent-project-chat"
+  });
+});
+
+test("active project-list sidebar navigation re-click returns to the prior page", () => {
+  const action = resolveConsoleNavAction({
+    currentHref: "/projects/project-a?panel=projects",
+    itemHref: "/projects/project-a?panel=projects",
+    returnDestination: { href: "/projects/project-a", source: "prior" }
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});
+
+test("active project-list sidebar navigation falls back to current project chat", () => {
+  const returnDestination = resolveConsoleReturnDestination({
+    currentHref: "/projects/project-a?panel=projects",
+    recentProjectChats: [{ projectId: "project-a", latestAt: "2026-05-03T10:00:00.000Z" }]
+  });
+  const action = resolveConsoleNavAction({
+    currentHref: "/projects/project-a?panel=projects",
+    itemHref: "/projects/project-a?panel=projects",
+    returnDestination
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text, Title } from "@mantine/core";
-import { Archive, FolderKanban, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
+import { Archive, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunIssueAction } from "@/components/ProjectAutoRunIssueAction";
 import { ProjectAutoRunIssuesButton } from "@/components/ProjectAutoRunIssuesButton";
@@ -21,7 +21,8 @@ import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { RequirementDetailPanel } from "@/components/RequirementDetailPanel";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
-import { ProjectsPanel } from "@/components/ProjectsPanel";
+import { ProjectListSidebarLink } from "@/components/projects/ProjectListReturnControls";
+import { ProjectsPanel } from "@/components/projects/ProjectsPanel";
 import { SettingsPanel } from "@/components/SettingsPanel";
 import { ToolsPanel } from "@/components/ToolsPanel";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
@@ -378,14 +379,11 @@ function ProjectWorkspaceSidebar(input: {
           </Group>
           <Group gap={4} wrap="nowrap">
             <ProjectSyncForm projectId={project.projectId} compact />
-            <Link
-              href={`/projects/${project.projectId}?panel=projects`}
-              className={`sidebar-icon-link${input.activePanel === "projects" ? " active" : ""}`}
-              title="Projects"
-              aria-label="Projects"
-            >
-              <FolderKanban size={16} />
-            </Link>
+            <ProjectListSidebarLink
+              active={input.activePanel === "projects"}
+              projectId={project.projectId}
+              recentProjectChats={[{ projectId: project.projectId, createdAt: project.createdAt }]}
+            />
             <Link
               href={`/projects/${project.projectId}?panel=tools`}
               className={`sidebar-icon-link${input.activePanel === "tools" ? " active" : ""}`}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,4 @@
-import { ProjectsPanel } from "@/components/ProjectsPanel";
+import { ProjectsPanel } from "@/components/projects/ProjectsPanel";
 import { requireConsolePageAuth } from "@/lib/console-auth";
 
 export default async function ProjectsPage({ searchParams }: { searchParams: Promise<{ message?: string; error?: string }> }) {

--- a/src/components/projects/ProjectListReturnControls.tsx
+++ b/src/components/projects/ProjectListReturnControls.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Group } from "@mantine/core";
+import { FolderKanban } from "lucide-react";
+import type { ReactNode } from "react";
+import { ConsoleReturnLink } from "@/components/console/ConsoleReturnLink";
+import { ConsoleNavLink } from "@/components/navigation/ConsoleNavLink";
+import { useConsoleReturnNavigation } from "@/components/navigation/useConsoleReturnNavigation";
+import type { RecentProjectChat } from "@/lib/return-navigation";
+
+export function ProjectListReturnControl({ recentProjectChats }: { recentProjectChats: RecentProjectChat[] }) {
+  const { returnDestination } = useConsoleReturnNavigation({ recentProjectChats });
+
+  return (
+    <ConsoleReturnLink destination={returnDestination}>
+      Back
+    </ConsoleReturnLink>
+  );
+}
+
+export function ProjectListSidebarLink({
+  active,
+  projectId,
+  recentProjectChats
+}: {
+  active: boolean;
+  projectId: string;
+  recentProjectChats: RecentProjectChat[];
+}) {
+  const { currentHref, returnDestination } = useConsoleReturnNavigation({ recentProjectChats });
+  const projectListHref = `/projects/${projectId}?panel=projects`;
+
+  return (
+    <ConsoleNavLink
+      href={projectListHref}
+      currentHref={active ? projectListHref : currentHref}
+      returnDestination={returnDestination}
+      className="sidebar-icon-link"
+      title="Projects"
+      aria-label="Projects"
+    >
+      <FolderKanban size={16} />
+    </ConsoleNavLink>
+  );
+}
+
+export function ProjectListHeaderActions({
+  recentProjectChats,
+  children
+}: {
+  recentProjectChats: RecentProjectChat[];
+  children: ReactNode;
+}) {
+  return (
+    <Group gap="xs" wrap="nowrap">
+      <ProjectListReturnControl recentProjectChats={recentProjectChats} />
+      {children}
+    </Group>
+  );
+}

--- a/src/components/projects/ProjectsPanel.tsx
+++ b/src/components/projects/ProjectsPanel.tsx
@@ -1,0 +1,54 @@
+import { Alert, Button, Group, Paper, Text } from "@mantine/core";
+import { FolderPlus, Info } from "lucide-react";
+import { PageTitle } from "@/components/PageTitle";
+import { ProjectsTable } from "@/components/Tables";
+import { listProjects, listWorkflows } from "@/lib/store";
+import { ProjectListHeaderActions } from "./ProjectListReturnControls";
+
+export async function ProjectsPanel({ message, error }: { message?: string; error?: string }) {
+  const [projects, workflows] = await Promise.all([listProjects(), listWorkflows()]);
+  const latestWorkflowByProject = new Map<string, string>();
+  for (const workflow of workflows) {
+    if (!workflow.projectId) continue;
+    const current = latestWorkflowByProject.get(workflow.projectId);
+    if (!current || workflow.createdAt > current) latestWorkflowByProject.set(workflow.projectId, workflow.createdAt);
+  }
+  const projectsWithLatest = projects
+    .map((project) => ({
+      ...project,
+      latestAt: latestWorkflowByProject.get(project.projectId) ?? project.createdAt
+    }))
+    .sort((a, b) => b.latestAt.localeCompare(a.latestAt));
+  const recentProjectChats = projectsWithLatest.map((project) => ({
+    projectId: project.projectId,
+    latestAt: project.latestAt,
+    createdAt: project.createdAt
+  }));
+
+  return (
+    <>
+      <PageTitle title="Projects" />
+      {(message || error) && (
+        <Alert color={error ? "red" : "blue"} icon={<Info size={16} />} mb="md">
+          {message ?? error}
+        </Alert>
+      )}
+      <Paper>
+        <Group justify="space-between" p="md" className="section-header">
+          <div>
+            <Text fw={760}>Projects</Text>
+            <Text size="sm" c="dimmed">
+              Switch project context from the left sidebar, or add a new GitHub-backed project.
+            </Text>
+          </div>
+          <ProjectListHeaderActions recentProjectChats={recentProjectChats}>
+            <Button component="a" href="/projects/new" leftSection={<FolderPlus size={16} />}>
+              Add Project
+            </Button>
+          </ProjectListHeaderActions>
+        </Group>
+        <ProjectsTable projects={projectsWithLatest} />
+      </Paper>
+    </>
+  );
+}


### PR DESCRIPTION
Gitdex workflow: R1
Issue: #162
## Summary
Read GitHub issue #162, labels, PR search, and timeline with gh. No linked PRs or comments existed; worktree was clean on main, so I created and pushed the expected branch gitdex/R1-issue-162. Implemented project-list return navigation in owned scope: added an owned ProjectsPanel with a visible Back control using shared console return behavior, wired /projects and the project-list workspace panel to it, and changed the active project-list sidebar button to resolve a re-click through the shared return action with fallback to the current/recent project chat. Restored Next-generated next-env.d.ts noise after builds. Commit pushed: de6fb0c8e98ec817a8bf22d8c670f93517018a65.
## Changed Files
- src/app/projects/[projectId]/page.tsx
- src/app/projects/page.tsx
- src/components/projects/ProjectListReturnControls.tsx
- src/components/projects/ProjectsPanel.tsx
- scripts/project-list-return-navigation.test.mjs
## Verification
- node --experimental-strip-types scripts/project-list-return-navigation.test.mjs
- git diff --check
- npm run typecheck
- npm test
- npm run build
Closes #162