### PR TITLE
Add top-level missing configuration summary to settings panel

### DIFF
--- a/scripts/settings-summary.test.mjs
+++ b/scripts/settings-summary.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import {
+  getMissingRequiredSettingsGroups,
+  settingsMetadataByKey
+} from "../src/lib/settings-metadata.ts";
+
+const completeRequiredSettings = {
+  codexBin: "codex",
+  codexHome: "/Users/example/.codex",
+  codexModel: "gpt-5.4",
+  codexSandbox: "workspace-write",
+  codexApprovalPolicy: "never",
+  githubRepo: "Gitdex-AI/gitdex",
+  githubApiUrl: "https://api.github.com",
+  githubToken: "ghp_example"
+};
+
+describe("settings missing configuration summary", () => {
+  it("groups missing required settings by the labels used in the settings UI", () => {
+    const groups = getMissingRequiredSettingsGroups({
+      ...completeRequiredSettings,
+      codexHome: " ",
+      githubRepo: "",
+      githubToken: undefined
+    });
+
+    assert.deepEqual(
+      groups.map((group) => ({
+        groupLabel: group.groupLabel,
+        labels: group.settings.map((setting) => setting.label)
+      })),
+      [
+        {
+          groupLabel: "Codex",
+          labels: [settingsMetadataByKey.codexHome.label]
+        },
+        {
+          groupLabel: "GitHub",
+          labels: [settingsMetadataByKey.githubRepo.label, settingsMetadataByKey.githubToken.label]
+        }
+      ]
+    );
+  });
+
+  it("excludes optional blank settings from summary groups", () => {
+    const groups = getMissingRequiredSettingsGroups({
+      ...completeRequiredSettings,
+      appBaseUrl: "",
+      telegramBotToken: "",
+      telegramWebhookSecret: ""
+    });
+
+    assert.deepEqual(groups, []);
+  });
+
+  it("returns no summary groups when required Codex and GitHub settings are complete", () => {
+    assert.deepEqual(getMissingRequiredSettingsGroups(completeRequiredSettings), []);
+  });
+
+  it("wires the missing-configuration summary into SettingsPanel before grouped settings sections", () => {
+    const source = readFileSync(new URL("../src/components/SettingsPanel.tsx", import.meta.url), "utf8");
+
+    assert.match(source, /Gitdex cannot complete the GitHub PR workflow end to end/);
+    assert.ok(source.indexOf("<MissingConfigurationSummary") < source.indexOf("<section className=\"settings-section\">"));
+    assert.ok(source.includes("getMissingRequiredSettingsGroups(settings)"));
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1001,6 +1001,65 @@ pre,
   border-top: 1px solid var(--app-border-muted);
 }
 
+.settings-missing-summary {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 18px;
+  padding: 16px;
+  background: var(--app-surface-info);
+  border: 1px solid var(--app-border-info);
+  border-radius: var(--radius-md);
+}
+
+.settings-missing-summary-title {
+  color: var(--app-text-strong);
+  font-weight: var(--weight-extrabold);
+  line-height: 1.3;
+}
+
+.settings-missing-summary-copy {
+  margin-top: 4px;
+  color: var(--app-text-subtle);
+  font-size: var(--text-sm);
+  line-height: var(--leading-ui);
+}
+
+.settings-missing-summary-groups {
+  display: grid;
+  gap: 10px;
+}
+
+.settings-missing-summary-group {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-missing-summary-group-title {
+  color: var(--app-text-strong);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  line-height: 1.3;
+}
+
+.settings-missing-summary-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.settings-missing-summary-list li {
+  padding: 4px 8px;
+  color: var(--app-text-subtle);
+  font-size: var(--text-sm);
+  line-height: 1.3;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border-muted);
+  border-radius: var(--radius-sm);
+}
+
 .settings-section:first-of-type {
   border-top: 0;
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -4,7 +4,11 @@ import packageJson from "../../package.json";
 import { SelfUpdateDialog } from "@/components/SelfUpdateDialog";
 import { buildSettingsGroupState, type SettingsFieldState } from "@/components/settings/settings-field-model";
 import { ThemeSelector } from "@/components/theme/ThemeSelector";
-import { getSettings } from "@/lib/settings";
+import {
+  getMissingRequiredSettingsGroups,
+  getSettings,
+  type MissingRequiredSettingsGroup
+} from "@/lib/settings";
 import { settingsMetadataGroups } from "@/lib/settings-metadata";
 
 export async function SettingsPanel({
@@ -20,6 +24,7 @@ export async function SettingsPanel({
 }) {
   const settings = await getSettings();
   const settingsGroups = buildSettingsGroupState(settingsMetadataGroups, settings);
+  const missingRequiredSettingsGroups = getMissingRequiredSettingsGroups(settings);
 
   return (
     <div className="settings-panel">
@@ -34,6 +39,7 @@ export async function SettingsPanel({
           {message ?? error}
         </Alert>
       )}
+      <MissingConfigurationSummary groups={missingRequiredSettingsGroups} />
       <section className="settings-section">
         <div className="settings-row">
           <div className="settings-row-copy">
@@ -96,6 +102,35 @@ export async function SettingsPanel({
         </Group>
       </form>
     </div>
+  );
+}
+
+function MissingConfigurationSummary({ groups }: { groups: MissingRequiredSettingsGroup[] }) {
+  if (groups.length === 0) return null;
+
+  return (
+    <section className="settings-missing-summary" aria-labelledby="settings-missing-summary-title">
+      <div>
+        <Text id="settings-missing-summary-title" className="settings-missing-summary-title">
+          Missing required configuration
+        </Text>
+        <Text className="settings-missing-summary-copy">
+          Gitdex cannot complete the GitHub PR workflow end to end until the missing required Codex and GitHub configuration is provided.
+        </Text>
+      </div>
+      <div className="settings-missing-summary-groups">
+        {groups.map((group) => (
+          <div key={group.groupId} className="settings-missing-summary-group">
+            <Text className="settings-missing-summary-group-title">{group.groupLabel}</Text>
+            <ul className="settings-missing-summary-list">
+              {group.settings.map((setting) => (
+                <li key={setting.key}>{setting.label}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/src/lib/settings-metadata.ts
+++ b/src/lib/settings-metadata.ts
@@ -24,6 +24,12 @@ export type MissingRequiredSetting = SettingMetadata & {
   value: Settings[keyof Settings] | undefined;
 };
 
+export type MissingRequiredSettingsGroup = {
+  groupId: SettingsMetadataGroupId;
+  groupLabel: string;
+  settings: MissingRequiredSetting[];
+};
+
 export const settingsMetadataGroups: readonly SettingsMetadataGroup[] = [
   {
     id: "runtime",
@@ -177,6 +183,17 @@ export function getMissingRequiredSettings(settings: Partial<Settings>): Missing
         value: settings[setting.key]
       }))
   );
+}
+
+export function getMissingRequiredSettingsGroups(settings: Partial<Settings>): MissingRequiredSettingsGroup[] {
+  const missingSettings = getMissingRequiredSettings(settings);
+  return settingsMetadataGroups
+    .map((group) => ({
+      groupId: group.id,
+      groupLabel: group.label,
+      settings: missingSettings.filter((setting) => setting.groupId === group.id)
+    }))
+    .filter((group) => group.settings.length > 0);
 }
 
 function isMissingSettingValue(value: unknown): boolean {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,12 +9,14 @@ const defaultCodexHome = path.join(os.homedir(), ".codex");
 
 export {
   getMissingRequiredSettings,
+  getMissingRequiredSettingsGroups,
   settingsMetadata,
   settingsMetadataByKey,
   settingsMetadataGroups
 } from "@/lib/settings-metadata";
 export type {
   MissingRequiredSetting,
+  MissingRequiredSettingsGroup,
   SettingMetadata,
   SettingRequirement,
   SettingsMetadataGroup,


### PR DESCRIPTION
Gitdex workflow: R3
Issue: #182
## Summary
Implemented issue #182 on `gitdex/R3-issue-182` and pushed commit `731b42e`. The settings panel now renders a top-level missing-configuration summary after the heading/save alert and before the grouped settings sections when required Codex/GitHub settings are missing. The summary uses existing metadata labels and group labels, excludes optional blank App/Telegram fields, and is hidden when required settings are complete. Added focused coverage in `scripts/settings-summary.test.mjs`; test-scope reason: it directly verifies the issue acceptance criteria for incomplete visibility, missing content, optional exclusion, complete hidden state, and SettingsPanel wiring. QA should rerun: `node --experimental-strip-types --test scripts/settings-summary.test.mjs scripts/settings-metadata.test.mjs`, `npm test`, `npm run typecheck`, and `npm run build`. Minimal manual validation: open the project settings panel with missing required Codex/GitHub values and confirm the summary appears above Appearance/Tool Checks/Runtime sections; fill required values and confirm it disappears. No active PR existed, per instructions I pushed the expected issue branch and did not create a PR.
## Changed Files
- scripts/settings-summary.test.mjs
- src/app/globals.css
- src/components/SettingsPanel.tsx
- src/lib/settings-metadata.ts
- src/lib/settings.ts
## Verification
- node --experimental-strip-types --test scripts/settings-summary.test.mjs scripts/settings-metadata.test.mjs
- npm test
- npm run typecheck
- npm run build
Closes #182