### PR TITLE
Render grouped settings with field-level guidance

### DIFF
--- a/scripts/settings-page-rendering.test.mjs
+++ b/scripts/settings-page-rendering.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import { settingsMetadataGroups } from "../src/lib/settings-metadata.ts";
+import { buildSettingsGroupState } from "../src/components/settings/settings-field-model.ts";
+
+const completeSettings = {
+  appBaseUrl: "http://127.0.0.1:8000",
+  telegramBotToken: "telegram-token",
+  telegramWebhookSecret: "telegram-secret",
+  codexBin: "codex",
+  codexHome: "/Users/example/.codex",
+  codexModel: "gpt-5.4",
+  codexSandbox: "workspace-write",
+  codexApprovalPolicy: "never",
+  githubToken: "ghp_example",
+  githubRepo: "Gitdex-AI/gitdex",
+  githubApiUrl: "https://api.github.com",
+  worktreeRetentionDays: 7,
+  autoCleanupCompletedWorktrees: true,
+  rebuildWorktreeOnEnvironmentBlocked: true
+};
+
+describe("settings page rendering contract", () => {
+  it("builds one grouped field state for every settings metadata entry", () => {
+    const groups = buildSettingsGroupState(settingsMetadataGroups, completeSettings);
+
+    assert.deepEqual(
+      groups.map((group) => group.id),
+      settingsMetadataGroups.map((group) => group.id)
+    );
+    assert.deepEqual(
+      groups.flatMap((group) => group.settings.map((field) => field.key)),
+      settingsMetadataGroups.flatMap((group) => group.settings.map((field) => field.key))
+    );
+
+    for (const group of groups) {
+      assert.ok(group.label);
+      assert.ok(group.description);
+      for (const field of group.settings) {
+        assert.match(field.requirement, /^(required|optional)$/);
+        assert.ok(field.purpose);
+        assert.ok(field.behaviorImpact);
+        assert.equal(field.missingRequired, false);
+        assert.equal(field.missingRequiredPrompt, null);
+      }
+    }
+  });
+
+  it("adds local GitHub PR workflow prompts only to missing required fields", () => {
+    const groups = buildSettingsGroupState(settingsMetadataGroups, {
+      ...completeSettings,
+      codexHome: " ",
+      githubRepo: "",
+      githubToken: ""
+    });
+    const fields = groups.flatMap((group) => group.settings);
+    const missing = fields.filter((field) => field.missingRequired);
+
+    assert.deepEqual(
+      missing.map((field) => field.key),
+      ["codexHome", "githubRepo", "githubToken"]
+    );
+    for (const field of missing) {
+      assert.match(field.missingRequiredPrompt ?? "", /required for the GitHub PR workflow/);
+      assert.match(field.missingRequiredPrompt ?? "", new RegExp(field.behaviorImpact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+
+    assert.equal(fields.find((field) => field.key === "appBaseUrl")?.missingRequired, false);
+    assert.equal(fields.find((field) => field.key === "telegramBotToken")?.missingRequired, false);
+  });
+
+  it("wires the settings panel to metadata groups, labels, descriptions, and field prompts", async () => {
+    const source = await readFile(new URL("../src/components/SettingsPanel.tsx", import.meta.url), "utf8");
+
+    assert.match(source, /settingsMetadataGroups/);
+    assert.match(source, /buildSettingsGroupState/);
+    assert.match(source, /data-settings-group=\{group\.id\}/);
+    assert.match(source, /field\.requirement/);
+    assert.match(source, /field\.purpose/);
+    assert.match(source, /field\.behaviorImpact/);
+    assert.match(source, /field\.missingRequiredPrompt/);
+  });
+});

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,9 +1,11 @@
-import { Alert, Button, Checkbox, Group, NumberInput, PasswordInput, SimpleGrid, Text, TextInput } from "@mantine/core";
+import { Alert, Badge, Button, Checkbox, Group, NumberInput, PasswordInput, SimpleGrid, Stack, Text, TextInput } from "@mantine/core";
 import { Info, Save, Trash2, Webhook, Wrench } from "lucide-react";
 import packageJson from "../../package.json";
 import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
+import { buildSettingsGroupState, type SettingsFieldState } from "@/components/settings/settings-field-model";
 import { ThemeSelector } from "@/components/theme/ThemeSelector";
 import { getSettings } from "@/lib/settings";
+import { settingsMetadataGroups } from "@/lib/settings-metadata";
 
 export async function SettingsPanel({
   message,
@@ -17,6 +19,7 @@ export async function SettingsPanel({
   toolsHref?: string;
 }) {
   const settings = await getSettings();
+  const settingsGroups = buildSettingsGroupState(settingsMetadataGroups, settings);
 
   return (
     <div className="settings-panel">
@@ -65,64 +68,32 @@ export async function SettingsPanel({
 
       <form method="post" action="/api/settings" data-settings-form className="settings-form">
         <ReturnToInput returnTo={returnTo} />
-        <section className="settings-section">
-          <div className="settings-section-heading">
-            <div>
-              <Text className="settings-section-title">Runtime</Text>
-              <Text className="settings-row-description">Saved to data/gitdex.sqlite.</Text>
-            </div>
-          </div>
-          <div className="settings-subsection">
-            <Text className="section-title">App</Text>
-            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-              <TextInput name="appBaseUrl" label="App Base URL" defaultValue={settings.appBaseUrl} placeholder="https://your-bot.example.com" />
-              <TextInput name="telegramWebhookSecret" label="Telegram Webhook Secret" defaultValue={settings.telegramWebhookSecret} placeholder="secret-token" />
-            </SimpleGrid>
-            <PasswordInput name="telegramBotToken" label="Telegram Bot Token" defaultValue={settings.telegramBotToken} placeholder="123456:ABC..." />
-          </div>
-          <div className="settings-subsection">
-            <Text className="section-title">Codex CLI</Text>
-            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-              <TextInput name="codexBin" label="Codex Binary" defaultValue={settings.codexBin} />
-              <TextInput name="codexHome" label="Codex Home" defaultValue={settings.codexHome} />
-              <TextInput name="codexModel" label="Model" defaultValue={settings.codexModel} />
-              <TextInput name="codexSandbox" label="Sandbox" defaultValue={settings.codexSandbox} />
-              <TextInput name="codexApprovalPolicy" label="Approval Policy" defaultValue={settings.codexApprovalPolicy} />
-            </SimpleGrid>
-          </div>
-          <div className="settings-subsection">
-            <Text className="section-title">Fallback GitHub API</Text>
-            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-              <TextInput name="githubRepo" label="GitHub Repo" defaultValue={settings.githubRepo} placeholder="owner/repo" />
-              <TextInput name="githubApiUrl" label="GitHub API URL" defaultValue={settings.githubApiUrl} />
-            </SimpleGrid>
-            <PasswordInput name="githubToken" label="GitHub Token" defaultValue={settings.githubToken} placeholder="ghp_..." />
-          </div>
-          <div className="settings-subsection">
-            <Text className="section-title">Worktrees</Text>
-            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-              <NumberInput name="worktreeRetentionDays" label="Worktree Retention Days" min={1} max={365} defaultValue={settings.worktreeRetentionDays} />
-              <div className="settings-checkbox-stack">
-                <Checkbox name="autoCleanupCompletedWorktrees" label="Auto cleanup completed worktrees" defaultChecked={settings.autoCleanupCompletedWorktrees} />
-                <Checkbox name="rebuildWorktreeOnEnvironmentBlocked" label="Rebuild worktree on environment blocked" defaultChecked={settings.rebuildWorktreeOnEnvironmentBlocked} />
+        {settingsGroups.map((group) => (
+          <section key={group.id} className="settings-section" data-settings-group={group.id}>
+            <div className="settings-section-heading">
+              <div>
+                <Text className="settings-section-title">{group.label}</Text>
+                <Text className="settings-row-description">{group.description}</Text>
               </div>
+            </div>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+              {group.settings.map((field) => (
+                <SettingsField key={field.key} field={field} />
+              ))}
             </SimpleGrid>
-            <Text size="sm" c="dimmed">
-              Completed worktrees are local execution buffers. Gitdex keeps recent buffers for diagnosis and removes older completed buffers after the retention window.
-            </Text>
-          </div>
-          <Group className="form-actions">
-            <Button type="submit" leftSection={<Save size={16} />}>
-              Save Settings
-            </Button>
-            <Button type="submit" variant="light" leftSection={<Webhook size={16} />} formAction="/api/setup/webhook">
-              Setup Webhook
-            </Button>
-            <Button type="submit" variant="light" color="red" leftSection={<Trash2 size={16} />} formAction="/api/worktrees/cleanup">
-              Clean Worktrees
-            </Button>
-          </Group>
-        </section>
+          </section>
+        ))}
+        <Group className="form-actions">
+          <Button type="submit" leftSection={<Save size={16} />}>
+            Save Settings
+          </Button>
+          <Button type="submit" variant="light" leftSection={<Webhook size={16} />} formAction="/api/setup/webhook">
+            Setup Webhook
+          </Button>
+          <Button type="submit" variant="light" color="red" leftSection={<Trash2 size={16} />} formAction="/api/worktrees/cleanup">
+            Clean Worktrees
+          </Button>
+        </Group>
       </form>
     </div>
   );
@@ -130,4 +101,91 @@ export async function SettingsPanel({
 
 function ReturnToInput({ returnTo }: { returnTo?: string }) {
   return returnTo ? <input type="hidden" name="next" value={returnTo} /> : null;
+}
+
+function SettingsField({ field }: { field: SettingsFieldState }) {
+  const label = <SettingLabel field={field} />;
+  const description = <SettingDescription field={field} />;
+  const error = field.missingRequiredPrompt ?? undefined;
+
+  if (field.key === "githubToken" || field.key === "telegramBotToken") {
+    return (
+      <PasswordInput
+        name={field.key}
+        label={label}
+        description={description}
+        defaultValue={String(field.value ?? "")}
+        placeholder={field.key === "githubToken" ? "ghp_..." : "123456:ABC..."}
+        error={error}
+      />
+    );
+  }
+
+  if (field.key === "worktreeRetentionDays") {
+    return (
+      <NumberInput
+        name={field.key}
+        label={label}
+        description={description}
+        min={1}
+        max={365}
+        defaultValue={Number(field.value)}
+        error={error}
+      />
+    );
+  }
+
+  if (field.key === "autoCleanupCompletedWorktrees" || field.key === "rebuildWorktreeOnEnvironmentBlocked") {
+    return (
+      <Checkbox
+        name={field.key}
+        label={label}
+        description={description}
+        defaultChecked={Boolean(field.value)}
+        error={error}
+      />
+    );
+  }
+
+  return (
+    <TextInput
+      name={field.key}
+      label={label}
+      description={description}
+      defaultValue={String(field.value ?? "")}
+      placeholder={getTextPlaceholder(field.key)}
+      error={error}
+    />
+  );
+}
+
+function SettingLabel({ field }: { field: SettingsFieldState }) {
+  return (
+    <Group gap="xs" wrap="nowrap">
+      <span>{field.label}</span>
+      <Badge size="xs" variant={field.requirement === "required" ? "filled" : "light"} color={field.requirement === "required" ? "red" : "gray"}>
+        {field.requirement}
+      </Badge>
+    </Group>
+  );
+}
+
+function SettingDescription({ field }: { field: SettingsFieldState }) {
+  return (
+    <Stack gap={2}>
+      <Text span size="xs" c="dimmed">
+        {field.purpose}
+      </Text>
+      <Text span size="xs" c="dimmed">
+        {field.behaviorImpact}
+      </Text>
+    </Stack>
+  );
+}
+
+function getTextPlaceholder(key: SettingsFieldState["key"]): string | undefined {
+  if (key === "appBaseUrl") return "https://your-bot.example.com";
+  if (key === "telegramWebhookSecret") return "secret-token";
+  if (key === "githubRepo") return "owner/repo";
+  return undefined;
 }

--- a/src/components/settings/settings-field-model.ts
+++ b/src/components/settings/settings-field-model.ts
@@ -1,0 +1,39 @@
+import type { SettingMetadata, SettingsMetadataGroup } from "../../lib/settings-metadata";
+import type { Settings } from "../../lib/types";
+
+export type SettingsFieldState = SettingMetadata & {
+  value: Settings[keyof Settings];
+  missingRequired: boolean;
+  missingRequiredPrompt: string | null;
+};
+
+export type SettingsGroupState = Omit<SettingsMetadataGroup, "settings"> & {
+  settings: SettingsFieldState[];
+};
+
+export function buildSettingsGroupState(groups: readonly SettingsMetadataGroup[], settings: Settings): SettingsGroupState[] {
+  return groups.map((group) => ({
+    id: group.id,
+    label: group.label,
+    description: group.description,
+    settings: group.settings.map((setting) => {
+      const value = settings[setting.key];
+      const missingRequired = setting.requirement === "required" && isMissingSettingValue(value);
+
+      return {
+        ...setting,
+        value,
+        missingRequired,
+        missingRequiredPrompt: missingRequired
+          ? `${setting.label} is required for the GitHub PR workflow. ${setting.behaviorImpact}`
+          : null
+      };
+    })
+  }));
+}
+
+function isMissingSettingValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim() === "";
+  return false;
+}


### PR DESCRIPTION
Gitdex workflow: R3
Issue: #181
## Summary
Implemented issue #181 on `gitdex/R3-issue-181` and pushed commit `daa7db5`. The settings panel now consumes `settingsMetadataGroups`, renders each existing setting by functional group, shows required/optional badges, includes purpose and behavior-impact text, and displays field-level missing-required prompts for required GitHub PR workflow settings. Added a component-owned field-state helper and focused settings page tests.

Branch recovery: worktree was clean on `main` with no active PR, so I created and pushed the expected issue branch.

Test files added/updated: `scripts/settings-page-rendering.test.mjs`.

QA rerun commands: `node --experimental-strip-types --test scripts/settings-metadata.test.mjs scripts/settings-page-rendering.test.mjs`, `npm run typecheck`, `npm test`, `npm run build`.

Manual validation: optional browser smoke on a project settings panel to confirm grouped layout and local required-field prompts are visually clear.
## Changed Files
- src/components/SettingsPanel.tsx
- src/components/settings/settings-field-model.ts
- scripts/settings-page-rendering.test.mjs
## Verification
- node --experimental-strip-types --test scripts/settings-metadata.test.mjs scripts/settings-page-rendering.test.mjs
- npm run typecheck
- npm test
- npm run build
Closes #181