### PR TITLE
Add automated coverage for theme preference behavior

### DIFF
--- a/scripts/theme-state.test.mjs
+++ b/scripts/theme-state.test.mjs
@@ -1,10 +1,32 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  createThemePreferenceState,
   normalizeThemeMode,
+  persistThemeMode,
+  readStoredThemeMode,
   resolveEffectiveTheme,
-  themeStorageKey
+  themeStorageKey,
+  updateSystemThemePreference,
+  updateThemeMode
 } from "../src/components/theme/theme-state.ts";
+
+function createStorageMock(initialValue = null) {
+  const writes = [];
+
+  return {
+    writes,
+    getItem(key) {
+      assert.equal(key, themeStorageKey);
+      return initialValue;
+    },
+    setItem(key, value) {
+      assert.equal(key, themeStorageKey);
+      writes.push(value);
+      initialValue = value;
+    }
+  };
+}
 
 describe("theme state helpers", () => {
   it("accepts only supported stored theme modes", () => {
@@ -25,6 +47,125 @@ describe("theme state helpers", () => {
     assert.equal(resolveEffectiveTheme("light", true), "light");
     assert.equal(resolveEffectiveTheme("dark", false), "dark");
     assert.equal(resolveEffectiveTheme("dark", true), "dark");
+  });
+
+  it("reads persisted light and dark modes as manual overrides", () => {
+    assert.equal(readStoredThemeMode(createStorageMock("light")), "light");
+    assert.equal(readStoredThemeMode(createStorageMock("dark")), "dark");
+  });
+
+  it("falls back to system mode for missing, unsupported, or unreadable storage", () => {
+    assert.equal(readStoredThemeMode(createStorageMock(null)), "system");
+    assert.equal(readStoredThemeMode(createStorageMock("sepia")), "system");
+    assert.equal(
+      readStoredThemeMode({
+        getItem() {
+          throw new Error("storage unavailable");
+        },
+        setItem() {}
+      }),
+      "system"
+    );
+  });
+
+  it("persists manual and system mode selections under the theme storage key", () => {
+    const storage = createStorageMock();
+
+    assert.equal(persistThemeMode(storage, "light"), true);
+    assert.equal(persistThemeMode(storage, "dark"), true);
+    assert.equal(persistThemeMode(storage, "system"), true);
+    assert.deepEqual(storage.writes, ["light", "dark", "system"]);
+  });
+
+  it("reports failed persistence without throwing", () => {
+    assert.equal(
+      persistThemeMode(
+        {
+          getItem() {
+            return null;
+          },
+          setItem() {
+            throw new Error("storage full");
+          }
+        },
+        "dark"
+      ),
+      false
+    );
+  });
+
+  it("keeps persisted manual preferences ahead of the mocked system scheme", () => {
+    let state = createThemePreferenceState(
+      readStoredThemeMode(createStorageMock("light")),
+      true
+    );
+    assert.deepEqual(state, {
+      mode: "light",
+      prefersDark: true,
+      effectiveTheme: "light"
+    });
+
+    state = updateSystemThemePreference(state, false);
+    assert.deepEqual(state, {
+      mode: "light",
+      prefersDark: false,
+      effectiveTheme: "light"
+    });
+
+    state = createThemePreferenceState(
+      readStoredThemeMode(createStorageMock("dark")),
+      false
+    );
+    assert.deepEqual(state, {
+      mode: "dark",
+      prefersDark: false,
+      effectiveTheme: "dark"
+    });
+
+    state = updateSystemThemePreference(state, true);
+    assert.deepEqual(state, {
+      mode: "dark",
+      prefersDark: true,
+      effectiveTheme: "dark"
+    });
+  });
+
+  it("updates system mode when the mocked operating system preference changes", () => {
+    let state = createThemePreferenceState("system", false);
+    assert.equal(state.effectiveTheme, "light");
+
+    state = updateSystemThemePreference(state, true);
+    assert.deepEqual(state, {
+      mode: "system",
+      prefersDark: true,
+      effectiveTheme: "dark"
+    });
+
+    state = updateSystemThemePreference(state, false);
+    assert.deepEqual(state, {
+      mode: "system",
+      prefersDark: false,
+      effectiveTheme: "light"
+    });
+  });
+
+  it("re-resolves effective theme when users switch modes", () => {
+    let state = createThemePreferenceState("system", true);
+    assert.equal(state.effectiveTheme, "dark");
+
+    state = updateThemeMode(state, "light");
+    assert.deepEqual(state, {
+      mode: "light",
+      prefersDark: true,
+      effectiveTheme: "light"
+    });
+
+    state = updateThemeMode(state, "system");
+    assert.deepEqual(state, {
+      mode: "system",
+      prefersDark: true,
+      effectiveTheme: "dark"
+    });
   });
 
   it("uses a namespaced storage key", () => {

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -4,10 +4,10 @@ import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   type EffectiveTheme,
   type ThemeMode,
-  normalizeThemeMode,
+  persistThemeMode,
+  readStoredThemeMode,
   resolveEffectiveTheme,
-  themePalettes,
-  themeStorageKey
+  themePalettes
 } from "./theme-state";
 import { ThemeSelector } from "./ThemeSelector";
 
@@ -24,17 +24,11 @@ function getPrefersDark() {
 }
 
 function getStoredThemeMode() {
-  try {
-    return normalizeThemeMode(window.localStorage.getItem(themeStorageKey));
-  } catch (error) {
-    return "system";
-  }
+  return readStoredThemeMode(window.localStorage);
 }
 
 function storeThemeMode(mode: ThemeMode) {
-  try {
-    window.localStorage.setItem(themeStorageKey, mode);
-  } catch (error) {}
+  persistThemeMode(window.localStorage, mode);
 }
 
 function applyDocumentTheme(mode: ThemeMode, effectiveTheme: EffectiveTheme) {

--- a/src/components/theme/theme-state.ts
+++ b/src/components/theme/theme-state.ts
@@ -2,6 +2,13 @@ export const themeStorageKey = "gitdex.theme.mode";
 
 export type ThemeMode = "system" | "light" | "dark";
 export type EffectiveTheme = "light" | "dark";
+export type ThemeModeStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type ThemePreferenceState = {
+  mode: ThemeMode;
+  prefersDark: boolean;
+  effectiveTheme: EffectiveTheme;
+};
 
 export const themeModes: ThemeMode[] = ["system", "light", "dark"];
 export const themePalettes: Record<EffectiveTheme, Record<string, string>> = {
@@ -36,4 +43,49 @@ export function resolveEffectiveTheme(
   }
 
   return mode;
+}
+
+export function createThemePreferenceState(
+  mode: ThemeMode,
+  prefersDark: boolean
+): ThemePreferenceState {
+  return {
+    mode,
+    prefersDark,
+    effectiveTheme: resolveEffectiveTheme(mode, prefersDark)
+  };
+}
+
+export function updateThemeMode(
+  state: ThemePreferenceState,
+  mode: ThemeMode
+): ThemePreferenceState {
+  return createThemePreferenceState(mode, state.prefersDark);
+}
+
+export function updateSystemThemePreference(
+  state: ThemePreferenceState,
+  prefersDark: boolean
+): ThemePreferenceState {
+  return createThemePreferenceState(state.mode, prefersDark);
+}
+
+export function readStoredThemeMode(storage: ThemeModeStorage): ThemeMode {
+  try {
+    return normalizeThemeMode(storage.getItem(themeStorageKey));
+  } catch (error) {
+    return "system";
+  }
+}
+
+export function persistThemeMode(
+  storage: ThemeModeStorage,
+  mode: ThemeMode
+): boolean {
+  try {
+    storage.setItem(themeStorageKey, mode);
+    return true;
+  } catch (error) {
+    return false;
+  }
 }


### PR DESCRIPTION
Gitdex workflow: R2
Issue: #169
## Summary
Created and pushed branch `gitdex/R2-issue-169` at commit `17e43b7`. Implemented focused theme preference coverage by extracting testable storage/state helpers into `src/components/theme/theme-state.ts`, wiring `ThemeProvider` to those helpers, and expanding `scripts/theme-state.test.mjs` to cover System/Light/Dark behavior, persistence, manual overrides against mocked system preference, and System-mode response to mocked preference changes. Restored `next-env.d.ts` after build rewrote it as generated noise. QA should rerun: `npm test`, `npm run typecheck`, and `npm run build`. Test file updated: `scripts/theme-state.test.mjs`. No acceptance criteria require manual validation beyond the automated checks.
## Changed Files
- scripts/theme-state.test.mjs
- src/components/theme/ThemeProvider.tsx
- src/components/theme/theme-state.ts
## Verification
- node --experimental-strip-types --test scripts/theme-state.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #169