### PR TITLE
Define settings metadata and required GitHub PR workflow validation

### DIFF
--- a/scripts/settings-metadata.test.mjs
+++ b/scripts/settings-metadata.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getMissingRequiredSettings,
+  settingsMetadata,
+  settingsMetadataByKey,
+  settingsMetadataGroups
+} from "../src/lib/settings-metadata.ts";
+
+const settingsKeys = [
+  "appBaseUrl",
+  "telegramBotToken",
+  "telegramWebhookSecret",
+  "codexBin",
+  "codexHome",
+  "codexModel",
+  "codexSandbox",
+  "codexApprovalPolicy",
+  "githubToken",
+  "githubRepo",
+  "githubApiUrl",
+  "worktreeRetentionDays",
+  "autoCleanupCompletedWorktrees",
+  "rebuildWorktreeOnEnvironmentBlocked"
+];
+
+const requiredForGithubPrWorkflow = [
+  "codexBin",
+  "codexHome",
+  "codexModel",
+  "codexSandbox",
+  "codexApprovalPolicy",
+  "githubToken",
+  "githubRepo",
+  "githubApiUrl"
+];
+
+describe("settings metadata", () => {
+  it("represents every settings-page parameter exactly once", () => {
+    const metadataKeys = settingsMetadata.map((setting) => setting.key);
+
+    assert.deepEqual([...metadataKeys].sort(), [...settingsKeys].sort());
+    assert.equal(new Set(metadataKeys).size, settingsKeys.length);
+    for (const key of settingsKeys) {
+      assert.equal(settingsMetadataByKey[key].key, key);
+    }
+  });
+
+  it("groups settings by functional area with prompt-ready labels and explanations", () => {
+    assert.deepEqual(
+      settingsMetadataGroups.map((group) => group.id),
+      ["runtime", "telegram", "codex", "github", "worktrees"]
+    );
+
+    for (const group of settingsMetadataGroups) {
+      assert.ok(group.label);
+      assert.ok(group.description);
+      assert.ok(group.settings.length > 0);
+
+      for (const setting of group.settings) {
+        assert.ok(setting.label);
+        assert.match(setting.requirement, /^(required|optional)$/);
+        assert.ok(setting.purpose.length >= 20);
+        assert.ok(setting.behaviorImpact.length >= 20);
+      }
+    }
+  });
+
+  it("marks only the minimum GitHub PR workflow configuration as required", () => {
+    const requiredKeys = settingsMetadata.filter((setting) => setting.requirement === "required").map((setting) => setting.key);
+    const optionalKeys = settingsMetadata.filter((setting) => setting.requirement === "optional").map((setting) => setting.key);
+
+    assert.deepEqual([...requiredKeys].sort(), [...requiredForGithubPrWorkflow].sort());
+    assert.equal(optionalKeys.includes("appBaseUrl"), true);
+    assert.equal(optionalKeys.includes("telegramBotToken"), true);
+    assert.equal(optionalKeys.includes("worktreeRetentionDays"), true);
+  });
+
+  it("returns prompt-ready missing required settings for incomplete configuration", () => {
+    const missing = getMissingRequiredSettings({
+      codexBin: "codex",
+      codexHome: " ",
+      codexModel: "gpt-5.4",
+      codexSandbox: "workspace-write",
+      codexApprovalPolicy: "never",
+      githubRepo: "",
+      githubApiUrl: "https://api.github.com",
+      appBaseUrl: "",
+      telegramBotToken: "",
+      worktreeRetentionDays: 7
+    });
+
+    assert.deepEqual(
+      missing.map((setting) => setting.key),
+      ["codexHome", "githubRepo", "githubToken"]
+    );
+    assert.deepEqual(
+      missing.map((setting) => setting.groupLabel),
+      ["Codex", "GitHub", "GitHub"]
+    );
+    for (const setting of missing) {
+      assert.equal(setting.requirement, "required");
+      assert.ok(setting.label);
+      assert.ok(setting.purpose);
+      assert.ok(setting.behaviorImpact);
+    }
+  });
+
+  it("does not report missing required settings for complete GitHub PR workflow configuration", () => {
+    const missing = getMissingRequiredSettings({
+      codexBin: "codex",
+      codexHome: "/Users/example/.codex",
+      codexModel: "gpt-5.4",
+      codexSandbox: "workspace-write",
+      codexApprovalPolicy: "never",
+      githubRepo: "Gitdex-AI/gitdex",
+      githubApiUrl: "https://api.github.com",
+      githubToken: "ghp_example"
+    });
+
+    assert.deepEqual(missing, []);
+  });
+});

--- a/src/lib/settings-metadata.ts
+++ b/src/lib/settings-metadata.ts
@@ -1,0 +1,186 @@
+import type { Settings } from "./types";
+
+export type SettingsMetadataGroupId = "runtime" | "telegram" | "codex" | "github" | "worktrees";
+export type SettingRequirement = "required" | "optional";
+
+export type SettingMetadata = {
+  key: keyof Settings;
+  label: string;
+  requirement: SettingRequirement;
+  purpose: string;
+  behaviorImpact: string;
+};
+
+export type SettingsMetadataGroup = {
+  id: SettingsMetadataGroupId;
+  label: string;
+  description: string;
+  settings: readonly SettingMetadata[];
+};
+
+export type MissingRequiredSetting = SettingMetadata & {
+  groupId: SettingsMetadataGroupId;
+  groupLabel: string;
+  value: Settings[keyof Settings] | undefined;
+};
+
+export const settingsMetadataGroups: readonly SettingsMetadataGroup[] = [
+  {
+    id: "runtime",
+    label: "Runtime",
+    description: "Local Gitdex server and browser-facing runtime settings.",
+    settings: [
+      {
+        key: "appBaseUrl",
+        label: "App Base URL",
+        requirement: "optional",
+        purpose: "Public base URL used when Gitdex needs to build links back to this app.",
+        behaviorImpact: "Incorrect values can break webhook callbacks or links opened outside the local browser."
+      }
+    ]
+  },
+  {
+    id: "telegram",
+    label: "Telegram",
+    description: "Telegram bot ingress configuration for chat-driven workflows.",
+    settings: [
+      {
+        key: "telegramBotToken",
+        label: "Telegram Bot Token",
+        requirement: "optional",
+        purpose: "Authenticates Gitdex when it sends or receives Telegram bot messages.",
+        behaviorImpact: "Leaving it blank disables Telegram bot setup and webhook calls."
+      },
+      {
+        key: "telegramWebhookSecret",
+        label: "Telegram Webhook Secret",
+        requirement: "optional",
+        purpose: "Adds a shared secret check to incoming Telegram webhook requests.",
+        behaviorImpact: "Leaving it blank accepts Telegram webhook requests without the secret-token guard."
+      }
+    ]
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    description: "Codex command and execution policy used by developer, QA, and architect jobs.",
+    settings: [
+      {
+        key: "codexBin",
+        label: "Codex Binary",
+        requirement: "required",
+        purpose: "Command Gitdex runs to start Codex agent sessions.",
+        behaviorImpact: "Missing or invalid values prevent developer, QA, architect, and review jobs from starting."
+      },
+      {
+        key: "codexHome",
+        label: "Codex Home",
+        requirement: "required",
+        purpose: "Codex home directory containing local authentication and session state.",
+        behaviorImpact: "Missing or invalid values prevent Codex from reusing the authenticated local account."
+      },
+      {
+        key: "codexModel",
+        label: "Model",
+        requirement: "required",
+        purpose: "Model identifier passed to Codex for agent execution.",
+        behaviorImpact: "Missing values leave agent runs without an explicit model selection."
+      },
+      {
+        key: "codexSandbox",
+        label: "Sandbox",
+        requirement: "required",
+        purpose: "Filesystem sandbox policy passed to Codex agent runs.",
+        behaviorImpact: "Missing values leave agent runs without the intended write-access boundary."
+      },
+      {
+        key: "codexApprovalPolicy",
+        label: "Approval Policy",
+        requirement: "required",
+        purpose: "Approval mode passed to Codex when it executes commands.",
+        behaviorImpact: "Missing values leave command approval behavior undefined for automated jobs."
+      }
+    ]
+  },
+  {
+    id: "github",
+    label: "GitHub",
+    description: "GitHub API configuration required to create issues, branches, pull requests, and labels.",
+    settings: [
+      {
+        key: "githubRepo",
+        label: "GitHub Repo",
+        requirement: "required",
+        purpose: "Default owner/repository target for GitHub workflow operations.",
+        behaviorImpact: "Missing values prevent Gitdex from creating or updating issues, labels, and pull requests."
+      },
+      {
+        key: "githubApiUrl",
+        label: "GitHub API URL",
+        requirement: "required",
+        purpose: "GitHub API endpoint used by workflow automation.",
+        behaviorImpact: "Missing values prevent GitHub client calls from resolving the API host."
+      },
+      {
+        key: "githubToken",
+        label: "GitHub Token",
+        requirement: "required",
+        purpose: "Token Gitdex uses to authenticate GitHub API requests.",
+        behaviorImpact: "Missing values prevent authenticated repository, issue, label, and pull request operations."
+      }
+    ]
+  },
+  {
+    id: "worktrees",
+    label: "Worktrees",
+    description: "Local worktree lifecycle settings for agent job retries and cleanup.",
+    settings: [
+      {
+        key: "worktreeRetentionDays",
+        label: "Worktree Retention Days",
+        requirement: "optional",
+        purpose: "Number of days completed local worktrees are retained before cleanup.",
+        behaviorImpact: "Lower values reclaim disk faster; higher values keep more local debugging context."
+      },
+      {
+        key: "autoCleanupCompletedWorktrees",
+        label: "Auto cleanup completed worktrees",
+        requirement: "optional",
+        purpose: "Controls whether completed worktrees are cleaned up after jobs finish.",
+        behaviorImpact: "Disabling it keeps completed worktrees on disk until manually removed."
+      },
+      {
+        key: "rebuildWorktreeOnEnvironmentBlocked",
+        label: "Rebuild worktree on environment blocked",
+        requirement: "optional",
+        purpose: "Allows Gitdex to rebuild worktrees after environment-blocked agent runs.",
+        behaviorImpact: "Disabling it leaves environment-blocked worktrees in place for manual inspection."
+      }
+    ]
+  }
+];
+
+export const settingsMetadata: readonly SettingMetadata[] = settingsMetadataGroups.flatMap((group) => group.settings);
+
+export const settingsMetadataByKey: Record<keyof Settings, SettingMetadata> = Object.fromEntries(
+  settingsMetadata.map((setting) => [setting.key, setting])
+) as Record<keyof Settings, SettingMetadata>;
+
+export function getMissingRequiredSettings(settings: Partial<Settings>): MissingRequiredSetting[] {
+  return settingsMetadataGroups.flatMap((group) =>
+    group.settings
+      .filter((setting) => setting.requirement === "required" && isMissingSettingValue(settings[setting.key]))
+      .map((setting) => ({
+        ...setting,
+        groupId: group.id,
+        groupLabel: group.label,
+        value: settings[setting.key]
+      }))
+  );
+}
+
+function isMissingSettingValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim() === "";
+  return false;
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -7,6 +7,20 @@ import type { Settings } from "@/lib/types";
 const legacyCodexHome = `${dataDir}/codex-home`;
 const defaultCodexHome = path.join(os.homedir(), ".codex");
 
+export {
+  getMissingRequiredSettings,
+  settingsMetadata,
+  settingsMetadataByKey,
+  settingsMetadataGroups
+} from "@/lib/settings-metadata";
+export type {
+  MissingRequiredSetting,
+  SettingMetadata,
+  SettingRequirement,
+  SettingsMetadataGroup,
+  SettingsMetadataGroupId
+} from "@/lib/settings-metadata";
+
 const defaults: Settings = {
   appBaseUrl: "http://localhost:8000",
   telegramBotToken: "",


### PR DESCRIPTION
Gitdex workflow: R3
Issue: #180
## Summary
Implemented issue #180 on branch gitdex/R3-issue-180 and pushed commit 7e878a7. Added a pure settings metadata module covering every existing settings-page parameter, grouped by runtime, Telegram, Codex, GitHub, and worktrees. The metadata includes stable keys, labels, required/optional classification, purpose text, and behavior-impact text. Added getMissingRequiredSettings for prompt-ready missing required configuration data, and re-exported the helper/metadata from src/lib/settings.ts. Test-scope reason: scripts/settings-metadata.test.mjs directly verifies this issue’s acceptance criteria. QA should rerun: node --experimental-strip-types --test scripts/settings-metadata.test.mjs, npm test, npm run typecheck, npm run build. No manual validation is required beyond confirming future UI wiring consumes the helper if/when that UI work is added. Recovery decision: worktree was clean on main with no active PR, so I created and used the expected issue branch.
## Changed Files
- src/lib/settings.ts
- src/lib/settings-metadata.ts
- scripts/settings-metadata.test.mjs
## Verification
- node --experimental-strip-types --test scripts/settings-metadata.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #180