### PR TITLE
Add persistent site theme state and UI control

### DIFF
--- a/scripts/theme-state.test.mjs
+++ b/scripts/theme-state.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  normalizeThemeMode,
+  resolveEffectiveTheme,
+  themeStorageKey
+} from "../src/components/theme/theme-state.ts";
+
+describe("theme state helpers", () => {
+  it("accepts only supported stored theme modes", () => {
+    assert.equal(normalizeThemeMode("system"), "system");
+    assert.equal(normalizeThemeMode("light"), "light");
+    assert.equal(normalizeThemeMode("dark"), "dark");
+    assert.equal(normalizeThemeMode("unexpected"), "system");
+    assert.equal(normalizeThemeMode(null), "system");
+  });
+
+  it("resolves system mode from the operating system preference", () => {
+    assert.equal(resolveEffectiveTheme("system", false), "light");
+    assert.equal(resolveEffectiveTheme("system", true), "dark");
+  });
+
+  it("keeps explicit light and dark modes independent of system preference", () => {
+    assert.equal(resolveEffectiveTheme("light", false), "light");
+    assert.equal(resolveEffectiveTheme("light", true), "light");
+    assert.equal(resolveEffectiveTheme("dark", false), "dark");
+    assert.equal(resolveEffectiveTheme("dark", true), "dark");
+  });
+
+  it("uses a namespaced storage key", () => {
+    assert.equal(themeStorageKey, "gitdex.theme.mode");
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Providers } from "@/components/Providers";
 import { ShellLayout } from "@/components/ShellLayout";
+import { ThemeProvider } from "@/components/theme/ThemeProvider";
+import { ThemeScript } from "@/components/theme/theme-script";
 import "@mantine/core/styles.css";
 import "./globals.css";
 
@@ -11,11 +13,16 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
       <body>
-        <Providers>
-          <ShellLayout>{children}</ShellLayout>
-        </Providers>
+        <ThemeProvider>
+          <Providers>
+            <ShellLayout>{children}</ShellLayout>
+          </Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+  type EffectiveTheme,
+  type ThemeMode,
+  normalizeThemeMode,
+  resolveEffectiveTheme,
+  themePalettes,
+  themeStorageKey
+} from "./theme-state";
+import { ThemeSelector } from "./ThemeSelector";
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  effectiveTheme: EffectiveTheme;
+  setMode: (mode: ThemeMode) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getPrefersDark() {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function getStoredThemeMode() {
+  try {
+    return normalizeThemeMode(window.localStorage.getItem(themeStorageKey));
+  } catch (error) {
+    return "system";
+  }
+}
+
+function storeThemeMode(mode: ThemeMode) {
+  try {
+    window.localStorage.setItem(themeStorageKey, mode);
+  } catch (error) {}
+}
+
+function applyDocumentTheme(mode: ThemeMode, effectiveTheme: EffectiveTheme) {
+  document.documentElement.dataset.themeMode = mode;
+  document.documentElement.dataset.theme = effectiveTheme;
+  document.documentElement.style.colorScheme = effectiveTheme;
+  Object.entries(themePalettes[effectiveTheme]).forEach(([property, value]) => {
+    document.documentElement.style.setProperty(property, value);
+  });
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+
+  return context;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>("system");
+  const [prefersDark, setPrefersDark] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const effectiveTheme = resolveEffectiveTheme(mode, prefersDark);
+
+  useEffect(() => {
+    setModeState(getStoredThemeMode());
+    setPrefersDark(getPrefersDark());
+    setInitialized(true);
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersDark(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+
+    applyDocumentTheme(mode, effectiveTheme);
+  }, [effectiveTheme, initialized, mode]);
+
+  const value = useMemo(
+    () => ({
+      mode,
+      effectiveTheme,
+      setMode: (nextMode: ThemeMode) => {
+        storeThemeMode(nextMode);
+        setModeState(nextMode);
+      }
+    }),
+    [effectiveTheme, mode]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+      <ThemeSelector />
+    </ThemeContext.Provider>
+  );
+}

--- a/src/components/theme/ThemeSelector.tsx
+++ b/src/components/theme/ThemeSelector.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
+import { type ThemeMode, themeModes } from "./theme-state";
+import { useTheme } from "./ThemeProvider";
+import styles from "./theme-selector.module.css";
+
+const themeLabels: Record<ThemeMode, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark"
+};
+
+const themeIcons = {
+  system: Monitor,
+  light: Sun,
+  dark: Moon
+};
+
+export function ThemeSelector() {
+  const { mode, setMode } = useTheme();
+
+  return (
+    <div
+      aria-label="Theme mode"
+      className={styles.selector}
+      role="radiogroup"
+    >
+      {themeModes.map((themeMode) => {
+        const Icon = themeIcons[themeMode];
+        const selected = mode === themeMode;
+
+        return (
+          <button
+            aria-checked={selected}
+            aria-label={`${themeLabels[themeMode]} theme`}
+            className={styles.option}
+            data-selected={selected ? "true" : undefined}
+            key={themeMode}
+            onClick={() => setMode(themeMode)}
+            role="radio"
+            title={`${themeLabels[themeMode]} theme`}
+            type="button"
+          >
+            <Icon aria-hidden="true" size={15} strokeWidth={2.2} />
+            <span>{themeLabels[themeMode]}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/theme/theme-script.tsx
+++ b/src/components/theme/theme-script.tsx
@@ -1,0 +1,40 @@
+import { themePalettes, themeStorageKey } from "./theme-state";
+
+const bootstrapScript = `
+(function () {
+  var storageKey = ${JSON.stringify(themeStorageKey)};
+  var mode = "system";
+  try {
+    var storedMode = window.localStorage.getItem(storageKey);
+    if (storedMode === "light" || storedMode === "dark" || storedMode === "system") {
+      mode = storedMode;
+    }
+  } catch (error) {}
+
+  var prefersDark = false;
+  try {
+    prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch (error) {}
+
+  var effectiveTheme = mode === "system" ? (prefersDark ? "dark" : "light") : mode;
+  var root = document.documentElement;
+  var palettes = ${JSON.stringify(themePalettes)};
+  var palette = palettes[effectiveTheme];
+  root.dataset.themeMode = mode;
+  root.dataset.theme = effectiveTheme;
+  root.style.colorScheme = effectiveTheme;
+  Object.keys(palette).forEach(function (property) {
+    root.style.setProperty(property, palette[property]);
+  });
+}());
+`;
+
+export function ThemeScript() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: bootstrapScript
+      }}
+    />
+  );
+}

--- a/src/components/theme/theme-selector.module.css
+++ b/src/components/theme/theme-selector.module.css
@@ -1,0 +1,98 @@
+.selector {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 40;
+  display: inline-grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: min(312px, calc(100vw - 24px));
+  min-height: 38px;
+  padding: 3px;
+  background: color-mix(in srgb, var(--app-shell) 92%, transparent);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+.option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 30px;
+  gap: 5px;
+  padding: 0 7px;
+  color: color-mix(in srgb, var(--app-ink) 72%, transparent);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  cursor: pointer;
+}
+
+.option:hover,
+.option:focus-visible {
+  color: var(--app-ink);
+  background: color-mix(in srgb, var(--app-ink) 8%, transparent);
+}
+
+.option:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+.option[data-selected="true"] {
+  color: #ffffff;
+  background: #1f2937;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
+}
+
+:global(html[data-theme="dark"]) .option[data-selected="true"] {
+  color: #111827;
+  background: #f8fafc;
+}
+
+:global(html[data-theme="dark"] body) {
+  background:
+    linear-gradient(180deg, rgba(20, 184, 166, 0.08), rgba(15, 23, 42, 0) 260px),
+    var(--app-bg);
+}
+
+:global(html[data-theme="dark"] .layout.workspace-mode) {
+  background: #0f172a;
+}
+
+:global(html[data-theme="dark"] .auth-panel),
+:global(html[data-theme="dark"] .project-form),
+:global(html[data-theme="dark"] .mantine-Paper-root) {
+  color: var(--app-ink);
+  background: var(--app-shell);
+  border-color: var(--app-border);
+}
+
+:global(html[data-theme="dark"] .project-switcher-trigger.sidebar) {
+  color: var(--app-ink);
+}
+
+:global(html[data-theme="dark"] .project-switcher-trigger.sidebar:hover),
+:global(html[data-theme="dark"] .project-switcher-trigger.sidebar:focus-visible) {
+  color: #f8fafc;
+  background: #1e293b;
+}
+
+@media (max-width: 560px) {
+  .selector {
+    top: auto;
+    right: 10px;
+    bottom: 10px;
+    width: min(300px, calc(100vw - 20px));
+  }
+
+  .option span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/src/components/theme/theme-state.ts
+++ b/src/components/theme/theme-state.ts
@@ -1,0 +1,39 @@
+export const themeStorageKey = "gitdex.theme.mode";
+
+export type ThemeMode = "system" | "light" | "dark";
+export type EffectiveTheme = "light" | "dark";
+
+export const themeModes: ThemeMode[] = ["system", "light", "dark"];
+export const themePalettes: Record<EffectiveTheme, Record<string, string>> = {
+  light: {
+    "--app-bg": "#f4f7fb",
+    "--app-shell": "#ffffff",
+    "--app-border": "#dde5ee",
+    "--app-ink": "#172033"
+  },
+  dark: {
+    "--app-bg": "#0f172a",
+    "--app-shell": "#172033",
+    "--app-border": "#334155",
+    "--app-ink": "#e5edf8"
+  }
+};
+
+export function isThemeMode(value: string | null): value is ThemeMode {
+  return value === "system" || value === "light" || value === "dark";
+}
+
+export function normalizeThemeMode(value: string | null): ThemeMode {
+  return isThemeMode(value) ? value : "system";
+}
+
+export function resolveEffectiveTheme(
+  mode: ThemeMode,
+  prefersDark: boolean
+): EffectiveTheme {
+  if (mode === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+
+  return mode;
+}


### PR DESCRIPTION
Gitdex workflow: R2
Issue: #165
## Summary
Implemented issue #165 on `gitdex/R2-issue-165` and pushed commit `4b286bd`. Added a site-wide System/Light/Dark selector with client-side persistence, document-level bootstrap to apply the saved effective theme before hydration, OS color-scheme synchronization for System mode, and manual Light/Dark override behavior. Added focused test coverage in `scripts/theme-state.test.mjs` for mode normalization, system resolution, manual overrides, and the storage key. `next-env.d.ts` was rewritten by Next during validation and restored as generated noise before commit. QA should rerun: `npm test`, `npm run typecheck`, and `npm run build`. Minimal manual validation: start the app, click System/Light/Dark in the visible theme selector, refresh to confirm persistence, and verify System follows OS theme changes while manual choices do not.
## Changed Files
- scripts/theme-state.test.mjs
- src/app/layout.tsx
- src/components/theme/ThemeProvider.tsx
- src/components/theme/ThemeSelector.tsx
- src/components/theme/theme-script.tsx
- src/components/theme/theme-selector.module.css
- src/components/theme/theme-state.ts
## Verification
- npm run typecheck
- npm test
- npm run build
Closes #165