### PR TITLE
Wire tools page return behavior across project workspace tools

### DIFF
--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -134,6 +134,20 @@ test("active project workspace panel nav preserves encoded project id", () => {
   });
 });
 
+test("active project workspace projects nav ignores stale prior destinations", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project-a",
+    panel: "projects",
+    activePanel: "projects"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});
+
 test("inactive project workspace panel nav opens the requested panel for the same project", () => {
   const action = resolveProjectWorkspacePanelNavAction({
     projectId: "project-a",

--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -107,6 +107,20 @@ test("active project workspace panel nav re-click returns to the same project wo
   });
 });
 
+test("active project workspace panel nav preserves encoded project id", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project/a",
+    panel: "settings",
+    activePanel: "settings"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project%2Fa",
+    active: true,
+    action: "return"
+  });
+});
+
 test("inactive project workspace panel nav opens the requested panel for the same project", () => {
   const action = resolveProjectWorkspacePanelNavAction({
     projectId: "project-a",

--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -5,6 +5,7 @@ import {
   isProjectChatHref,
   resolveConsoleNavAction,
   resolveConsoleReturnDestination,
+  resolveProjectWorkspacePanelNavAction,
   shouldRecordPriorConsoleDestination
 } from "../src/lib/return-navigation.ts";
 
@@ -87,6 +88,34 @@ test("inactive left-bottom navigation opens the selected destination", () => {
 
   assert.deepEqual(action, {
     href: "/projects/project-a?panel=tools",
+    active: false,
+    action: "open"
+  });
+});
+
+test("active project workspace panel nav re-click returns to the same project workspace", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project-a",
+    panel: "tools",
+    activePanel: "tools"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});
+
+test("inactive project workspace panel nav opens the requested panel for the same project", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project-a",
+    panel: "settings",
+    activePanel: "tools"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a?panel=settings",
     active: false,
     action: "open"
   });

--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -161,3 +161,17 @@ test("inactive project workspace panel nav opens the requested panel for the sam
     action: "open"
   });
 });
+
+test("inactive project workspace panel nav preserves encoded project id", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project/a",
+    panel: "tools",
+    activePanel: "settings"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project%2Fa?panel=tools",
+    active: false,
+    action: "open"
+  });
+});

--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -148,6 +148,20 @@ test("active project workspace projects nav ignores stale prior destinations", (
   });
 });
 
+test("active project workspace requirements nav returns to the same project workspace", () => {
+  const action = resolveProjectWorkspacePanelNavAction({
+    projectId: "project-a",
+    panel: "requirements",
+    activePanel: "requirements"
+  });
+
+  assert.deepEqual(action, {
+    href: "/projects/project-a",
+    active: true,
+    action: "return"
+  });
+});
+
 test("inactive project workspace panel nav opens the requested panel for the same project", () => {
   const action = resolveProjectWorkspacePanelNavAction({
     projectId: "project-a",

--- a/scripts/settings-return-navigation.test.mjs
+++ b/scripts/settings-return-navigation.test.mjs
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   shouldAllowBrowserSettingsReturnNavigation,
   settingsReturnDirtyPrompt,
+  shouldGuardWorkspaceSettingsReturn,
   shouldAllowSettingsReturnNavigation
 } from "../src/components/settings/settings-return-policy.ts";
 
@@ -42,6 +43,14 @@ test("settings return navigation proceeds when unsaved confirmation is accepted"
   });
 
   assert.equal(allowed, true);
+});
+
+test("workspace settings back control is guarded by dirty settings confirmation", () => {
+  assert.equal(shouldGuardWorkspaceSettingsReturn({ panel: "settings" }), true);
+  assert.equal(shouldGuardWorkspaceSettingsReturn({ panel: "tools" }), false);
+  assert.equal(shouldGuardWorkspaceSettingsReturn({ panel: "projects" }), false);
+  assert.equal(shouldGuardWorkspaceSettingsReturn({ panel: "requirements" }), false);
+  assert.equal(shouldGuardWorkspaceSettingsReturn({ panel: null }), false);
 });
 
 test("browser settings return confirmation preserves the window receiver", () => {

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -23,6 +23,7 @@ import { RequirementDetailPanel } from "@/components/RequirementDetailPanel";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
 import { ProjectsPanel } from "@/components/projects/ProjectsPanel";
 import { SettingsPanel } from "@/components/SettingsPanel";
+import { shouldGuardWorkspaceSettingsReturn } from "@/components/settings/settings-return-policy";
 import { ToolsPanel } from "@/components/ToolsPanel";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { getAutoRunState } from "@/lib/auto-run-control";
@@ -195,11 +196,18 @@ function normalizeWorkspacePanel(value: string | undefined): WorkspacePanel | nu
 function WorkspacePanelContent({ panel, project, projects, workflows, jobs, message, error }: { panel: WorkspacePanel; project: ProjectRecord; projects: ProjectRecord[]; workflows: WorkflowRecord[]; jobs: JobRecord[]; message?: string; error?: string }) {
   const workspaceHref = `/projects/${encodeURIComponent(project.projectId)}`;
   const returnTo = `${workspaceHref}?panel=${panel}`;
+  const guardSettingsReturn = shouldGuardWorkspaceSettingsReturn({ panel });
   const recentProjectChats = projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }));
   return (
     <div className="workspace-panel-content">
       <Group justify="flex-start" mb="md">
-        <Button component="a" href={workspaceHref} variant="subtle" leftSection={<ArrowLeft size={16} />}>
+        <Button
+          component="a"
+          href={workspaceHref}
+          variant="subtle"
+          leftSection={<ArrowLeft size={16} />}
+          data-settings-return-action={guardSettingsReturn ? true : undefined}
+        >
           Back to workspace
         </Button>
       </Group>

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -193,8 +193,8 @@ function normalizeWorkspacePanel(value: string | undefined): WorkspacePanel | nu
 }
 
 function WorkspacePanelContent({ panel, project, projects, workflows, jobs, message, error }: { panel: WorkspacePanel; project: ProjectRecord; projects: ProjectRecord[]; workflows: WorkflowRecord[]; jobs: JobRecord[]; message?: string; error?: string }) {
-  const returnTo = `/projects/${project.projectId}?panel=${panel}`;
-  const workspaceHref = `/projects/${project.projectId}`;
+  const workspaceHref = `/projects/${encodeURIComponent(project.projectId)}`;
+  const returnTo = `${workspaceHref}?panel=${panel}`;
   const recentProjectChats = projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }));
   return (
     <div className="workspace-panel-content">
@@ -205,7 +205,7 @@ function WorkspacePanelContent({ panel, project, projects, workflows, jobs, mess
       </Group>
       {panel === "projects" ? <ProjectsPanel message={message} error={error} /> : null}
       {panel === "tools" ? <ToolsPanel /> : null}
-      {panel === "settings" ? <SettingsPanel message={message} error={error} returnTo={returnTo} toolsHref={`/projects/${project.projectId}?panel=tools`} recentProjectChats={recentProjectChats} /> : null}
+      {panel === "settings" ? <SettingsPanel message={message} error={error} returnTo={returnTo} toolsHref={`${workspaceHref}?panel=tools`} recentProjectChats={recentProjectChats} /> : null}
       {panel === "requirements" ? <RequirementsPanelContent project={project} workflows={workflows} jobs={jobs} message={message} error={error} /> : null}
     </div>
   );

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text, Title } from "@mantine/core";
-import { Archive, ArrowLeft, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
+import { Archive, ArrowLeft, FolderKanban, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunIssueAction } from "@/components/ProjectAutoRunIssueAction";
 import { ProjectAutoRunIssuesButton } from "@/components/ProjectAutoRunIssuesButton";
@@ -21,7 +21,6 @@ import { ProjectRunJobsForm } from "@/components/ProjectRunJobsForm";
 import { ProjectSyncForm } from "@/components/ProjectSyncForm";
 import { RequirementDetailPanel } from "@/components/RequirementDetailPanel";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
-import { ProjectListSidebarLink } from "@/components/projects/ProjectListReturnControls";
 import { ProjectsPanel } from "@/components/projects/ProjectsPanel";
 import { SettingsPanel } from "@/components/SettingsPanel";
 import { ToolsPanel } from "@/components/ToolsPanel";
@@ -129,7 +128,6 @@ export default async function ProjectDetailPage({
           autorunEnabled={query.autorun === "1"}
           activePanel={activePanel}
           switcherProjects={switcherProjects}
-          recentProjectChats={projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }))}
           ghUserLogin={ghUserLogin}
         />
 
@@ -310,11 +308,11 @@ function ProjectWorkspaceSidebar(input: {
   autorunEnabled: boolean;
   activePanel: WorkspacePanel | null;
   switcherProjects: ComponentProps<typeof ProjectSwitcher>["projects"];
-  recentProjectChats: { projectId: string; createdAt?: string | null }[];
   ghUserLogin: string | null;
 }) {
   const project = input.project;
   const draftWorkflow = input.requirementWorkflows.find((workflow) => isDiscardableDraftWorkflow(project.projectId, workflow)) ?? null;
+  const projectsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "projects", activePanel: input.activePanel });
   const toolsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "tools", activePanel: input.activePanel });
   const settingsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "settings", activePanel: input.activePanel });
 
@@ -391,11 +389,15 @@ function ProjectWorkspaceSidebar(input: {
           </Group>
           <Group gap={4} wrap="nowrap">
             <ProjectSyncForm projectId={project.projectId} compact />
-            <ProjectListSidebarLink
-              active={input.activePanel === "projects"}
-              projectId={project.projectId}
-              recentProjectChats={[{ projectId: project.projectId, createdAt: project.createdAt }]}
-            />
+            <Link
+              href={projectsPanelAction.href}
+              className={`sidebar-icon-link${projectsPanelAction.active ? " active" : ""}`}
+              title="Projects"
+              aria-label="Projects"
+              data-nav-action={projectsPanelAction.action}
+            >
+              <FolderKanban size={16} />
+            </Link>
             <Link
               href={toolsPanelAction.href}
               className={`sidebar-icon-link${toolsPanelAction.active ? " active" : ""}`}

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -198,7 +198,7 @@ function WorkspacePanelContent({ panel, project, workflows, jobs, message, error
   return (
     <div className="workspace-panel-content">
       <Group justify="flex-start" mb="md">
-        <Button component={Link} href={workspaceHref} variant="subtle" leftSection={<ArrowLeft size={16} />}>
+        <Button component="a" href={workspaceHref} variant="subtle" leftSection={<ArrowLeft size={16} />}>
           Back to workspace
         </Button>
       </Group>

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Alert, Badge, Button, Code, Group, Paper, Stack, Text, Title } from "@mantine/core";
-import { Archive, FolderKanban, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
+import { Archive, ArrowLeft, FolderKanban, GitBranch, Info, ListTodo, Plus, RefreshCw, RotateCcw, Settings, Trash2, UserCircle, Wrench } from "lucide-react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { ProjectAutoRunIssueAction } from "@/components/ProjectAutoRunIssueAction";
 import { ProjectAutoRunIssuesButton } from "@/components/ProjectAutoRunIssuesButton";
@@ -34,6 +34,7 @@ import { findReadyForPlannerPayload, formatPmHandoffPayload } from "@/lib/pm-han
 import { findDependencyIssue, isDependencySatisfied } from "@/lib/issue-dependencies";
 import { getIssueStage, type IssueStage } from "@/lib/issue-stage";
 import { getIssueQaStatus } from "@/lib/qa-status";
+import { resolveProjectWorkspacePanelNavAction, type ProjectWorkspacePanel } from "@/lib/return-navigation";
 import { getAgentSession, getProject, listAgentSessions, listJobs, listProjectWorkflows, listProjects } from "@/lib/store";
 import type { AgentSessionRecord, IssueRecord, JobRecord, ProjectRecord, WorkflowRecord } from "@/lib/types";
 import type { AutoRunState } from "@/lib/auto-run-control";
@@ -184,7 +185,7 @@ function findWorkflowPmSession(sessions: AgentSessionRecord[], projectId: string
 }
 
 type WorkflowPhase = "requirements" | "github" | "operations";
-type WorkspacePanel = "projects" | "tools" | "settings" | "requirements";
+type WorkspacePanel = ProjectWorkspacePanel;
 
 function normalizeWorkspacePanel(value: string | undefined): WorkspacePanel | null {
   if (value === "projects" || value === "tools" || value === "settings" || value === "requirements") return value;
@@ -193,8 +194,14 @@ function normalizeWorkspacePanel(value: string | undefined): WorkspacePanel | nu
 
 function WorkspacePanelContent({ panel, project, workflows, jobs, message, error }: { panel: WorkspacePanel; project: ProjectRecord; workflows: WorkflowRecord[]; jobs: JobRecord[]; message?: string; error?: string }) {
   const returnTo = `/projects/${project.projectId}?panel=${panel}`;
+  const workspaceHref = `/projects/${project.projectId}`;
   return (
     <div className="workspace-panel-content">
+      <Group justify="flex-start" mb="md">
+        <Button component={Link} href={workspaceHref} variant="subtle" leftSection={<ArrowLeft size={16} />}>
+          Back to workspace
+        </Button>
+      </Group>
       {panel === "projects" ? <ProjectsPanel message={message} error={error} /> : null}
       {panel === "tools" ? <ToolsPanel /> : null}
       {panel === "settings" ? <SettingsPanel message={message} error={error} returnTo={returnTo} toolsHref={`/projects/${project.projectId}?panel=tools`} /> : null}
@@ -304,6 +311,9 @@ function ProjectWorkspaceSidebar(input: {
 }) {
   const project = input.project;
   const draftWorkflow = input.requirementWorkflows.find((workflow) => isDiscardableDraftWorkflow(project.projectId, workflow)) ?? null;
+  const projectsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "projects", activePanel: input.activePanel });
+  const toolsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "tools", activePanel: input.activePanel });
+  const settingsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "settings", activePanel: input.activePanel });
 
   return (
     <aside className="project-workspace-sidebar" aria-label="Project workspace">
@@ -379,18 +389,20 @@ function ProjectWorkspaceSidebar(input: {
           <Group gap={4} wrap="nowrap">
             <ProjectSyncForm projectId={project.projectId} compact />
             <Link
-              href={`/projects/${project.projectId}?panel=projects`}
-              className={`sidebar-icon-link${input.activePanel === "projects" ? " active" : ""}`}
+              href={projectsPanelAction.href}
+              className={`sidebar-icon-link${projectsPanelAction.active ? " active" : ""}`}
               title="Projects"
               aria-label="Projects"
+              data-nav-action={projectsPanelAction.action}
             >
               <FolderKanban size={16} />
             </Link>
             <Link
-              href={`/projects/${project.projectId}?panel=tools`}
-              className={`sidebar-icon-link${input.activePanel === "tools" ? " active" : ""}`}
+              href={toolsPanelAction.href}
+              className={`sidebar-icon-link${toolsPanelAction.active ? " active" : ""}`}
               title="Tools"
               aria-label="Tools"
+              data-nav-action={toolsPanelAction.action}
             >
               <Wrench size={16} />
             </Link>
@@ -403,10 +415,11 @@ function ProjectWorkspaceSidebar(input: {
               <ListTodo size={16} />
             </Link>
             <Link
-              href={`/projects/${project.projectId}?panel=settings`}
-              className={`sidebar-icon-link${input.activePanel === "settings" ? " active" : ""}`}
+              href={settingsPanelAction.href}
+              className={`sidebar-icon-link${settingsPanelAction.active ? " active" : ""}`}
               title="Settings"
               aria-label="Settings"
+              data-nav-action={settingsPanelAction.action}
             >
               <Settings size={16} />
             </Link>

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -313,6 +313,7 @@ function ProjectWorkspaceSidebar(input: {
   const project = input.project;
   const draftWorkflow = input.requirementWorkflows.find((workflow) => isDiscardableDraftWorkflow(project.projectId, workflow)) ?? null;
   const projectsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "projects", activePanel: input.activePanel });
+  const requirementsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "requirements", activePanel: input.activePanel });
   const toolsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "tools", activePanel: input.activePanel });
   const settingsPanelAction = resolveProjectWorkspacePanelNavAction({ projectId: project.projectId, panel: "settings", activePanel: input.activePanel });
 
@@ -360,8 +361,9 @@ function ProjectWorkspaceSidebar(input: {
           <Group justify="space-between" gap="xs" mb="xs" wrap="nowrap">
             <Text size="xs" fw={820} tt="uppercase" c="dimmed">Requirements</Text>
             <Link
-              href={`/projects/${project.projectId}?panel=requirements`}
-              className={`sidebar-pill-link${input.activePanel === "requirements" ? " active" : ""}`}
+              href={requirementsPanelAction.href}
+              className={`sidebar-pill-link${requirementsPanelAction.active ? " active" : ""}`}
+              data-nav-action={requirementsPanelAction.action}
             >
               View all
             </Link>

--- a/src/components/settings/settings-return-policy.ts
+++ b/src/components/settings/settings-return-policy.ts
@@ -1,5 +1,9 @@
 export const settingsReturnDirtyPrompt = "You have unsaved settings changes. Leave without saving?";
 
+export function shouldGuardWorkspaceSettingsReturn(input: { panel: string | null }): boolean {
+  return input.panel === "settings";
+}
+
 export function shouldAllowSettingsReturnNavigation(input: {
   isDirty: boolean;
   confirmLeave: (message: string) => boolean;

--- a/src/lib/return-navigation.ts
+++ b/src/lib/return-navigation.ts
@@ -21,6 +21,8 @@ export type ConsoleNavAction = {
   action: "open" | "return";
 };
 
+export type ProjectWorkspacePanel = "projects" | "tools" | "settings" | "requirements";
+
 export const defaultConsoleReturnHref = "/projects";
 
 const nonChatConsolePaths = new Set(["/projects", "/projects/new", "/settings", "/tools"]);
@@ -57,6 +59,22 @@ export function resolveConsoleNavAction(input: {
 
   return {
     href: active ? input.returnDestination.href : itemHref,
+    active,
+    action: active ? "return" : "open"
+  };
+}
+
+export function resolveProjectWorkspacePanelNavAction(input: {
+  projectId: string;
+  panel: ProjectWorkspacePanel;
+  activePanel?: ProjectWorkspacePanel | null;
+}): ConsoleNavAction {
+  const workspaceHref = `/projects/${encodeURIComponent(input.projectId)}`;
+  const panelHref = `${workspaceHref}?panel=${input.panel}`;
+  const active = input.activePanel === input.panel;
+
+  return {
+    href: active ? workspaceHref : panelHref,
     active,
     action: active ? "return" : "open"
   };


### PR DESCRIPTION
Gitdex workflow: R1
Issue: #163
## Summary
Implemented issue #163 on gitdex/R1-issue-163. Added project workspace panel return behavior so panel surfaces show a Back to workspace control, active bottom panel nav re-clicks return to /projects/{projectId}, and switching to a different panel still opens that panel. Added deterministic helper coverage in return-navigation tests. Restored build-generated next-env.d.ts noise before committing. Pushed commit 1cda155.
## Changed Files
- src/app/projects/[projectId]/page.tsx
- src/lib/return-navigation.ts
- scripts/return-navigation.test.mjs
## Verification
- node --experimental-strip-types --test scripts/return-navigation.test.mjs
- npm run typecheck
- npm test
- npm run build
Closes #163