### PR TITLE
Wire settings return behavior with unsaved-change confirmation

### DIFF
--- a/scripts/return-navigation.test.mjs
+++ b/scripts/return-navigation.test.mjs
@@ -49,6 +49,19 @@ test("return destination uses stable fallback when no prior page or project chat
   });
 });
 
+test("return destination ignores invalid prior page before checking recent project chat", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/settings",
+    priorDestination: "https://example.com/projects/external",
+    recentProjectChats: [{ projectId: "project-a", createdAt: "2026-05-01T10:00:00.000Z" }]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/project-a",
+    source: "recent-project-chat"
+  });
+});
+
 test("non-chat views do not replace the prior chat return target", () => {
   assert.equal(shouldRecordPriorConsoleDestination("/projects/project-a"), true);
   assert.equal(shouldRecordPriorConsoleDestination("/projects/project-a?workflow=wf-1"), true);

--- a/scripts/settings-return-navigation.test.mjs
+++ b/scripts/settings-return-navigation.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  settingsReturnDirtyPrompt,
+  shouldAllowSettingsReturnNavigation
+} from "../src/components/settings/settings-return-policy.ts";
+
+test("settings return navigation proceeds without prompting when forms are unchanged", () => {
+  let prompted = false;
+  const allowed = shouldAllowSettingsReturnNavigation({
+    isDirty: false,
+    confirmLeave: () => {
+      prompted = true;
+      return false;
+    }
+  });
+
+  assert.equal(allowed, true);
+  assert.equal(prompted, false);
+});
+
+test("settings return navigation is prevented when unsaved confirmation is cancelled", () => {
+  const allowed = shouldAllowSettingsReturnNavigation({
+    isDirty: true,
+    confirmLeave: (message) => {
+      assert.equal(message, settingsReturnDirtyPrompt);
+      return false;
+    }
+  });
+
+  assert.equal(allowed, false);
+});
+
+test("settings return navigation proceeds when unsaved confirmation is accepted", () => {
+  const allowed = shouldAllowSettingsReturnNavigation({
+    isDirty: true,
+    confirmLeave: (message) => {
+      assert.equal(message, settingsReturnDirtyPrompt);
+      return true;
+    }
+  });
+
+  assert.equal(allowed, true);
+});

--- a/scripts/settings-return-navigation.test.mjs
+++ b/scripts/settings-return-navigation.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  shouldAllowBrowserSettingsReturnNavigation,
   settingsReturnDirtyPrompt,
   shouldAllowSettingsReturnNavigation
 } from "../src/components/settings/settings-return-policy.ts";
@@ -41,4 +42,34 @@ test("settings return navigation proceeds when unsaved confirmation is accepted"
   });
 
   assert.equal(allowed, true);
+});
+
+test("browser settings return confirmation preserves the window receiver", () => {
+  const previousWindow = globalThis.window;
+  const fakeWindow = {
+    confirm(message) {
+      assert.equal(this, fakeWindow);
+      assert.equal(message, settingsReturnDirtyPrompt);
+      return false;
+    }
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: fakeWindow,
+    configurable: true
+  });
+
+  try {
+    const allowed = shouldAllowBrowserSettingsReturnNavigation({ isDirty: true });
+    assert.equal(allowed, false);
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      Object.defineProperty(globalThis, "window", {
+        value: previousWindow,
+        configurable: true
+      });
+    }
+  }
 });

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -23,6 +23,7 @@ import { RequirementDetailPanel } from "@/components/RequirementDetailPanel";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
 import { ProjectsPanel } from "@/components/ProjectsPanel";
 import { SettingsPanel } from "@/components/SettingsPanel";
+import { ProjectSettingsSidebarLink } from "@/components/settings/SettingsReturnNavigation";
 import { ToolsPanel } from "@/components/ToolsPanel";
 import { WorkflowPauseButton } from "@/components/WorkflowPauseButton";
 import { getAutoRunState } from "@/lib/auto-run-control";
@@ -127,12 +128,13 @@ export default async function ProjectDetailPage({
           autorunEnabled={query.autorun === "1"}
           activePanel={activePanel}
           switcherProjects={switcherProjects}
+          recentProjectChats={projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }))}
           ghUserLogin={ghUserLogin}
         />
 
         <main className="chat-panel">
           {activePanel ? (
-            <WorkspacePanelContent panel={activePanel} project={project} workflows={sortedWorkflows} jobs={jobs} message={query.message} error={query.error} />
+            <WorkspacePanelContent panel={activePanel} project={project} projects={projects} workflows={sortedWorkflows} jobs={jobs} message={query.message} error={query.error} />
           ) : (
             <ProjectChatArea projectId={project.projectId} sessions={chatSessions} jobs={workflowPanelJobs.length ? workflowPanelJobs : jobs} workflows={workflowPanelWorkflows.length ? workflowPanelWorkflows : workflows} activeWorkflowId={latestWorkflow?.workflowId ?? null} inspectedSession={activeSession} readOnly={isInspectingIssueSession} />
           )}
@@ -191,13 +193,14 @@ function normalizeWorkspacePanel(value: string | undefined): WorkspacePanel | nu
   return null;
 }
 
-function WorkspacePanelContent({ panel, project, workflows, jobs, message, error }: { panel: WorkspacePanel; project: ProjectRecord; workflows: WorkflowRecord[]; jobs: JobRecord[]; message?: string; error?: string }) {
+function WorkspacePanelContent({ panel, project, projects, workflows, jobs, message, error }: { panel: WorkspacePanel; project: ProjectRecord; projects: ProjectRecord[]; workflows: WorkflowRecord[]; jobs: JobRecord[]; message?: string; error?: string }) {
   const returnTo = `/projects/${project.projectId}?panel=${panel}`;
+  const recentProjectChats = projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }));
   return (
     <div className="workspace-panel-content">
       {panel === "projects" ? <ProjectsPanel message={message} error={error} /> : null}
       {panel === "tools" ? <ToolsPanel /> : null}
-      {panel === "settings" ? <SettingsPanel message={message} error={error} returnTo={returnTo} toolsHref={`/projects/${project.projectId}?panel=tools`} /> : null}
+      {panel === "settings" ? <SettingsPanel message={message} error={error} returnTo={returnTo} toolsHref={`/projects/${project.projectId}?panel=tools`} recentProjectChats={recentProjectChats} /> : null}
       {panel === "requirements" ? <RequirementsPanelContent project={project} workflows={workflows} jobs={jobs} message={message} error={error} /> : null}
     </div>
   );
@@ -300,6 +303,7 @@ function ProjectWorkspaceSidebar(input: {
   autorunEnabled: boolean;
   activePanel: WorkspacePanel | null;
   switcherProjects: ComponentProps<typeof ProjectSwitcher>["projects"];
+  recentProjectChats: { projectId: string; createdAt?: string | null }[];
   ghUserLogin: string | null;
 }) {
   const project = input.project;
@@ -402,14 +406,13 @@ function ProjectWorkspaceSidebar(input: {
             >
               <ListTodo size={16} />
             </Link>
-            <Link
-              href={`/projects/${project.projectId}?panel=settings`}
-              className={`sidebar-icon-link${input.activePanel === "settings" ? " active" : ""}`}
-              title="Settings"
-              aria-label="Settings"
+            <ProjectSettingsSidebarLink
+              projectId={project.projectId}
+              active={input.activePanel === "settings"}
+              recentProjectChats={input.recentProjectChats}
             >
               <Settings size={16} />
-            </Link>
+            </ProjectSettingsSidebarLink>
           </Group>
         </Group>
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,10 +1,12 @@
 import { SettingsPanel } from "@/components/SettingsPanel";
 import { requireConsolePageAuth } from "@/lib/console-auth";
+import { listProjects } from "@/lib/store";
 
 export default async function SettingsPage({ searchParams }: { searchParams: Promise<{ message?: string; error?: string }> }) {
   const { message, error } = await searchParams;
   await requireConsolePageAuth(buildSettingsNextPath({ message, error }));
-  return <SettingsPanel message={message} error={error} />;
+  const projects = await listProjects();
+  return <SettingsPanel message={message} error={error} recentProjectChats={projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }))} />;
 }
 
 function buildSettingsNextPath({ message, error }: { message?: string; error?: string }): string {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,18 +1,22 @@
 import { Alert, Badge, Button, Checkbox, Code, Group, NumberInput, Paper, PasswordInput, SimpleGrid, Text, TextInput, Textarea } from "@mantine/core";
 import { GitBranch, Info, KeyRound, Save, Trash2, Webhook, Wrench } from "lucide-react";
 import { PageTitle } from "@/components/PageTitle";
+import { SettingsReturnNavigation } from "@/components/settings/SettingsReturnNavigation";
 import { getSettings } from "@/lib/settings";
+import type { RecentProjectChat } from "@/lib/return-navigation";
 
 export async function SettingsPanel({
   message,
   error,
   returnTo,
-  toolsHref = "/tools"
+  toolsHref = "/tools",
+  recentProjectChats = []
 }: {
   message?: string;
   error?: string;
   returnTo?: string;
   toolsHref?: string;
+  recentProjectChats?: RecentProjectChat[];
 }) {
   const settings = await getSettings();
   const hasGitHubKey = Boolean(settings.githubUsername && settings.githubSshPrivateKeyPath && settings.githubSshPublicKey);
@@ -20,6 +24,9 @@ export async function SettingsPanel({
   return (
     <>
       <PageTitle title="Settings" />
+      <Group justify="flex-start" mb="md">
+        <SettingsReturnNavigation recentProjectChats={recentProjectChats} />
+      </Group>
       {(message || error) && (
         <Alert color={error ? "red" : "blue"} icon={<Info size={16} />} mb="md">
           {message ?? error}
@@ -51,7 +58,7 @@ export async function SettingsPanel({
           </div>
         </Group>
         <div className="panel-body">
-          <form method="post" action="/api/github/account">
+          <form method="post" action="/api/github/account" data-settings-form>
             <ReturnToInput returnTo={returnTo} />
             <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
               <TextInput name="githubUsername" label="GitHub Owner" description="User or organization, for example octocat or my-org." defaultValue={settings.githubUsername} placeholder="owner-or-org" required />
@@ -94,7 +101,7 @@ export async function SettingsPanel({
           </div>
         </Group>
         <div className="panel-body">
-          <form method="post" action="/api/settings">
+          <form method="post" action="/api/settings" data-settings-form>
             <ReturnToInput returnTo={returnTo} />
             <Text className="section-title">App</Text>
             <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">

--- a/src/components/settings/SettingsReturnNavigation.tsx
+++ b/src/components/settings/SettingsReturnNavigation.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Button } from "@mantine/core";
+import { ArrowLeft } from "lucide-react";
+import { useConsoleReturnNavigation } from "@/components/navigation/useConsoleReturnNavigation";
+import type { RecentProjectChat } from "@/lib/return-navigation";
+import { shouldAllowSettingsReturnNavigation } from "./settings-return-policy";
+
+const settingsReturnSelector = "[data-settings-return-action]";
+
+export function SettingsReturnNavigation({
+  recentProjectChats = [],
+  fallbackHref
+}: {
+  recentProjectChats?: RecentProjectChat[];
+  fallbackHref?: string;
+}) {
+  const { returnDestination } = useConsoleReturnNavigation({ recentProjectChats, fallbackHref });
+  const [dirty, setDirty] = useState(false);
+  const formSnapshots = useRef(new WeakMap<HTMLFormElement, string>());
+
+  const updateDirtyState = useCallback(() => {
+    const forms = Array.from(document.querySelectorAll<HTMLFormElement>("form[data-settings-form]"));
+    const hasDirtyForm = forms.some((form) => serializeSettingsForm(form) !== getInitialSnapshot(form, formSnapshots.current));
+    setDirty(hasDirtyForm);
+  }, []);
+
+  useEffect(() => {
+    const forms = Array.from(document.querySelectorAll<HTMLFormElement>("form[data-settings-form]"));
+    formSnapshots.current = new WeakMap(forms.map((form) => [form, serializeSettingsForm(form)]));
+    updateDirtyState();
+  }, [updateDirtyState]);
+
+  useEffect(() => {
+    const handleFormChange = () => updateDirtyState();
+    document.addEventListener("input", handleFormChange, true);
+    document.addEventListener("change", handleFormChange, true);
+    return () => {
+      document.removeEventListener("input", handleFormChange, true);
+      document.removeEventListener("change", handleFormChange, true);
+    };
+  }, [updateDirtyState]);
+
+  useEffect(() => {
+    const handleReturnClick = (event: MouseEvent) => {
+      const target = event.target instanceof Element ? event.target.closest(settingsReturnSelector) : null;
+      if (!target) return;
+      if (shouldAllowSettingsReturnNavigation({ isDirty: dirty, confirmLeave: window.confirm })) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    document.addEventListener("click", handleReturnClick, true);
+    return () => document.removeEventListener("click", handleReturnClick, true);
+  }, [dirty]);
+
+  return (
+    <Button
+      component={Link}
+      href={returnDestination.href}
+      variant="subtle"
+      leftSection={<ArrowLeft size={16} />}
+      data-settings-return-action
+      data-return-source={returnDestination.source}
+    >
+      Return
+    </Button>
+  );
+}
+
+export function ProjectSettingsSidebarLink({
+  projectId,
+  active,
+  recentProjectChats = [],
+  children
+}: {
+  projectId: string;
+  active: boolean;
+  recentProjectChats?: RecentProjectChat[];
+  children: ReactNode;
+}) {
+  const href = `/projects/${projectId}?panel=settings`;
+  const { currentHref, returnDestination } = useConsoleReturnNavigation({ recentProjectChats });
+  const resolvedHref = useMemo(() => {
+    if (!active) return href;
+    return returnDestination.href;
+  }, [active, href, returnDestination.href]);
+
+  return (
+    <Link
+      href={resolvedHref}
+      className={`sidebar-icon-link${active ? " active" : ""}`}
+      title="Settings"
+      aria-label="Settings"
+      aria-current={active ? "page" : undefined}
+      data-nav-action={active ? "return" : "open"}
+      data-settings-return-action={active ? true : undefined}
+      data-return-source={active ? returnDestination.source : undefined}
+      data-current-href={currentHref}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function getInitialSnapshot(form: HTMLFormElement, snapshots: WeakMap<HTMLFormElement, string>): string {
+  const snapshot = snapshots.get(form);
+  if (snapshot !== undefined) return snapshot;
+  const current = serializeSettingsForm(form);
+  snapshots.set(form, current);
+  return current;
+}
+
+function serializeSettingsForm(form: HTMLFormElement): string {
+  return JSON.stringify(Array.from(new FormData(form).entries()).map(([key, value]) => [key, String(value)]));
+}

--- a/src/components/settings/SettingsReturnNavigation.tsx
+++ b/src/components/settings/SettingsReturnNavigation.tsx
@@ -7,7 +7,7 @@ import { Button } from "@mantine/core";
 import { ArrowLeft } from "lucide-react";
 import { useConsoleReturnNavigation } from "@/components/navigation/useConsoleReturnNavigation";
 import type { RecentProjectChat } from "@/lib/return-navigation";
-import { shouldAllowSettingsReturnNavigation } from "./settings-return-policy";
+import { shouldAllowBrowserSettingsReturnNavigation } from "./settings-return-policy";
 
 const settingsReturnSelector = "[data-settings-return-action]";
 
@@ -48,7 +48,7 @@ export function SettingsReturnNavigation({
     const handleReturnClick = (event: MouseEvent) => {
       const target = event.target instanceof Element ? event.target.closest(settingsReturnSelector) : null;
       if (!target) return;
-      if (shouldAllowSettingsReturnNavigation({ isDirty: dirty, confirmLeave: window.confirm })) return;
+      if (shouldAllowBrowserSettingsReturnNavigation({ isDirty: dirty })) return;
       event.preventDefault();
       event.stopPropagation();
     };

--- a/src/components/settings/settings-return-policy.ts
+++ b/src/components/settings/settings-return-policy.ts
@@ -1,0 +1,10 @@
+export const settingsReturnDirtyPrompt = "You have unsaved settings changes. Leave without saving?";
+
+export function shouldAllowSettingsReturnNavigation(input: {
+  isDirty: boolean;
+  confirmLeave: (message: string) => boolean;
+  prompt?: string;
+}): boolean {
+  if (!input.isDirty) return true;
+  return input.confirmLeave(input.prompt ?? settingsReturnDirtyPrompt);
+}

--- a/src/components/settings/settings-return-policy.ts
+++ b/src/components/settings/settings-return-policy.ts
@@ -8,3 +8,13 @@ export function shouldAllowSettingsReturnNavigation(input: {
   if (!input.isDirty) return true;
   return input.confirmLeave(input.prompt ?? settingsReturnDirtyPrompt);
 }
+
+export function shouldAllowBrowserSettingsReturnNavigation(input: {
+  isDirty: boolean;
+  prompt?: string;
+}): boolean {
+  return shouldAllowSettingsReturnNavigation({
+    ...input,
+    confirmLeave: (message) => window.confirm(message)
+  });
+}


### PR DESCRIPTION
Gitdex workflow: R1
Issue: #161
## Summary
Implemented issue #161 on `gitdex/R1-issue-161` and pushed commit `e66fa09`. Settings now has a visible return control on standalone and workspace settings, active workspace settings re-click resolves through the shared return destination policy, and both return paths share an unsaved-settings confirmation guard. Restored `next-env.d.ts` after `next build` rewrote it as generated tooling noise. No PR was created because the task explicitly says Gitdex will create/update it after this return.
## Changed Files
- scripts/return-navigation.test.mjs
- scripts/settings-return-navigation.test.mjs
- src/app/projects/[projectId]/page.tsx
- src/app/settings/page.tsx
- src/components/SettingsPanel.tsx
- src/components/settings/SettingsReturnNavigation.tsx
- src/components/settings/settings-return-policy.ts
## Verification
- npm test
- npm run typecheck
- npm run build
- node --experimental-strip-types --test scripts/return-navigation.test.mjs scripts/settings-return-navigation.test.mjs
Closes #161