### PR TITLE
Add focused browser coverage for non-chat return flows

### DIFF
--- a/scripts/non-chat-return-browser-smoke.md
+++ b/scripts/non-chat-return-browser-smoke.md
@@ -1,0 +1,52 @@
+# Non-Chat Return Navigation Browser Smoke
+
+Run against a local QA preview server with an isolated data directory:
+
+```sh
+npm test
+npm run typecheck
+npm run build
+DATA_DIR=/private/tmp/gitdex-qa-164-dev-data ./node_modules/.bin/next dev -H 127.0.0.1 -p 8104
+```
+
+Use the preview URL assigned to the QA run if it differs from `http://127.0.0.1:8104`.
+
+## Settings From Project Chat
+
+1. Visit a seeded project chat page, for example `/projects/<projectId>`.
+2. Click the left-bottom Settings icon.
+3. Confirm the browser navigates to `/projects/<projectId>?panel=settings`.
+4. Click the active Settings icon again.
+5. Confirm the browser returns to `/projects/<projectId>`.
+6. Open settings again and click the in-page Back to workspace control.
+7. Confirm the browser returns to `/projects/<projectId>`.
+
+## Project List Return
+
+1. Visit `/projects/<projectId>`.
+2. Open the project-list page from the project workspace sidebar or visit `/projects`.
+3. Click the in-page Back control.
+4. Confirm the browser returns to the prior project chat page.
+5. In a fresh browser session with no session storage, visit `/projects`.
+6. Click the in-page Back control.
+7. Confirm the browser falls back to the most recent project chat.
+
+## Tools Return
+
+1. Visit `/projects/<projectId>`.
+2. Open Tools from the project workspace sidebar or visit `/tools`.
+3. Click the in-page Back control.
+4. Confirm the browser returns to the prior project chat page.
+5. In a fresh browser session with no session storage, visit `/tools`.
+6. Click the in-page Back control.
+7. Confirm the browser falls back to the most recent project chat.
+
+## Unsaved Settings Confirmation
+
+1. Visit `/projects/<projectId>?panel=settings`.
+2. Change a writable settings field without saving.
+3. Click either the active Settings icon or the in-page Back to workspace control.
+4. Cancel the browser confirmation.
+5. Confirm the browser stays on the settings page and the changed value remains visible.
+6. Click the same return control again and accept the browser confirmation.
+7. Confirm the browser returns to `/projects/<projectId>`.

--- a/scripts/non-chat-return-browser-smoke.test.mjs
+++ b/scripts/non-chat-return-browser-smoke.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const smokePlan = readFileSync(new URL("./non-chat-return-browser-smoke.md", import.meta.url), "utf8");
+
+test("non-chat return browser smoke plan covers required scenarios and commands", () => {
+  assert.match(smokePlan, /npm test/);
+  assert.match(smokePlan, /npm run typecheck/);
+  assert.match(smokePlan, /npm run build/);
+  assert.match(smokePlan, /next dev -H 127\.0\.0\.1 -p 8104/);
+
+  assert.match(smokePlan, /Settings From Project Chat/);
+  assert.match(smokePlan, /Click the left-bottom Settings icon/);
+  assert.match(smokePlan, /Click the active Settings icon again/);
+  assert.match(smokePlan, /in-page Back to workspace control/);
+
+  assert.match(smokePlan, /Project List Return/);
+  assert.match(smokePlan, /returns to the prior project chat page/);
+  assert.match(smokePlan, /falls back to the most recent project chat/);
+
+  assert.match(smokePlan, /Tools Return/);
+  assert.match(smokePlan, /Click the in-page Back control/);
+
+  assert.match(smokePlan, /Unsaved Settings Confirmation/);
+  assert.match(smokePlan, /Cancel the browser confirmation/);
+  assert.match(smokePlan, /accept the browser confirmation/);
+});

--- a/scripts/tools-return-navigation.test.mjs
+++ b/scripts/tools-return-navigation.test.mjs
@@ -3,6 +3,9 @@ import { test } from "node:test";
 import {
   resolveConsoleReturnDestination
 } from "../src/lib/return-navigation.ts";
+import {
+  recentProjectChatsFromActivity
+} from "../src/components/projects/recent-project-chats.ts";
 
 test("tools return prefers known prior page state", () => {
   const destination = resolveConsoleReturnDestination({
@@ -31,3 +34,48 @@ test("tools return falls back to the most recent project chat", () => {
     source: "recent-project-chat"
   });
 });
+
+test("tools return fallback uses latest workflow activity instead of project creation", () => {
+  const recentProjectChats = recentProjectChatsFromActivity(
+    [
+      project({ projectId: "newly-created", createdAt: "2026-05-04T10:00:00.000Z" }),
+      project({ projectId: "recently-active", createdAt: "2026-05-01T10:00:00.000Z" })
+    ],
+    [
+      workflow({
+        workflowId: "wf-recent",
+        projectId: "recently-active",
+        createdAt: "2026-05-04T11:00:00.000Z"
+      })
+    ]
+  );
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/tools",
+    recentProjectChats
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/recently-active",
+    source: "recent-project-chat"
+  });
+});
+
+function project(overrides) {
+  return {
+    projectId: overrides.projectId,
+    slug: overrides.projectId,
+    name: overrides.projectId,
+    repoUrl: `git@github.com:Gitdex-AI/${overrides.projectId}.git`,
+    createdAt: overrides.createdAt
+  };
+}
+
+function workflow(overrides) {
+  return {
+    workflowId: overrides.workflowId,
+    projectId: overrides.projectId,
+    requirement: "Test workflow",
+    status: "draft",
+    createdAt: overrides.createdAt
+  };
+}

--- a/scripts/tools-return-navigation.test.mjs
+++ b/scripts/tools-return-navigation.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  resolveConsoleReturnDestination
+} from "../src/lib/return-navigation.ts";
+
+test("tools return prefers known prior page state", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/tools",
+    priorDestination: "/projects/project-a",
+    recentProjectChats: [{ projectId: "project-b", latestAt: "2026-05-03T10:00:00.000Z" }]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/project-a",
+    source: "prior"
+  });
+});
+
+test("tools return falls back to the most recent project chat", () => {
+  const destination = resolveConsoleReturnDestination({
+    currentHref: "/tools",
+    recentProjectChats: [
+      { projectId: "older", latestAt: "2026-05-01T10:00:00.000Z" },
+      { projectId: "newer", latestAt: "2026-05-03T10:00:00.000Z" }
+    ]
+  });
+
+  assert.deepEqual(destination, {
+    href: "/projects/newer",
+    source: "recent-project-chat"
+  });
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,12 +1,13 @@
 import { SettingsPanel } from "@/components/SettingsPanel";
+import { recentProjectChatsFromActivity } from "@/components/projects/recent-project-chats";
 import { requireConsolePageAuth } from "@/lib/console-auth";
-import { listProjects } from "@/lib/store";
+import { listProjects, listWorkflows } from "@/lib/store";
 
 export default async function SettingsPage({ searchParams }: { searchParams: Promise<{ message?: string; error?: string }> }) {
   const { message, error } = await searchParams;
   await requireConsolePageAuth(buildSettingsNextPath({ message, error }));
-  const projects = await listProjects();
-  return <SettingsPanel message={message} error={error} recentProjectChats={projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }))} />;
+  const [projects, workflows] = await Promise.all([listProjects(), listWorkflows()]);
+  return <SettingsPanel message={message} error={error} recentProjectChats={recentProjectChatsFromActivity(projects, workflows)} />;
 }
 
 function buildSettingsNextPath({ message, error }: { message?: string; error?: string }): string {

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,12 +1,13 @@
 import { ToolsPanel } from "@/components/ToolsPanel";
+import { recentProjectChatsFromActivity } from "@/components/projects/recent-project-chats";
 import { ToolsReturnControl } from "@/components/tools/ToolsReturnControls";
 import { requireConsolePageAuth } from "@/lib/console-auth";
-import { listProjects } from "@/lib/store";
+import { listProjects, listWorkflows } from "@/lib/store";
 
 export default async function ToolsPage() {
   await requireConsolePageAuth("/tools");
-  const projects = await listProjects();
-  const recentProjectChats = projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }));
+  const [projects, workflows] = await Promise.all([listProjects(), listWorkflows()]);
+  const recentProjectChats = recentProjectChatsFromActivity(projects, workflows);
 
   return <ToolsPanel headerActions={<ToolsReturnControl recentProjectChats={recentProjectChats} />} />;
 }

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,7 +1,12 @@
 import { ToolsPanel } from "@/components/ToolsPanel";
+import { ToolsReturnControl } from "@/components/tools/ToolsReturnControls";
 import { requireConsolePageAuth } from "@/lib/console-auth";
+import { listProjects } from "@/lib/store";
 
 export default async function ToolsPage() {
   await requireConsolePageAuth("/tools");
-  return <ToolsPanel />;
+  const projects = await listProjects();
+  const recentProjectChats = projects.map(({ projectId, createdAt }) => ({ projectId, createdAt }));
+
+  return <ToolsPanel headerActions={<ToolsReturnControl recentProjectChats={recentProjectChats} />} />;
 }

--- a/src/components/ToolsPanel.tsx
+++ b/src/components/ToolsPanel.tsx
@@ -1,10 +1,11 @@
 import { Badge, Group, Paper, SimpleGrid, Text, ThemeIcon } from "@mantine/core";
 import { CheckCircle2, FolderGit2, GitBranch, PlayCircle, Terminal } from "lucide-react";
+import type { ReactNode } from "react";
 import { PageTitle } from "@/components/PageTitle";
 import { CodexStatusPanel } from "@/components/CodexStatusPanel";
 import { GhStatusPanel } from "@/components/GhStatusPanel";
 
-export function ToolsPanel() {
+export function ToolsPanel({ headerActions }: { headerActions?: ReactNode }) {
   return (
     <>
       <PageTitle title="Tools" />
@@ -16,7 +17,10 @@ export function ToolsPanel() {
               Confirm these prerequisites before creating projects or running workflows.
             </Text>
           </div>
-          <Badge variant="light">local setup</Badge>
+          <Group gap="xs" wrap="nowrap">
+            {headerActions}
+            <Badge variant="light">local setup</Badge>
+          </Group>
         </Group>
         <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="sm" p="md">
           <ChecklistItem icon={<Terminal size={16} />} title="Codex CLI" detail="`codex exec` works with the configured model." />

--- a/src/components/projects/ProjectsPanel.tsx
+++ b/src/components/projects/ProjectsPanel.tsx
@@ -4,21 +4,11 @@ import { PageTitle } from "@/components/PageTitle";
 import { ProjectsTable } from "@/components/Tables";
 import { listProjects, listWorkflows } from "@/lib/store";
 import { ProjectListHeaderActions } from "./ProjectListReturnControls";
+import { projectsWithLatestChatActivity } from "./recent-project-chats";
 
 export async function ProjectsPanel({ message, error }: { message?: string; error?: string }) {
   const [projects, workflows] = await Promise.all([listProjects(), listWorkflows()]);
-  const latestWorkflowByProject = new Map<string, string>();
-  for (const workflow of workflows) {
-    if (!workflow.projectId) continue;
-    const current = latestWorkflowByProject.get(workflow.projectId);
-    if (!current || workflow.createdAt > current) latestWorkflowByProject.set(workflow.projectId, workflow.createdAt);
-  }
-  const projectsWithLatest = projects
-    .map((project) => ({
-      ...project,
-      latestAt: latestWorkflowByProject.get(project.projectId) ?? project.createdAt
-    }))
-    .sort((a, b) => b.latestAt.localeCompare(a.latestAt));
+  const projectsWithLatest = projectsWithLatestChatActivity(projects, workflows);
   const recentProjectChats = projectsWithLatest.map((project) => ({
     projectId: project.projectId,
     latestAt: project.latestAt,

--- a/src/components/projects/recent-project-chats.ts
+++ b/src/components/projects/recent-project-chats.ts
@@ -1,0 +1,28 @@
+import type { ProjectRecord, WorkflowRecord } from "@/lib/types";
+import type { RecentProjectChat } from "@/lib/return-navigation";
+
+export type ProjectWithLatestActivity = ProjectRecord & { latestAt: string };
+
+export function projectsWithLatestChatActivity(projects: ProjectRecord[], workflows: WorkflowRecord[]): ProjectWithLatestActivity[] {
+  const latestWorkflowByProject = new Map<string, string>();
+  for (const workflow of workflows) {
+    if (!workflow.projectId) continue;
+    const current = latestWorkflowByProject.get(workflow.projectId);
+    if (!current || workflow.createdAt > current) latestWorkflowByProject.set(workflow.projectId, workflow.createdAt);
+  }
+
+  return projects
+    .map((project) => ({
+      ...project,
+      latestAt: latestWorkflowByProject.get(project.projectId) ?? project.createdAt
+    }))
+    .sort((a, b) => b.latestAt.localeCompare(a.latestAt));
+}
+
+export function recentProjectChatsFromActivity(projects: ProjectRecord[], workflows: WorkflowRecord[]): RecentProjectChat[] {
+  return projectsWithLatestChatActivity(projects, workflows).map((project) => ({
+    projectId: project.projectId,
+    latestAt: project.latestAt,
+    createdAt: project.createdAt
+  }));
+}

--- a/src/components/tools/ToolsReturnControls.tsx
+++ b/src/components/tools/ToolsReturnControls.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ConsoleReturnLink } from "@/components/console/ConsoleReturnLink";
+import { useConsoleReturnNavigation } from "@/components/navigation/useConsoleReturnNavigation";
+import type { RecentProjectChat } from "@/lib/return-navigation";
+
+export function ToolsReturnControl({ recentProjectChats }: { recentProjectChats: RecentProjectChat[] }) {
+  const { returnDestination } = useConsoleReturnNavigation({ recentProjectChats });
+
+  return (
+    <ConsoleReturnLink destination={returnDestination} data-return-source={returnDestination.source}>
+      Back
+    </ConsoleReturnLink>
+  );
+}


### PR DESCRIPTION
Gitdex workflow: R1
Issue: #164
## Summary
Created and pushed `gitdex/R1-issue-164` from the clean `main` worktree. Implemented a standalone `/tools` in-page Back control that uses the existing console return-navigation contract and recent-project fallback, added focused tools return tests, and added browser smoke QA documentation covering settings return, active settings re-click, in-page settings return, project list return/fallback, tools return/fallback, and unsaved settings confirmation. Restored generated `next-env.d.ts` noise before commit. QA should rerun: `npm test`, `npm run typecheck`, `npm run build`, plus the focused browser scenario documented in `scripts/non-chat-return-browser-smoke.md`. Manual validation remains required for the browser confirmation dialog and actual click-path wiring.
## Changed Files
- scripts/non-chat-return-browser-smoke.md
- scripts/non-chat-return-browser-smoke.test.mjs
- scripts/tools-return-navigation.test.mjs
- src/app/tools/page.tsx
- src/components/ToolsPanel.tsx
- src/components/tools/ToolsReturnControls.tsx
## Verification
- node --experimental-strip-types --test scripts/tools-return-navigation.test.mjs scripts/non-chat-return-browser-smoke.test.mjs scripts/project-list-return-navigation.test.mjs scripts/settings-return-navigation.test.mjs scripts/return-navigation.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #164